### PR TITLE
feat: 카카오 소셜 로그인 및 유저 정보 수정 API 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.env
 .gradle
 build/
 !gradle/wrapper/gradle-wrapper.jar

--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,9 @@ out/
 
 ### VS Code ###
 .vscode/
+
+### H2 Database Files ###
+/data/
+*.db
+*.trace.db
+*.lock.db

--- a/build.gradle
+++ b/build.gradle
@@ -25,15 +25,31 @@ repositories {
 }
 
 dependencies {
+    // Spring Boot Starters
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+
+    // External Libraries
+    implementation 'io.jsonwebtoken:jjwt-api:0.12.3'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.3'
+    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.3'
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.7'
+    implementation 'me.paulschwarz:spring-dotenv:4.0.0'
+
+    // Development & Utilities
     compileOnly 'org.projectlombok:lombok'
+    annotationProcessor 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
+
+    // Database
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'org.postgresql:postgresql'
-    annotationProcessor 'org.projectlombok:lombok'
+
+    // Test
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
-    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    testImplementation 'org.springframework.security:spring-security-test'
 }
 
 tasks.named('test') {

--- a/src/main/java/kr/santanrudolph/everyvent/auth/AuthenticationUtil.java
+++ b/src/main/java/kr/santanrudolph/everyvent/auth/AuthenticationUtil.java
@@ -1,0 +1,34 @@
+package kr.santanrudolph.everyvent.auth;
+
+import kr.santanrudolph.everyvent.global.exception.ErrorCode;
+import kr.santanrudolph.everyvent.global.exception.EveryventException;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+public class AuthenticationUtil {
+
+  private AuthenticationUtil() {
+    throw new IllegalStateException("Utility class");
+  }
+
+  public static Long getCurrentUserId() {
+    Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+    if (authentication == null || !authentication.isAuthenticated() || authentication.getPrincipal()
+        .equals("anonymousUser")) {
+      throw new EveryventException(ErrorCode.UNAUTHORIZED);
+    }
+
+    try {
+      return (Long) authentication.getPrincipal();
+    } catch (ClassCastException e) {
+      throw new EveryventException(ErrorCode.INVALID_TOKEN);
+    }
+  }
+
+  public static boolean isAuthenticated() {
+    Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+    return authentication != null && authentication.isAuthenticated()
+        && !authentication.getPrincipal().equals("anonymousUser");
+  }
+}

--- a/src/main/java/kr/santanrudolph/everyvent/auth/JwtTokenProvider.java
+++ b/src/main/java/kr/santanrudolph/everyvent/auth/JwtTokenProvider.java
@@ -1,0 +1,97 @@
+package kr.santanrudolph.everyvent.auth;
+
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.Jwts.SIG;
+import io.jsonwebtoken.security.Keys;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+
+
+@Slf4j
+@Component
+public class JwtTokenProvider {
+
+  private final SecretKey secretKey;
+  private final long accessTokenExpiration;
+  private final long refreshTokenExpiration;
+
+  public JwtTokenProvider(
+      @Value("${jwt.secret}") String secret,
+      @Value("${jwt.access-token-expiration}") long accessTokenExpiration,
+      @Value("${jwt.refresh-token-expiration}") long refreshTokenExpiration) {
+    byte[] keyBytes = secret.getBytes(StandardCharsets.UTF_8);
+    if (keyBytes.length < 32) { // hmacShaKey가 검증해주지만 명확한 예외 메시지를 위해 명시
+      throw new IllegalArgumentException("JWT secret must be at least 32 bytes");
+    }
+
+    this.secretKey = Keys.hmacShaKeyFor(keyBytes);
+    this.accessTokenExpiration = accessTokenExpiration;
+    this.refreshTokenExpiration = refreshTokenExpiration;
+  }
+
+  private String generateToken(Long userId, long expiration) {
+    if (userId == null) {
+      throw new IllegalArgumentException("userId cannot be null");
+    }
+
+    Date now = new Date();
+    Date expirationDate = new Date(now.getTime() + expiration);
+
+    return Jwts.builder()
+        .setSubject(String.valueOf(userId))
+        .setIssuedAt(now)
+        .setExpiration(expirationDate)
+        .signWith(secretKey, SIG.HS256)
+        .compact();
+  }
+
+  public String createAccessToken(Long userId) {
+    return generateToken(userId, accessTokenExpiration);
+  }
+
+  public String createRefreshToken(Long userId) {
+    return generateToken(userId, refreshTokenExpiration);
+  }
+
+  public Long getUserIdFromToken(String token) {
+    Claims claims = parseClaims(token);
+    return Long.parseLong(claims.getSubject());
+  }
+
+  public boolean validateToken(String token) {
+    try {
+      parseClaims(token);
+      return true;
+    } catch (JwtException | IllegalArgumentException e) {
+      log.warn("Invalid JWT: {}: {}", e.getClass().getSimpleName(), e.getMessage());
+    }
+    return false;
+  }
+
+  private Claims parseClaims(String token) {
+    if (token == null) { // JWT가 내부적으로 처리해주지만 명시
+      throw new IllegalArgumentException("Token cannot be null");
+    }
+
+    return Jwts.parser()
+        .verifyWith(secretKey)
+        .build()
+        .parseSignedClaims(token)
+        .getPayload();
+  }
+
+  public String resolveToken(String bearerToken) {
+    if (bearerToken != null && bearerToken.startsWith("Bearer ")) {
+      return bearerToken.substring(7);
+    }
+    return null;
+  }
+}

--- a/src/main/java/kr/santanrudolph/everyvent/auth/controller/AuthController.java
+++ b/src/main/java/kr/santanrudolph/everyvent/auth/controller/AuthController.java
@@ -1,0 +1,129 @@
+package kr.santanrudolph.everyvent.auth.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.Valid;
+import kr.santanrudolph.everyvent.auth.AuthenticationUtil;
+import kr.santanrudolph.everyvent.auth.dto.TokenRefreshRequest;
+import kr.santanrudolph.everyvent.auth.dto.TokenResponse;
+import kr.santanrudolph.everyvent.auth.entity.RefreshToken;
+import kr.santanrudolph.everyvent.auth.security.JwtTokenProvider;
+import kr.santanrudolph.everyvent.auth.entity.BlacklistedToken;
+import kr.santanrudolph.everyvent.auth.repository.BlacklistedTokenRepository;
+import kr.santanrudolph.everyvent.auth.repository.RefreshTokenRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.ResponseEntity;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.time.LocalDateTime;
+
+@Tag(name = "인증", description = "인증 관련 API")
+@Slf4j
+@RestController
+@RequestMapping("/api/auth")
+@RequiredArgsConstructor
+public class AuthController {
+
+  private final RefreshTokenRepository refreshTokenRepository;
+  private final BlacklistedTokenRepository blacklistedTokenRepository;
+  private final JwtTokenProvider jwtTokenProvider;
+
+  @Value("${jwt.access-token-expiration}")
+  private long accessTokenExpiration;
+  @Value("${jwt.refresh-token-expiration}")
+  private long refreshTokenExpiration;
+
+  @Operation(
+      summary = "토큰 재발급",
+      description = "Refresh Token을 사용하여 새로운 Access Token과 Refresh Token을 발급받습니다."
+  )
+  @ApiResponses({
+      @ApiResponse(responseCode = "200", description = "토큰 재발급 성공"),
+      @ApiResponse(responseCode = "400", description = "비즈니스 에러 (에러코드로 구분: INVALID_TOKEN, TOKEN_EXPIRED, INVALID_INPUT_VALUE 등)")
+  })
+  @PostMapping("/refresh")
+  @Transactional
+  public ResponseEntity<TokenResponse> refreshToken(
+      @Valid @RequestBody TokenRefreshRequest request) {
+
+    String requestRefreshToken = request.getRefreshToken();
+
+    if (!jwtTokenProvider.validateToken(requestRefreshToken)) {
+      log.warn("Invalid refresh token");
+      return ResponseEntity.badRequest().build();
+    }
+
+    RefreshToken refreshToken = refreshTokenRepository.findByToken(requestRefreshToken)
+        .orElseThrow(() -> {
+          log.warn("Refresh token not found in database");
+          return new IllegalArgumentException("Invalid refresh token");
+        });
+
+    if (refreshToken.isExpired()) {
+      log.warn("Refresh token expired - User ID: {}", refreshToken.getUserId());
+      refreshTokenRepository.delete(refreshToken);
+      return ResponseEntity.status(401).build();
+    }
+
+    Long userId = jwtTokenProvider.getUserIdFromToken(requestRefreshToken);
+    String newAccessToken = jwtTokenProvider.createAccessToken(userId);
+    String newRefreshToken = jwtTokenProvider.createRefreshToken(userId);
+
+    LocalDateTime newExpiresAt = LocalDateTime.now()
+        .plusSeconds(refreshTokenExpiration);
+    refreshToken.updateToken(newRefreshToken, newExpiresAt);
+
+    log.info("Token refreshed - User ID: {}", userId);
+
+    // 응답 생성
+    TokenResponse response = TokenResponse.builder()
+        .accessToken(newAccessToken)
+        .refreshToken(newRefreshToken)
+        .tokenType("Bearer")
+        .expiresIn(accessTokenExpiration / 1000) // ms를 초로 변환
+        .build();
+
+    return ResponseEntity.ok(response);
+  }
+
+  @Operation(
+      summary = "로그아웃",
+      description = "RefreshToken을 DB에서 삭제하고 AccessToken을 블랙리스트에 추가합니다."
+  )
+  @ApiResponses({
+      @ApiResponse(responseCode = "200", description = "로그아웃 성공"),
+      @ApiResponse(responseCode = "400", description = "비즈니스 에러 (에러코드로 구분: USER_NOT_FOUND, UNAUTHORIZED 등)")
+  })
+  @PostMapping("/logout")
+  @Transactional
+  public ResponseEntity<String> logout(HttpServletRequest request) {
+    Long userId = AuthenticationUtil.getCurrentUserId();
+
+    String bearerToken = request.getHeader("Authorization");
+    String accessToken = jwtTokenProvider.resolveToken(bearerToken);
+
+    refreshTokenRepository.deleteByUserId(userId);
+
+    if (accessToken != null) {
+      BlacklistedToken blacklist = BlacklistedToken.builder()
+          .token(accessToken)
+          .expiresAt(LocalDateTime.now().plusHours(1))
+          .build();
+      blacklistedTokenRepository.save(blacklist);
+    }
+
+    log.info("User logged out - User ID: {}, RefreshToken deleted, AccessToken blacklisted",
+        userId);
+
+    return ResponseEntity.ok("Logged out successfully");
+  }
+}

--- a/src/main/java/kr/santanrudolph/everyvent/auth/controller/AuthController.java
+++ b/src/main/java/kr/santanrudolph/everyvent/auth/controller/AuthController.java
@@ -59,6 +59,14 @@ public class AuthController {
 
     if (!jwtTokenProvider.validateToken(requestRefreshToken)) {
       log.warn("Invalid refresh token");
+
+      if (jwtTokenProvider.isExpired(requestRefreshToken)) {
+        refreshTokenRepository.findByToken(requestRefreshToken)
+            .ifPresent(token -> {
+              log.info("Deleting expired token - User ID: {}", token.getUserId());
+              refreshTokenRepository.delete(token);
+            });
+      }
       return ResponseEntity.badRequest().build();
     }
 
@@ -68,31 +76,23 @@ public class AuthController {
           return new IllegalArgumentException("Invalid refresh token");
         });
 
-    if (refreshToken.isExpired()) {
-      log.warn("Refresh token expired - User ID: {}", refreshToken.getUserId());
-      refreshTokenRepository.delete(refreshToken);
-      return ResponseEntity.status(401).build();
-    }
-
     Long userId = jwtTokenProvider.getUserIdFromToken(requestRefreshToken);
     String newAccessToken = jwtTokenProvider.createAccessToken(userId);
     String newRefreshToken = jwtTokenProvider.createRefreshToken(userId);
 
-    LocalDateTime newExpiresAt = LocalDateTime.now()
-        .plusSeconds(refreshTokenExpiration);
-    refreshToken.updateToken(newRefreshToken, newExpiresAt);
+    refreshToken.updateToken(
+        newRefreshToken,
+        LocalDateTime.now().plusSeconds(refreshTokenExpiration)
+    );
 
     log.info("Token refreshed - User ID: {}", userId);
 
-    // 응답 생성
-    TokenResponse response = TokenResponse.builder()
+    return ResponseEntity.ok(TokenResponse.builder()
         .accessToken(newAccessToken)
         .refreshToken(newRefreshToken)
         .tokenType("Bearer")
-        .expiresIn(accessTokenExpiration / 1000) // ms를 초로 변환
-        .build();
-
-    return ResponseEntity.ok(response);
+        .expiresIn(accessTokenExpiration / 1000)
+        .build());
   }
 
   @Operation(

--- a/src/main/java/kr/santanrudolph/everyvent/auth/controller/AuthController.java
+++ b/src/main/java/kr/santanrudolph/everyvent/auth/controller/AuthController.java
@@ -14,6 +14,8 @@ import kr.santanrudolph.everyvent.auth.security.JwtTokenProvider;
 import kr.santanrudolph.everyvent.auth.entity.BlacklistedToken;
 import kr.santanrudolph.everyvent.auth.repository.BlacklistedTokenRepository;
 import kr.santanrudolph.everyvent.auth.repository.RefreshTokenRepository;
+import kr.santanrudolph.everyvent.global.exception.ErrorCode;
+import kr.santanrudolph.everyvent.global.exception.EveryventException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -66,15 +68,13 @@ public class AuthController {
               log.info("Deleting expired token - User ID: {}", token.getUserId());
               refreshTokenRepository.delete(token);
             });
+        throw new EveryventException(ErrorCode.EXPIRED_TOKEN);
       }
-      return ResponseEntity.badRequest().build();
+      throw new EveryventException(ErrorCode.INVALID_TOKEN);
     }
 
     RefreshToken refreshToken = refreshTokenRepository.findByToken(requestRefreshToken)
-        .orElseThrow(() -> {
-          log.warn("Refresh token not found in database");
-          return new IllegalArgumentException("Invalid refresh token");
-        });
+        .orElseThrow(() -> new EveryventException(ErrorCode.INVALID_TOKEN));
 
     Long userId = jwtTokenProvider.getUserIdFromToken(requestRefreshToken);
     String newAccessToken = jwtTokenProvider.createAccessToken(userId);

--- a/src/main/java/kr/santanrudolph/everyvent/auth/controller/OAuth2TestController.java
+++ b/src/main/java/kr/santanrudolph/everyvent/auth/controller/OAuth2TestController.java
@@ -13,6 +13,98 @@ import org.springframework.web.bind.annotation.ResponseBody;
 // 프론트 구현 전 OAuth2 로그인 테스트용 임시 컨트롤러 (토큰 값 보기 위함)
 public class OAuth2TestController {
 
+    @GetMapping("/oauth/test")
+    @ResponseBody
+    public String oauthTestPage() {
+        return """
+            <html>
+            <head>
+                <title>OAuth2 로그인 테스트</title>
+                <style>
+                    body {
+                        font-family: Arial, sans-serif;
+                        padding: 40px;
+                        text-align: center;
+                        background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+                        color: white;
+                        min-height: 100vh;
+                        display: flex;
+                        flex-direction: column;
+                        justify-content: center;
+                        align-items: center;
+                    }
+                    .container {
+                        background: rgba(255, 255, 255, 0.95);
+                        padding: 40px;
+                        border-radius: 10px;
+                        box-shadow: 0 10px 25px rgba(0,0,0,0.2);
+                        color: #333;
+                        max-width: 500px;
+                    }
+                    h1 { margin-bottom: 10px; color: #667eea; }
+                    p { color: #666; margin-bottom: 30px; }
+                    .login-button {
+                        display: inline-block;
+                        background: #FEE500;
+                        color: #000000;
+                        padding: 15px 30px;
+                        border-radius: 8px;
+                        text-decoration: none;
+                        font-weight: bold;
+                        font-size: 16px;
+                        margin: 10px;
+                        transition: all 0.3s;
+                    }
+                    .login-button:hover {
+                        background: #FDD835;
+                        transform: translateY(-2px);
+                        box-shadow: 0 5px 15px rgba(0,0,0,0.2);
+                    }
+                    .info {
+                        margin-top: 30px;
+                        padding: 20px;
+                        background: #f5f5f5;
+                        border-radius: 8px;
+                        font-size: 14px;
+                        text-align: left;
+                    }
+                    .info h3 { color: #667eea; margin-top: 0; }
+                    code {
+                        background: #e0e0e0;
+                        padding: 2px 6px;
+                        border-radius: 3px;
+                        font-size: 13px;
+                    }
+                </style>
+            </head>
+            <body>
+                <div class="container">
+                    <h1>🎄 EveryVent OAuth2 테스트</h1>
+                    <p>카카오 계정으로 로그인하여 테스트하세요</p>
+
+                    <a href="/oauth2/authorization/kakao?prompt=login" class="login-button">
+                        카카오 로그인 시작
+                    </a>
+
+                    <div class="info">
+                        <h3>📝 테스트 흐름</h3>
+                        <ol style="padding-left: 20px;">
+                            <li>카카오 로그인 버튼 클릭</li>
+                            <li>카카오 계정으로 로그인</li>
+                            <li>토큰 정보 확인 페이지로 이동</li>
+                            <li>내 정보 조회 / 로그아웃 테스트</li>
+                        </ol>
+                        <p style="margin-top: 15px; color: #666;">
+                            <strong>직접 접속:</strong><br>
+                            <code>http://localhost:8080/oauth/test</code>
+                        </p>
+                    </div>
+                </div>
+            </body>
+            </html>
+            """;
+    }
+
     @GetMapping("/oauth/callback")
     @ResponseBody
     public String oauthCallback(
@@ -22,20 +114,100 @@ public class OAuth2TestController {
 
         return """
             <html>
-            <head><title>OAuth2 Login Success</title></head>
+            <head>
+                <title>OAuth2 Login Success</title>
+                <style>
+                    body { font-family: Arial, sans-serif; padding: 20px; }
+                    .token-box { word-break: break-all; padding: 10px; font-size: 12px; margin: 10px 0; }
+                    .access-token { background: #e8f5e9; }
+                    .refresh-token { background: #fff3e0; }
+                    .button { background: #f44336; color: white; padding: 10px 20px; border: none; border-radius: 4px; cursor: pointer; margin: 10px 5px 10px 0; }
+                    .button:hover { background: #d32f2f; }
+                    .button.secondary { background: #2196F3; }
+                    .button.secondary:hover { background: #1976D2; }
+                    code { background: #f0f0f0; padding: 10px; display: block; margin: 10px 0; }
+                    #result { margin-top: 20px; padding: 10px; display: none; }
+                    .success { background: #c8e6c9; border: 1px solid #4caf50; }
+                    .error { background: #ffcdd2; border: 1px solid #f44336; }
+                </style>
+            </head>
             <body>
                 <h1>카카오 로그인 성공!</h1>
                 <h2>Access Token:</h2>
-                <p style="word-break: break-all; background: #e8f5e9; padding: 10px; font-size: 12px;">%s</p>
+                <p class="token-box access-token" id="accessToken">%s</p>
                 <h2>Refresh Token:</h2>
-                <p style="word-break: break-all; background: #fff3e0; padding: 10px; font-size: 12px;">%s</p>
-                <h3>테스트 방법:</h3>
-                <p>아래 명령어로 API 테스트하세요:</p>
-                <code style="background: #f0f0f0; padding: 10px; display: block;">
+                <p class="token-box refresh-token" id="refreshToken">%s</p>
+
+                <h3>테스트 기능:</h3>
+                <button class="button secondary" onclick="testMe()">내 정보 조회</button>
+                <button class="button" onclick="logout()">로그아웃</button>
+
+                <div id="result"></div>
+
+                <h3>cURL 명령어:</h3>
+                <code>
+                # 내 정보 조회
                 curl -H "Authorization: Bearer %s" http://localhost:8080/api/users/me
+
+                # 로그아웃
+                curl -X POST -H "Authorization: Bearer %s" http://localhost:8080/api/auth/logout
                 </code>
+
+                <script>
+                    const accessToken = document.getElementById('accessToken').textContent.trim();
+
+                    async function testMe() {
+                        const result = document.getElementById('result');
+                        result.style.display = 'block';
+                        result.textContent = '요청 중...';
+                        result.className = '';
+
+                        try {
+                            const response = await fetch('http://localhost:8080/api/users/me', {
+                                headers: { 'Authorization': 'Bearer ' + accessToken }
+                            });
+                            const data = await response.json();
+                            result.className = 'success';
+                            result.textContent = '성공: ' + JSON.stringify(data, null, 2);
+                        } catch (error) {
+                            result.className = 'error';
+                            result.textContent = '에러: ' + error.message;
+                        }
+                    }
+
+                    async function logout() {
+                        if (!confirm('로그아웃 하시겠습니까?')) return;
+
+                        const result = document.getElementById('result');
+                        result.style.display = 'block';
+                        result.textContent = '로그아웃 중...';
+                        result.className = '';
+
+                        try {
+                            const response = await fetch('http://localhost:8080/api/auth/logout', {
+                                method: 'POST',
+                                headers: { 'Authorization': 'Bearer ' + accessToken }
+                            });
+
+                            if (response.ok) {
+                                result.className = 'success';
+                                result.textContent = '로그아웃 성공! 로그인 페이지로 이동합니다...';
+                                setTimeout(() => {
+                                    window.location.href = '/oauth/test';
+                                }, 2000);
+                            } else {
+                                const errorText = await response.text();
+                                result.className = 'error';
+                                result.textContent = '로그아웃 실패: ' + errorText;
+                            }
+                        } catch (error) {
+                            result.className = 'error';
+                            result.textContent = '에러: ' + error.message;
+                        }
+                    }
+                </script>
             </body>
             </html>
-            """.formatted(accessToken, refreshToken, accessToken);
+            """.formatted(accessToken, refreshToken, accessToken, accessToken);
     }
 }

--- a/src/main/java/kr/santanrudolph/everyvent/auth/controller/OAuth2TestController.java
+++ b/src/main/java/kr/santanrudolph/everyvent/auth/controller/OAuth2TestController.java
@@ -1,0 +1,41 @@
+package kr.santanrudolph.everyvent.auth.controller;
+
+import io.swagger.v3.oas.annotations.Hidden;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseBody;
+
+@Slf4j
+@Controller
+@Hidden
+// 프론트 구현 전 OAuth2 로그인 테스트용 임시 컨트롤러 (토큰 값 보기 위함)
+public class OAuth2TestController {
+
+    @GetMapping("/oauth/callback")
+    @ResponseBody
+    public String oauthCallback(
+            @RequestParam(required = false) String accessToken,
+            @RequestParam(required = false) String refreshToken) {
+        log.info("OAuth2 Callback - AccessToken: {}, RefreshToken: {}", accessToken, refreshToken);
+
+        return """
+            <html>
+            <head><title>OAuth2 Login Success</title></head>
+            <body>
+                <h1>카카오 로그인 성공!</h1>
+                <h2>Access Token:</h2>
+                <p style="word-break: break-all; background: #e8f5e9; padding: 10px; font-size: 12px;">%s</p>
+                <h2>Refresh Token:</h2>
+                <p style="word-break: break-all; background: #fff3e0; padding: 10px; font-size: 12px;">%s</p>
+                <h3>테스트 방법:</h3>
+                <p>아래 명령어로 API 테스트하세요:</p>
+                <code style="background: #f0f0f0; padding: 10px; display: block;">
+                curl -H "Authorization: Bearer %s" http://localhost:8080/api/users/me
+                </code>
+            </body>
+            </html>
+            """.formatted(accessToken, refreshToken, accessToken);
+    }
+}

--- a/src/main/java/kr/santanrudolph/everyvent/auth/dto/TokenRefreshRequest.java
+++ b/src/main/java/kr/santanrudolph/everyvent/auth/dto/TokenRefreshRequest.java
@@ -1,0 +1,16 @@
+package kr.santanrudolph.everyvent.auth.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Schema(description = "토큰 재발급 요청")
+@Getter
+@NoArgsConstructor
+public class TokenRefreshRequest {
+
+  @Schema(description = "Refresh Token", example = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...")
+  @NotBlank(message = "refreshToken은 필수입니다")
+  private String refreshToken;
+}

--- a/src/main/java/kr/santanrudolph/everyvent/auth/dto/TokenResponse.java
+++ b/src/main/java/kr/santanrudolph/everyvent/auth/dto/TokenResponse.java
@@ -1,0 +1,23 @@
+package kr.santanrudolph.everyvent.auth.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+@Schema(description = "토큰 응답")
+@Getter
+@Builder
+public class TokenResponse {
+
+  @Schema(description = "Access Token", example = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...")
+  private String accessToken;
+
+  @Schema(description = "Refresh Token", example = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...")
+  private String refreshToken;
+
+  @Schema(description = "토큰 타입", example = "Bearer")
+  private String tokenType;
+
+  @Schema(description = "Access Token 만료 시간(초)", example = "3600")
+  private Long expiresIn;
+}

--- a/src/main/java/kr/santanrudolph/everyvent/auth/entity/BlacklistedToken.java
+++ b/src/main/java/kr/santanrudolph/everyvent/auth/entity/BlacklistedToken.java
@@ -1,0 +1,38 @@
+package kr.santanrudolph.everyvent.auth.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "blacklisted_token", indexes = {
+    @Index(name = "idx_token", columnList = "token")
+})
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class BlacklistedToken {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @Column(nullable = false, unique = true, length = 500)
+  private String token;
+
+  @Column(nullable = false)
+  private LocalDateTime expiresAt;
+
+  @Column(nullable = false)
+  private LocalDateTime createdAt;
+
+  @Builder
+  public BlacklistedToken(String token, LocalDateTime expiresAt) {
+    this.token = token;
+    this.expiresAt = expiresAt;
+    this.createdAt = LocalDateTime.now();
+  }
+}

--- a/src/main/java/kr/santanrudolph/everyvent/auth/entity/RefreshToken.java
+++ b/src/main/java/kr/santanrudolph/everyvent/auth/entity/RefreshToken.java
@@ -1,0 +1,41 @@
+package kr.santanrudolph.everyvent.auth.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "refresh_tokens")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class RefreshToken {
+
+  @Id
+  private Long userId;
+
+  @Column(nullable = false, unique = true, length = 500)
+  private String token;
+
+  @Column(nullable = false)
+  private LocalDateTime expiresAt;
+
+  @Builder
+  public RefreshToken(Long userId, String token, LocalDateTime expiresAt) {
+    this.userId = userId;
+    this.token = token;
+    this.expiresAt = expiresAt;
+  }
+
+  public void updateToken(String token, LocalDateTime expiresAt) {
+    this.token = token;
+    this.expiresAt = expiresAt;
+  }
+
+  public boolean isExpired() {
+    return LocalDateTime.now().isAfter(expiresAt);
+  }
+}

--- a/src/main/java/kr/santanrudolph/everyvent/auth/repository/BlacklistedTokenRepository.java
+++ b/src/main/java/kr/santanrudolph/everyvent/auth/repository/BlacklistedTokenRepository.java
@@ -1,0 +1,15 @@
+package kr.santanrudolph.everyvent.auth.repository;
+
+import kr.santanrudolph.everyvent.auth.entity.BlacklistedToken;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+
+@Repository
+public interface BlacklistedTokenRepository extends JpaRepository<BlacklistedToken, Long> {
+
+  boolean existsByToken(String token);
+
+  void deleteByExpiresAtBefore(LocalDateTime dateTime);
+}

--- a/src/main/java/kr/santanrudolph/everyvent/auth/repository/RefreshTokenRepository.java
+++ b/src/main/java/kr/santanrudolph/everyvent/auth/repository/RefreshTokenRepository.java
@@ -1,0 +1,17 @@
+package kr.santanrudolph.everyvent.auth.repository;
+
+import kr.santanrudolph.everyvent.auth.entity.RefreshToken;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
+
+  Optional<RefreshToken> findByToken(String token);
+
+  void deleteByUserId(Long userId);
+
+  boolean existsByToken(String token);
+}

--- a/src/main/java/kr/santanrudolph/everyvent/auth/security/EveryventOAuth2User.java
+++ b/src/main/java/kr/santanrudolph/everyvent/auth/security/EveryventOAuth2User.java
@@ -1,0 +1,39 @@
+package kr.santanrudolph.everyvent.auth.security;
+
+import kr.santanrudolph.everyvent.domain.user.User;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
+
+@Getter
+@RequiredArgsConstructor
+public class EveryventOAuth2User implements OAuth2User {
+
+    private final User user;
+
+    private final Map<String, Object> attributes;
+
+    @Override
+    public Map<String, Object> getAttributes() {
+        return attributes;
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public String getName() {
+        return user.getSocialId();
+    }
+
+    public Long getUserId() {
+        return user.getId();
+    }
+}

--- a/src/main/java/kr/santanrudolph/everyvent/auth/security/JwtAuthenticationFilter.java
+++ b/src/main/java/kr/santanrudolph/everyvent/auth/security/JwtAuthenticationFilter.java
@@ -1,0 +1,85 @@
+package kr.santanrudolph.everyvent.auth.security;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import kr.santanrudolph.everyvent.auth.repository.BlacklistedTokenRepository;
+import kr.santanrudolph.everyvent.domain.user.User;
+import kr.santanrudolph.everyvent.domain.user.UserRepository;
+import kr.santanrudolph.everyvent.global.exception.ErrorCode;
+import kr.santanrudolph.everyvent.global.exception.ErrorResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.Collections;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+  private final JwtTokenProvider jwtTokenProvider;
+  private final UserRepository userRepository;
+  private final BlacklistedTokenRepository blacklistedTokenRepository;
+
+  @Override
+  protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+      FilterChain filterChain)
+      throws ServletException, IOException {
+
+    try {
+      String bearerToken = request.getHeader("Authorization");
+      String token = jwtTokenProvider.resolveToken(bearerToken);
+
+      if (token != null) {
+        // 블랙리스트 체크
+        if (blacklistedTokenRepository.existsByToken(token)) {
+          log.warn("Blocked blacklisted token");
+          sendErrorResponse(response, ErrorCode.BLACKLISTED_TOKEN);
+          return;
+        }
+
+        if (jwtTokenProvider.validateToken(token)) {
+          Long userId = jwtTokenProvider.getUserIdFromToken(token);
+
+          User user = userRepository.findByIdAndDeletedAtIsNull(userId)
+              .orElse(null);
+
+          if (user != null) {
+            UsernamePasswordAuthenticationToken authentication =
+                new UsernamePasswordAuthenticationToken(userId, null, Collections.emptyList());
+            authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+            log.debug("Set Authentication for user: {}", userId);
+          }
+        }
+      }
+    } catch (Exception e) {
+      log.error("Could not set user authentication in security context", e);
+    }
+
+    filterChain.doFilter(request, response);
+  }
+
+  private void sendErrorResponse(HttpServletResponse response, ErrorCode errorCode)
+      throws IOException {
+    response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+    response.setContentType("application/json");
+    response.setCharacterEncoding("UTF-8");
+
+    ErrorResponse errorResponse = ErrorResponse.of(errorCode);
+    ObjectMapper objectMapper = new ObjectMapper();
+    String jsonResponse = objectMapper.writeValueAsString(errorResponse);
+
+    response.getWriter().write(jsonResponse);
+  }
+}

--- a/src/main/java/kr/santanrudolph/everyvent/auth/security/JwtTokenProvider.java
+++ b/src/main/java/kr/santanrudolph/everyvent/auth/security/JwtTokenProvider.java
@@ -2,6 +2,7 @@ package kr.santanrudolph.everyvent.auth.security;
 
 
 import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.Jwts.SIG;
@@ -74,6 +75,17 @@ public class JwtTokenProvider {
       log.warn("Invalid JWT: {}: {}", e.getClass().getSimpleName(), e.getMessage());
     }
     return false;
+  }
+
+  public boolean isExpired(String token) {
+    try {
+      parseClaims(token);
+      return false;
+    } catch (ExpiredJwtException e) {
+      return true;
+    } catch (JwtException | IllegalArgumentException e) {
+      return false;
+    }
   }
 
   private Claims parseClaims(String token) {

--- a/src/main/java/kr/santanrudolph/everyvent/auth/security/JwtTokenProvider.java
+++ b/src/main/java/kr/santanrudolph/everyvent/auth/security/JwtTokenProvider.java
@@ -1,4 +1,4 @@
-package kr.santanrudolph.everyvent.auth;
+package kr.santanrudolph.everyvent.auth.security;
 
 
 import io.jsonwebtoken.Claims;

--- a/src/main/java/kr/santanrudolph/everyvent/auth/security/OAuth2SuccessHandler.java
+++ b/src/main/java/kr/santanrudolph/everyvent/auth/security/OAuth2SuccessHandler.java
@@ -1,0 +1,64 @@
+package kr.santanrudolph.everyvent.auth.security;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import kr.santanrudolph.everyvent.auth.entity.RefreshToken;
+import kr.santanrudolph.everyvent.auth.repository.RefreshTokenRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.io.IOException;
+import java.time.LocalDateTime;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
+
+    private final JwtTokenProvider jwtTokenProvider;
+    private final RefreshTokenRepository refreshTokenRepository;
+
+    @Override
+    @Transactional
+    public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
+                                        Authentication authentication) throws IOException {
+        EveryventOAuth2User oAuth2User = (EveryventOAuth2User) authentication.getPrincipal();
+        Long userId = oAuth2User.getUserId();
+
+        log.info("OAuth2 Login Success - User ID: {}", userId);
+
+        // JWT 토큰 생성
+        String accessToken = jwtTokenProvider.createAccessToken(userId);
+        String refreshToken = jwtTokenProvider.createRefreshToken(userId);
+
+        // RefreshToken DB 저장 (기존 토큰이 있으면 업데이트)
+        RefreshToken refreshTokenEntity = refreshTokenRepository.findById(userId)
+                .orElse(RefreshToken.builder()
+                        .userId(userId)
+                        .token(refreshToken)
+                        .expiresAt(LocalDateTime.now().plusDays(7))
+                        .build());
+
+        if (refreshTokenEntity.getToken() != null) {
+            refreshTokenEntity.updateToken(refreshToken, LocalDateTime.now().plusDays(7));
+        }
+
+        refreshTokenRepository.save(refreshTokenEntity);
+        log.info("RefreshToken saved for User ID: {}", userId);
+
+        // 테스트용 콜백 엔드포인트로 리다이렉트 (토큰을 쿼리 파라미터로 전달하여, 로그인 시 프론트 없이도 토큰 확인 가능)
+        // 프론트 연동 시에는 삭제 필요
+        String targetUrl = UriComponentsBuilder.fromUriString("http://localhost:8080/oauth/callback")
+                .queryParam("accessToken", accessToken)
+                .queryParam("refreshToken", refreshToken)
+                .build().toUriString();
+
+        log.info("Redirecting to: {}", targetUrl);
+        getRedirectStrategy().sendRedirect(request, response, targetUrl);
+    }
+}

--- a/src/main/java/kr/santanrudolph/everyvent/auth/service/KakaoOAuthService.java
+++ b/src/main/java/kr/santanrudolph/everyvent/auth/service/KakaoOAuthService.java
@@ -1,0 +1,79 @@
+package kr.santanrudolph.everyvent.auth.service;
+
+import kr.santanrudolph.everyvent.auth.security.EveryventOAuth2User;
+import kr.santanrudolph.everyvent.domain.user.SocialProvider;
+import kr.santanrudolph.everyvent.domain.user.User;
+import kr.santanrudolph.everyvent.domain.user.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Map;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class KakaoOAuthService extends DefaultOAuth2UserService {
+
+  private final UserRepository userRepository;
+
+  @Override
+  @Transactional
+  public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+    OAuth2User oAuth2User = super.loadUser(userRequest);
+
+    String kakaoId = oAuth2User.getName();
+    log.info("Kakao Login - Kakao ID: {}", kakaoId);
+
+    Map<String, Object> attributes = oAuth2User.getAttributes();
+    Map<String, Object> kakaoAccount = (Map<String, Object>) attributes.get("kakao_account");
+
+    String email = kakaoAccount != null ? (String) kakaoAccount.get("email") : null;
+    log.info("Kakao Email: {}", email);
+
+    // socialId + provider로 사용자 조회 또는 생성
+    User user = userRepository.findBySocialIdAndProviderAndDeletedAtIsNull(kakaoId, "KAKAO")
+        .orElseGet(() -> createUser(kakaoId, email));
+
+    return new EveryventOAuth2User(user, oAuth2User.getAttributes());
+  }
+
+  private User createUser(String socialId, String email) {
+    log.info("Creating new user with socialId: {}", socialId);
+
+    // email이 null이 아닌 경우, 중복 체크
+    if (email != null && userRepository.findByEmail(email).isPresent()) {
+      log.warn("Email already exists: {}", email);
+      throw new OAuth2AuthenticationException("Email already registered with another account");
+    }
+
+    // 임시 닉네임 생성
+    String tempNickname = generateUniqueNickname(socialId);
+
+    User newUser = User.builder()
+        .socialId(socialId)
+        .socialProvider(SocialProvider.KAKAO)
+        .email(email)
+        .nickname(tempNickname)
+        .build();
+
+    return userRepository.save(newUser);
+  }
+
+  private String generateUniqueNickname(String socialId) {
+    String baseNickname = "kakao_" + socialId;
+    String nickname = baseNickname;
+    int suffix = 1;
+
+    while (userRepository.existsByNickname(nickname)) {
+      nickname = baseNickname + "_" + suffix++;
+    }
+
+    return nickname;
+  }
+}

--- a/src/main/java/kr/santanrudolph/everyvent/auth/service/KakaoOAuthService.java
+++ b/src/main/java/kr/santanrudolph/everyvent/auth/service/KakaoOAuthService.java
@@ -37,7 +37,7 @@ public class KakaoOAuthService extends DefaultOAuth2UserService {
     log.info("Kakao Email: {}", email);
 
     // socialId + provider로 사용자 조회 또는 생성
-    User user = userRepository.findBySocialIdAndProviderAndDeletedAtIsNull(kakaoId, "KAKAO")
+    User user = userRepository.findBySocialIdAndSocialProviderAndDeletedAtIsNull(kakaoId, SocialProvider.KAKAO)
         .orElseGet(() -> createUser(kakaoId, email));
 
     return new EveryventOAuth2User(user, oAuth2User.getAttributes());

--- a/src/main/java/kr/santanrudolph/everyvent/domain/user/Role.java
+++ b/src/main/java/kr/santanrudolph/everyvent/domain/user/Role.java
@@ -1,0 +1,14 @@
+package kr.santanrudolph.everyvent.domain.user;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum Role {
+  USER("ROLE_USER", "일반 사용자"),
+  ADMIN("ROLE_ADMIN", "관리자");
+
+  private final String key;
+  private final String description;
+}

--- a/src/main/java/kr/santanrudolph/everyvent/domain/user/SocialProvider.java
+++ b/src/main/java/kr/santanrudolph/everyvent/domain/user/SocialProvider.java
@@ -1,0 +1,6 @@
+package kr.santanrudolph.everyvent.domain.user;
+
+public enum SocialProvider {
+  KAKAO, GOOGLE, NAVER
+}
+

--- a/src/main/java/kr/santanrudolph/everyvent/domain/user/User.java
+++ b/src/main/java/kr/santanrudolph/everyvent/domain/user/User.java
@@ -25,7 +25,7 @@ public class User extends BaseEntity {
   private String socialId;
 
   @Column(nullable = false)
-  private String provider;
+  private SocialProvider socialProvider;
 
   @Column
   private String email;
@@ -44,10 +44,10 @@ public class User extends BaseEntity {
   private LocalDateTime deletedAt;
 
   @Builder
-  public User(String socialId, String provider, String email, String nickname,
+  public User(String socialId, SocialProvider socialProvider, String email, String nickname,
       String introduction) {
     this.socialId = socialId;
-    this.provider = provider;
+    this.socialProvider = socialProvider;
     this.email = email;
     this.nickname = nickname;
     this.introduction = introduction;

--- a/src/main/java/kr/santanrudolph/everyvent/domain/user/User.java
+++ b/src/main/java/kr/santanrudolph/everyvent/domain/user/User.java
@@ -24,7 +24,7 @@ public class User extends BaseEntity {
   @Column(nullable = false)
   private String socialId;
 
-  @Column(nullable = false)
+  @Enumerated(EnumType.STRING)
   private SocialProvider socialProvider;
 
   @Column

--- a/src/main/java/kr/santanrudolph/everyvent/domain/user/User.java
+++ b/src/main/java/kr/santanrudolph/everyvent/domain/user/User.java
@@ -1,0 +1,76 @@
+package kr.santanrudolph.everyvent.domain.user;
+
+import jakarta.persistence.*;
+import kr.santanrudolph.everyvent.global.entity.BaseEntity;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "users", uniqueConstraints = {
+    @UniqueConstraint(columnNames = {"socialId", "provider"})
+})
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class User extends BaseEntity {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @Column(nullable = false)
+  private String socialId;
+
+  @Column(nullable = false)
+  private String provider;
+
+  @Column
+  private String email;
+
+  @Column(nullable = false, unique = true)
+  private String nickname;
+
+  @Column
+  private String introduction;
+
+  @Enumerated(EnumType.STRING)
+  @Column(nullable = false)
+  private Role role;
+
+  @Column
+  private LocalDateTime deletedAt;
+
+  @Builder
+  public User(String socialId, String provider, String email, String nickname,
+      String introduction) {
+    this.socialId = socialId;
+    this.provider = provider;
+    this.email = email;
+    this.nickname = nickname;
+    this.introduction = introduction;
+    this.role = Role.USER; // 기본값 USER
+  }
+
+  public void updateIntroduction(String introduction) {
+    if (introduction != null) {
+      this.introduction = introduction;
+    }
+  }
+
+  public void updateNickname(String nickname) {
+    if (nickname != null && !nickname.isBlank()) {
+      this.nickname = nickname;
+    }
+  }
+
+  public void softDelete() {
+    this.deletedAt = LocalDateTime.now();
+  }
+
+  public boolean isDeleted() {
+    return this.deletedAt != null;
+  }
+}

--- a/src/main/java/kr/santanrudolph/everyvent/domain/user/User.java
+++ b/src/main/java/kr/santanrudolph/everyvent/domain/user/User.java
@@ -11,7 +11,7 @@ import java.time.LocalDateTime;
 
 @Entity
 @Table(name = "users", uniqueConstraints = {
-    @UniqueConstraint(columnNames = {"socialId", "provider"})
+    @UniqueConstraint(columnNames = {"social_id", "social_provider"})
 })
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)

--- a/src/main/java/kr/santanrudolph/everyvent/domain/user/UserController.java
+++ b/src/main/java/kr/santanrudolph/everyvent/domain/user/UserController.java
@@ -1,0 +1,69 @@
+package kr.santanrudolph.everyvent.domain.user;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import kr.santanrudolph.everyvent.auth.AuthenticationUtil;
+import kr.santanrudolph.everyvent.domain.user.dto.request.UpdateIntroductionRequest;
+import kr.santanrudolph.everyvent.domain.user.dto.request.UpdateNicknameRequest;
+import kr.santanrudolph.everyvent.domain.user.dto.response.UserResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@Slf4j
+@Tag(name = "사용자", description = "사용자 관련 API")
+@RestController
+@RequestMapping("/api/users")
+@RequiredArgsConstructor
+public class UserController {
+
+  private final UserService userService;
+
+  @Operation(summary = "내 정보 조회", description = "현재 로그인한 사용자의 정보를 조회합니다.")
+  @ApiResponses({
+      @ApiResponse(responseCode = "200", description = "조회 성공"),
+      @ApiResponse(responseCode = "400", description = "비즈니스 에러 (에러코드로 구분: USER_NOT_FOUND, UNAUTHORIZED 등)")
+  })
+  @GetMapping("/me")
+  public ResponseEntity<UserResponse> getMyInfo() {
+    Long userId = AuthenticationUtil.getCurrentUserId();
+    log.info("Get my info - User ID: {}", userId);
+
+    UserResponse response = userService.getUserInfo(userId);
+    return ResponseEntity.ok(response);
+  }
+
+  @Operation(summary = "소개글 수정", description = "현재 로그인한 사용자의 소개글을 수정합니다.")
+  @ApiResponses({
+      @ApiResponse(responseCode = "200", description = "수정 성공"),
+      @ApiResponse(responseCode = "400", description = "비즈니스 에러 (에러코드로 구분: USER_NOT_FOUND, UNAUTHORIZED, INVALID_INPUT_VALUE 등)")
+  })
+  @PatchMapping("/me/introduction")
+  public ResponseEntity<UserResponse> updateIntroduction(
+      @Valid @RequestBody UpdateIntroductionRequest request) {
+    Long userId = AuthenticationUtil.getCurrentUserId();
+    log.info("Update introduction - User ID: {}", userId);
+
+    UserResponse response = userService.updateIntroduction(userId, request);
+    return ResponseEntity.ok(response);
+  }
+
+  @Operation(summary = "닉네임 수정", description = "현재 로그인한 사용자의 닉네임을 수정합니다. 임시 닉네임(kakao_123456789)을 원하는 닉네임으로 변경할 수 있습니다.")
+  @ApiResponses({
+      @ApiResponse(responseCode = "200", description = "수정 성공"),
+      @ApiResponse(responseCode = "400", description = "비즈니스 에러 (에러코드로 구분: DUPLICATE_NICKNAME, USER_NOT_FOUND, UNAUTHORIZED, INVALID_INPUT_VALUE 등)")
+  })
+  @PatchMapping("/me/nickname")
+  public ResponseEntity<UserResponse> updateNickname(
+      @Valid @RequestBody UpdateNicknameRequest request) {
+    Long userId = AuthenticationUtil.getCurrentUserId();
+    log.info("Update nickname - User ID: {}", userId);
+
+    UserResponse response = userService.updateNickname(userId, request);
+    return ResponseEntity.ok(response);
+  }
+}

--- a/src/main/java/kr/santanrudolph/everyvent/domain/user/UserRepository.java
+++ b/src/main/java/kr/santanrudolph/everyvent/domain/user/UserRepository.java
@@ -14,7 +14,7 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
   Optional<User> findByIdAndDeletedAtIsNull(Long id);
 
-  Optional<User> findBySocialIdAndProviderAndDeletedAtIsNull(String socialId, String provider);
+  Optional<User> findBySocialIdAndSocialProviderAndDeletedAtIsNull(String socialId, SocialProvider socialProvider);
 
   Optional<User> findByEmail(String email);
 

--- a/src/main/java/kr/santanrudolph/everyvent/domain/user/UserRepository.java
+++ b/src/main/java/kr/santanrudolph/everyvent/domain/user/UserRepository.java
@@ -1,0 +1,21 @@
+package kr.santanrudolph.everyvent.domain.user;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface UserRepository extends JpaRepository<User, Long> {
+
+  Optional<User> findById(Long id);
+
+  boolean existsByNickname(String nickname);
+
+  Optional<User> findByIdAndDeletedAtIsNull(Long id);
+
+  Optional<User> findBySocialIdAndProviderAndDeletedAtIsNull(String socialId, String provider);
+
+  Optional<User> findByEmail(String email);
+
+}

--- a/src/main/java/kr/santanrudolph/everyvent/domain/user/UserService.java
+++ b/src/main/java/kr/santanrudolph/everyvent/domain/user/UserService.java
@@ -1,0 +1,54 @@
+package kr.santanrudolph.everyvent.domain.user;
+
+import kr.santanrudolph.everyvent.domain.user.dto.request.UpdateIntroductionRequest;
+import kr.santanrudolph.everyvent.domain.user.dto.request.UpdateNicknameRequest;
+import kr.santanrudolph.everyvent.domain.user.dto.response.UserResponse;
+import kr.santanrudolph.everyvent.global.exception.ErrorCode;
+import kr.santanrudolph.everyvent.global.exception.EveryventException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class UserService {
+
+  private final UserRepository userRepository;
+
+  public UserResponse getUserInfo(Long userId) {
+    User user = userRepository.findByIdAndDeletedAtIsNull(userId)
+        .orElseThrow(() -> new EveryventException(ErrorCode.USER_NOT_FOUND));
+
+    return UserResponse.from(user);
+  }
+
+  @Transactional
+  public UserResponse updateIntroduction(Long userId, UpdateIntroductionRequest request) {
+    User user = userRepository.findByIdAndDeletedAtIsNull(userId)
+        .orElseThrow(() -> new EveryventException(ErrorCode.USER_NOT_FOUND));
+
+    user.updateIntroduction(request.getIntroduction());
+    log.info("User introduction updated - User ID: {}", userId);
+
+    return UserResponse.from(user);
+  }
+
+  @Transactional
+  public UserResponse updateNickname(Long userId, UpdateNicknameRequest request) {
+    if (userRepository.existsByNickname(request.getNickname())) {
+      throw new EveryventException(ErrorCode.DUPLICATE_NICKNAME);
+    }
+
+    User user = userRepository.findByIdAndDeletedAtIsNull(userId)
+        .orElseThrow(() -> new EveryventException(ErrorCode.USER_NOT_FOUND));
+
+    user.updateNickname(request.getNickname());
+    log.info("User nickname updated - User ID: {}, New nickname: {}", userId,
+        request.getNickname());
+
+    return UserResponse.from(user);
+  }
+}

--- a/src/main/java/kr/santanrudolph/everyvent/domain/user/dto/request/UpdateIntroductionRequest.java
+++ b/src/main/java/kr/santanrudolph/everyvent/domain/user/dto/request/UpdateIntroductionRequest.java
@@ -1,0 +1,13 @@
+package kr.santanrudolph.everyvent.domain.user.dto.request;
+
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class UpdateIntroductionRequest {
+
+    @Size(max = 200, message = "소개글은 최대 200자까지 입력 가능합니다.")
+    private String introduction;
+}

--- a/src/main/java/kr/santanrudolph/everyvent/domain/user/dto/request/UpdateNicknameRequest.java
+++ b/src/main/java/kr/santanrudolph/everyvent/domain/user/dto/request/UpdateNicknameRequest.java
@@ -1,0 +1,17 @@
+package kr.santanrudolph.everyvent.domain.user.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class UpdateNicknameRequest {
+
+    @NotBlank(message = "닉네임은 필수입니다.")
+    @Size(min = 2, max = 20, message = "닉네임은 2~20자 사이여야 합니다.")
+    @Pattern(regexp = "^[a-zA-Z0-9가-힣_]+$", message = "닉네임은 한글, 영문, 숫자, 언더스코어만 사용 가능합니다.")
+    private String nickname;
+}

--- a/src/main/java/kr/santanrudolph/everyvent/domain/user/dto/response/UserResponse.java
+++ b/src/main/java/kr/santanrudolph/everyvent/domain/user/dto/response/UserResponse.java
@@ -12,7 +12,7 @@ public class UserResponse {
   private String nickname;
   private String email;
   private String introduction;
-  private String provider;
+  private String socialProvider;
   private String role;
 
   public static UserResponse from(User user) {
@@ -21,7 +21,7 @@ public class UserResponse {
         .nickname(user.getNickname())
         .email(user.getEmail())
         .introduction(user.getIntroduction())
-        .provider(user.getProvider())
+        .socialProvider(String.valueOf(user.getSocialProvider()))
         .role(user.getRole().name())
         .build();
   }

--- a/src/main/java/kr/santanrudolph/everyvent/domain/user/dto/response/UserResponse.java
+++ b/src/main/java/kr/santanrudolph/everyvent/domain/user/dto/response/UserResponse.java
@@ -1,0 +1,28 @@
+package kr.santanrudolph.everyvent.domain.user.dto.response;
+
+import kr.santanrudolph.everyvent.domain.user.User;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class UserResponse {
+
+  private Long id;
+  private String nickname;
+  private String email;
+  private String introduction;
+  private String provider;
+  private String role;
+
+  public static UserResponse from(User user) {
+    return UserResponse.builder()
+        .id(user.getId())
+        .nickname(user.getNickname())
+        .email(user.getEmail())
+        .introduction(user.getIntroduction())
+        .provider(user.getProvider())
+        .role(user.getRole().name())
+        .build();
+  }
+}

--- a/src/main/java/kr/santanrudolph/everyvent/global/config/CorsConfig.java
+++ b/src/main/java/kr/santanrudolph/everyvent/global/config/CorsConfig.java
@@ -1,0 +1,47 @@
+package kr.santanrudolph.everyvent.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+import java.util.Arrays;
+
+@Configuration
+public class CorsConfig {
+
+  @Bean
+  public CorsConfigurationSource corsConfigurationSource() {
+    CorsConfiguration configuration = new CorsConfiguration();
+
+    // 허용할 출처
+    configuration.setAllowedOrigins(Arrays.asList(
+        "http://localhost:3000",
+        "http://localhost:3001"
+    ));
+
+    // 허용할 HTTP 메서드
+    configuration.setAllowedMethods(Arrays.asList(
+        "GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"
+    ));
+
+    // 허용할 헤더
+    configuration.setAllowedHeaders(Arrays.asList(
+        "Authorization",
+        "Content-Type",
+        "X-Requested-With"
+    ));
+
+    // 인증 정보 허용 (쿠키 등)
+    configuration.setAllowCredentials(true);
+
+    // preflight 요청 캐시 시간 (초)
+    configuration.setMaxAge(3600L);
+
+    UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+    source.registerCorsConfiguration("/**", configuration);
+
+    return source;
+  }
+}

--- a/src/main/java/kr/santanrudolph/everyvent/global/config/JpaConfig.java
+++ b/src/main/java/kr/santanrudolph/everyvent/global/config/JpaConfig.java
@@ -1,0 +1,10 @@
+package kr.santanrudolph.everyvent.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaConfig {
+
+}

--- a/src/main/java/kr/santanrudolph/everyvent/global/config/SecurityConfig.java
+++ b/src/main/java/kr/santanrudolph/everyvent/global/config/SecurityConfig.java
@@ -35,7 +35,7 @@ public class SecurityConfig {
             .requestMatchers("/api/auth/**").permitAll()
             .requestMatchers("/oauth2/**").permitAll()
             .requestMatchers("/login/**").permitAll()
-            .requestMatchers("/oauth/callback").permitAll()
+            .requestMatchers("/oauth/callback", "/oauth/test").permitAll()
             .requestMatchers("/swagger-ui/**", "/v3/api-docs/**").permitAll()
             .anyRequest().authenticated())
         .headers(headers -> headers

--- a/src/main/java/kr/santanrudolph/everyvent/global/config/SecurityConfig.java
+++ b/src/main/java/kr/santanrudolph/everyvent/global/config/SecurityConfig.java
@@ -1,0 +1,50 @@
+package kr.santanrudolph.everyvent.global.config;
+
+import kr.santanrudolph.everyvent.auth.security.JwtAuthenticationFilter;
+import kr.santanrudolph.everyvent.auth.service.KakaoOAuthService;
+import kr.santanrudolph.everyvent.auth.security.OAuth2SuccessHandler;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+  private final KakaoOAuthService kakaoOAuthService;
+  private final OAuth2SuccessHandler oAuth2SuccessHandler;
+  private final JwtAuthenticationFilter jwtAuthenticationFilter;
+
+  @Bean
+  public SecurityFilterChain securityFilterChain(HttpSecurity http, CorsConfig corsConfig)
+      throws Exception {
+    http
+        .cors(cors -> cors.configurationSource(corsConfig.corsConfigurationSource()))
+        .csrf(csrf -> csrf.disable())
+        .sessionManagement(session -> session
+            .sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+        .authorizeHttpRequests(auth -> auth
+            .requestMatchers("/", "/error", "/favicon.ico").permitAll()
+            .requestMatchers("/h2-console/**").permitAll()
+            .requestMatchers("/api/auth/**").permitAll()
+            .requestMatchers("/oauth2/**").permitAll()
+            .requestMatchers("/login/**").permitAll()
+            .requestMatchers("/oauth/callback").permitAll()
+            .requestMatchers("/swagger-ui/**", "/v3/api-docs/**").permitAll()
+            .anyRequest().authenticated())
+        .headers(headers -> headers
+            .frameOptions(frameOptions -> frameOptions.sameOrigin()))
+        .oauth2Login(oauth2 -> oauth2
+            .userInfoEndpoint(userInfo -> userInfo
+                .userService(kakaoOAuthService))
+            .successHandler(oAuth2SuccessHandler))
+        .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
+    return http.build();
+  }
+}

--- a/src/main/java/kr/santanrudolph/everyvent/global/config/SwaggerConfig.java
+++ b/src/main/java/kr/santanrudolph/everyvent/global/config/SwaggerConfig.java
@@ -1,0 +1,45 @@
+package kr.santanrudolph.everyvent.global.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import io.swagger.v3.oas.models.servers.Server;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.List;
+
+@Configuration
+public class SwaggerConfig {
+
+  @Bean
+  public OpenAPI openAPI() {
+    String jwtSchemeName = "JWT Token";
+
+    SecurityRequirement securityRequirement = new SecurityRequirement()
+        .addList(jwtSchemeName);
+
+    Components components = new Components()
+        .addSecuritySchemes(jwtSchemeName, new SecurityScheme()
+            .name(jwtSchemeName)
+            .type(SecurityScheme.Type.HTTP)
+            .scheme("bearer")
+            .bearerFormat("JWT")
+            .description("JWT 토큰을 입력하세요. 'Bearer ' 접두사는 자동으로 추가됩니다."));
+
+    return new OpenAPI()
+        .info(new Info()
+            .title("Everyvent API")
+            .description("Everyvent 서버 API 문서")
+            .version("1.0.0"))
+        .servers(List.of(
+            new Server()
+                .url("http://localhost:8080")
+                .description("로컬 개발 서버")
+        ))
+        .addSecurityItem(securityRequirement)
+        .components(components);
+  }
+}

--- a/src/main/java/kr/santanrudolph/everyvent/global/entity/BaseEntity.java
+++ b/src/main/java/kr/santanrudolph/everyvent/global/entity/BaseEntity.java
@@ -1,0 +1,25 @@
+package kr.santanrudolph.everyvent.global.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseEntity {
+
+  @CreatedDate
+  @Column(nullable = false, updatable = false)
+  private LocalDateTime createdAt;
+
+  @LastModifiedDate
+  @Column(nullable = false)
+  private LocalDateTime updatedAt;
+}

--- a/src/main/java/kr/santanrudolph/everyvent/global/exception/ErrorCode.java
+++ b/src/main/java/kr/santanrudolph/everyvent/global/exception/ErrorCode.java
@@ -1,4 +1,4 @@
-package kr.santanrudolph.everyvent.global;
+package kr.santanrudolph.everyvent.global.exception;
 
 import lombok.RequiredArgsConstructor;
 
@@ -17,6 +17,7 @@ public enum ErrorCode {
   UNAUTHORIZED("인증이 필요합니다."),
   INVALID_TOKEN("유효하지 않은 토큰입니다."),
   EXPIRED_TOKEN("만료된 토큰입니다."),
+  BLACKLISTED_TOKEN("로그아웃된 토큰입니다."),
   ACCESS_DENIED("권한이 없습니다."),
 
   // 사용자 에러

--- a/src/main/java/kr/santanrudolph/everyvent/global/exception/ErrorResponse.java
+++ b/src/main/java/kr/santanrudolph/everyvent/global/exception/ErrorResponse.java
@@ -1,4 +1,4 @@
-package kr.santanrudolph.everyvent.global;
+package kr.santanrudolph.everyvent.global.exception;
 
 public record ErrorResponse(
     String code,

--- a/src/main/java/kr/santanrudolph/everyvent/global/exception/EveryventException.java
+++ b/src/main/java/kr/santanrudolph/everyvent/global/exception/EveryventException.java
@@ -1,4 +1,4 @@
-package kr.santanrudolph.everyvent.global;
+package kr.santanrudolph.everyvent.global.exception;
 
 import lombok.Getter;
 

--- a/src/main/java/kr/santanrudolph/everyvent/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/kr/santanrudolph/everyvent/global/exception/GlobalExceptionHandler.java
@@ -1,4 +1,4 @@
-package kr.santanrudolph.everyvent.global;
+package kr.santanrudolph.everyvent.global.exception;
 
 import jakarta.servlet.http.HttpServletRequest;
 import java.io.BufferedReader;

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,0 @@
-spring.application.name=everyvent-server

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,49 @@
+server:
+  port: 8080
+
+spring:
+  datasource:
+    driver-class-name: org.h2.Driver
+    url: jdbc:h2:mem:testdb # 개발용 인메모리 테스트 db
+    username: sa # system administartor
+    password:
+
+  h2:
+    console:
+      enabled: true
+      path: /h2-console
+
+  jpa:
+    hibernate:
+      ddl-auto: update
+    properties:
+      hibernate:
+        format_sql: true
+        show_sql: true
+
+  mvc:
+    async:
+      request-timeout: 60000
+
+  security:
+    oauth2:
+      client:
+        registration:
+          kakao:
+            client-id: ${KAKAO_CLIENT_ID}
+            client-secret: ${KAKAO_CLIENT_SECRET:}
+            redirect-uri: "{baseUrl}/login/oauth2/code/kakao"
+            authorization-grant-type: authorization_code
+            scope:
+              - account_email
+        provider:
+          kakao:
+            authorization-uri: https://kauth.kakao.com/oauth/authorize
+            token-uri: https://kauth.kakao.com/oauth/token
+            user-info-uri: https://kapi.kakao.com/v2/user/me
+            user-name-attribute: id
+
+jwt:
+  secret: ${jwt.secret}
+  access-token-expiration: 3600000
+  refresh-token-expiration: 604800000

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -4,7 +4,7 @@ server:
 spring:
   datasource:
     driver-class-name: org.h2.Driver
-    url: jdbc:h2:mem:testdb # 개발용 인메모리 테스트 db
+    url: jdbc:h2:file:./data/testdb # 개발용 파일 기반 DB (재시작해도 데이터 유지)
     username: sa # system administartor
     password:
 
@@ -44,6 +44,6 @@ spring:
             user-name-attribute: id
 
 jwt:
-  secret: ${jwt.secret}
+  secret: ${JWT_SECRET}
   access-token-expiration: 3600000
   refresh-token-expiration: 604800000

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,0 +1,49 @@
+server:
+  port: 8080
+
+spring:
+  datasource:
+    driver-class-name: org.h2.Driver
+    url: jdbc:h2:mem:testdb
+    username: sa
+    password:
+
+  h2:
+    console:
+      enabled: true
+      path: /h2-console
+
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+    properties:
+      hibernate:
+        format_sql: true
+        show_sql: false
+
+  security:
+    oauth2:
+      client:
+        registration:
+          kakao:
+            client-id: test-client-id
+            client-secret: test-client-secret
+            redirect-uri: "{baseUrl}/login/oauth2/code/kakao"
+            authorization-grant-type: authorization_code
+            scope:
+              - account_email
+        provider:
+          kakao:
+            authorization-uri: https://kauth.kakao.com/oauth/authorize
+            token-uri: https://kauth.kakao.com/oauth/token
+            user-info-uri: https://kapi.kakao.com/v2/user/me
+            user-name-attribute: id
+
+jwt:
+  secret: test-jwt-secret-key-for-testing-purpose-minimum-32-characters
+  access-token-expiration: 3600000
+  refresh-token-expiration: 604800000
+
+logging:
+  level:
+    kr.santanrudolph.everyvent: INFO


### PR DESCRIPTION
## 📝 무엇을 했나요?
- 카카오 소셜 로그인 기능
- 회원정보 조회, 수정 (닉네임, 소개글) 기능 

## 💭 고민 지점과 리뷰 포인트
확장성 있는 폴더 구조를 고민하다가 작업이 지연되었습니다...
인증 관련 코드가 아직 최적화되지 않아, 추후 리팩토링 예정입니다 🥲😿
빠른 완성을 위해 현재 테스트 코드는 작성하지 않았습니다. 리팩토링과 함께 추가 예정입니다.
나영님의 빠른 개발 시작을 위해서 심각한 문제가 있지 않은 이상 coderabbit의 리뷰는 다음 pr에 반영해서 고치도록 하겠슴당 ❕❕❕

## 🔧 추후 개선 계획
1. 토큰 관리에 Redis 도입
2. 만료 토큰 자동 정리 (스케줄러)
3. 토큰 자동 재발급 기능
4. OAuth2UserHelper를 이용한 OAuthService 리팩토링
5. OAuth 실패 핸들러 구현

## 🔗 관련 이슈
#1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - 카카오 OAuth2 로그인 도입 및 JWT 액세스/리프레시 토큰 발급, 토큰 갱신·로그아웃 지원
  - 내 정보 조회, 소개글·닉네임 수정 API 추가
  - 토큰 블랙리스트 처리 및 인증 필터로 요청 인증 강화
  - CORS 및 보안 설정 추가

- **Documentation**
  - Swagger/OpenAPI UI에 JWT 인증 스키마 및 API 문서 반영

- **Tests**
  - 테스트용 애플리케이션 설정(H2, OAuth, JWT) 추가

- **Chores**
  - .gitignore 확장(.env, H2 파일) 및 설정 파일 정리
<!-- end of auto-generated comment: release notes by coderabbit.ai -->