### PR TITLE
refactor: LocalDateTime -> Instant로 변경

### DIFF
--- a/src/main/java/kr/santanrudolph/everyvent/auth/controller/AuthController.java
+++ b/src/main/java/kr/santanrudolph/everyvent/auth/controller/AuthController.java
@@ -6,6 +6,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
+import java.time.Instant;
 import kr.santanrudolph.everyvent.auth.AuthenticationUtil;
 import kr.santanrudolph.everyvent.auth.dto.TokenRefreshRequest;
 import kr.santanrudolph.everyvent.auth.dto.TokenResponse;
@@ -26,7 +27,6 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import java.time.LocalDateTime;
 
 @Tag(name = "인증", description = "인증 관련 API")
 @Slf4j
@@ -82,8 +82,7 @@ public class AuthController {
 
     refreshToken.updateToken(
         newRefreshToken,
-        LocalDateTime.now().plusSeconds(refreshTokenExpiration)
-    );
+        Instant.now().plusMillis(refreshTokenExpiration));
 
     log.info("Token refreshed - User ID: {}", userId);
 
@@ -116,7 +115,7 @@ public class AuthController {
     if (accessToken != null) {
       BlacklistedToken blacklist = BlacklistedToken.builder()
           .token(accessToken)
-          .expiresAt(LocalDateTime.now().plusHours(1))
+          .expiresAt(Instant.now().plusMillis(accessTokenExpiration))
           .build();
       blacklistedTokenRepository.save(blacklist);
     }

--- a/src/main/java/kr/santanrudolph/everyvent/auth/entity/BlacklistedToken.java
+++ b/src/main/java/kr/santanrudolph/everyvent/auth/entity/BlacklistedToken.java
@@ -1,12 +1,12 @@
 package kr.santanrudolph.everyvent.auth.entity;
 
 import jakarta.persistence.*;
+import java.time.Instant;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.time.LocalDateTime;
 
 @Entity
 @Table(name = "blacklisted_token", indexes = {
@@ -24,15 +24,15 @@ public class BlacklistedToken {
   private String token;
 
   @Column(nullable = false)
-  private LocalDateTime expiresAt;
+  private Instant expiresAt;
 
   @Column(nullable = false)
-  private LocalDateTime createdAt;
+  private Instant createdAt;
 
   @Builder
-  public BlacklistedToken(String token, LocalDateTime expiresAt) {
+  public BlacklistedToken(String token, Instant expiresAt) {
     this.token = token;
     this.expiresAt = expiresAt;
-    this.createdAt = LocalDateTime.now();
+    this.createdAt = Instant.now();
   }
 }

--- a/src/main/java/kr/santanrudolph/everyvent/auth/entity/RefreshToken.java
+++ b/src/main/java/kr/santanrudolph/everyvent/auth/entity/RefreshToken.java
@@ -1,12 +1,12 @@
 package kr.santanrudolph.everyvent.auth.entity;
 
 import jakarta.persistence.*;
+import java.time.Instant;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.time.LocalDateTime;
 
 @Entity
 @Table(name = "refresh_tokens")
@@ -21,21 +21,21 @@ public class RefreshToken {
   private String token;
 
   @Column(nullable = false)
-  private LocalDateTime expiresAt;
+  private Instant expiresAt;
 
   @Builder
-  public RefreshToken(Long userId, String token, LocalDateTime expiresAt) {
+  public RefreshToken(Long userId, String token, Instant expiresAt) {
     this.userId = userId;
     this.token = token;
     this.expiresAt = expiresAt;
   }
 
-  public void updateToken(String token, LocalDateTime expiresAt) {
+  public void updateToken(String token, Instant expiresAt) {
     this.token = token;
     this.expiresAt = expiresAt;
   }
 
   public boolean isExpired() {
-    return LocalDateTime.now().isAfter(expiresAt);
+    return Instant.now().isAfter(expiresAt);
   }
 }

--- a/src/main/java/kr/santanrudolph/everyvent/auth/repository/BlacklistedTokenRepository.java
+++ b/src/main/java/kr/santanrudolph/everyvent/auth/repository/BlacklistedTokenRepository.java
@@ -1,15 +1,15 @@
 package kr.santanrudolph.everyvent.auth.repository;
 
+import java.time.Instant;
 import kr.santanrudolph.everyvent.auth.entity.BlacklistedToken;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
-import java.time.LocalDateTime;
 
 @Repository
 public interface BlacklistedTokenRepository extends JpaRepository<BlacklistedToken, Long> {
 
   boolean existsByToken(String token);
 
-  void deleteByExpiresAtBefore(LocalDateTime dateTime);
+  void deleteByExpiresAtBefore(Instant now);
 }

--- a/src/main/java/kr/santanrudolph/everyvent/auth/security/OAuth2SuccessHandler.java
+++ b/src/main/java/kr/santanrudolph/everyvent/auth/security/OAuth2SuccessHandler.java
@@ -2,63 +2,67 @@ package kr.santanrudolph.everyvent.auth.security;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import java.time.Instant;
 import kr.santanrudolph.everyvent.auth.entity.RefreshToken;
 import kr.santanrudolph.everyvent.auth.repository.RefreshTokenRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.util.UriComponentsBuilder;
-
 import java.io.IOException;
-import java.time.LocalDateTime;
 
 @Slf4j
 @Component
 @RequiredArgsConstructor
 public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
 
-    private final JwtTokenProvider jwtTokenProvider;
-    private final RefreshTokenRepository refreshTokenRepository;
+  private final JwtTokenProvider jwtTokenProvider;
+  private final RefreshTokenRepository refreshTokenRepository;
 
-    @Override
-    @Transactional
-    public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
-                                        Authentication authentication) throws IOException {
-        EveryventOAuth2User oAuth2User = (EveryventOAuth2User) authentication.getPrincipal();
-        Long userId = oAuth2User.getUserId();
+  @Value("${jwt.refresh-token-expiration}")
+  private long refreshTokenExpiration;
 
-        log.info("OAuth2 Login Success - User ID: {}", userId);
+  @Override
+  @Transactional
+  public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
+      Authentication authentication) throws IOException {
+    EveryventOAuth2User oAuth2User = (EveryventOAuth2User) authentication.getPrincipal();
+    Long userId = oAuth2User.getUserId();
 
-        // JWT 토큰 생성
-        String accessToken = jwtTokenProvider.createAccessToken(userId);
-        String refreshToken = jwtTokenProvider.createRefreshToken(userId);
+    log.info("OAuth2 Login Success - User ID: {}", userId);
 
-        // RefreshToken DB 저장 (기존 토큰이 있으면 업데이트)
-        RefreshToken refreshTokenEntity = refreshTokenRepository.findById(userId)
-                .orElse(RefreshToken.builder()
-                        .userId(userId)
-                        .token(refreshToken)
-                        .expiresAt(LocalDateTime.now().plusDays(7))
-                        .build());
+    // JWT 토큰 생성
+    String accessToken = jwtTokenProvider.createAccessToken(userId);
+    String refreshToken = jwtTokenProvider.createRefreshToken(userId);
 
-        if (refreshTokenEntity.getToken() != null) {
-            refreshTokenEntity.updateToken(refreshToken, LocalDateTime.now().plusDays(7));
-        }
+    // RefreshToken DB 저장 (기존 토큰이 있으면 업데이트)
+    RefreshToken refreshTokenEntity = refreshTokenRepository.findById(userId)
+        .orElse(RefreshToken.builder()
+            .userId(userId)
+            .token(refreshToken)
+            .expiresAt(Instant.now().plusMillis(refreshTokenExpiration))
+            .build());
 
-        refreshTokenRepository.save(refreshTokenEntity);
-        log.info("RefreshToken saved for User ID: {}", userId);
-
-        // 테스트용 콜백 엔드포인트로 리다이렉트 (토큰을 쿼리 파라미터로 전달하여, 로그인 시 프론트 없이도 토큰 확인 가능)
-        // 프론트 연동 시에는 삭제 필요
-        String targetUrl = UriComponentsBuilder.fromUriString("http://localhost:8080/oauth/callback")
-                .queryParam("accessToken", accessToken)
-                .queryParam("refreshToken", refreshToken)
-                .build().toUriString();
-
-        log.info("Redirecting to: {}", targetUrl);
-        getRedirectStrategy().sendRedirect(request, response, targetUrl);
+    if (refreshTokenEntity.getToken() != null) {
+      refreshTokenEntity.updateToken(refreshToken,
+          Instant.now().plusMillis(refreshTokenExpiration));
     }
+
+    refreshTokenRepository.save(refreshTokenEntity);
+    log.info("RefreshToken saved for User ID: {}", userId);
+
+    // 테스트용 콜백 엔드포인트로 리다이렉트 (토큰을 쿼리 파라미터로 전달하여, 로그인 시 프론트 없이도 토큰 확인 가능)
+    // 프론트 연동 시에는 삭제 필요
+    String targetUrl = UriComponentsBuilder.fromUriString("http://localhost:8080/oauth/callback")
+        .queryParam("accessToken", accessToken)
+        .queryParam("refreshToken", refreshToken)
+        .build().toUriString();
+
+    log.info("Redirecting to: {}", targetUrl);
+    getRedirectStrategy().sendRedirect(request, response, targetUrl);
+  }
 }

--- a/src/main/java/kr/santanrudolph/everyvent/domain/user/User.java
+++ b/src/main/java/kr/santanrudolph/everyvent/domain/user/User.java
@@ -1,13 +1,13 @@
 package kr.santanrudolph.everyvent.domain.user;
 
 import jakarta.persistence.*;
+import java.time.Instant;
 import kr.santanrudolph.everyvent.global.entity.BaseEntity;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.time.LocalDateTime;
 
 @Entity
 @Table(name = "users", uniqueConstraints = {
@@ -41,7 +41,7 @@ public class User extends BaseEntity {
   private Role role;
 
   @Column
-  private LocalDateTime deletedAt;
+  private Instant deletedAt;
 
   @Builder
   public User(String socialId, SocialProvider socialProvider, String email, String nickname,
@@ -67,7 +67,7 @@ public class User extends BaseEntity {
   }
 
   public void softDelete() {
-    this.deletedAt = LocalDateTime.now();
+    this.deletedAt = Instant.now();
   }
 
   public boolean isDeleted() {

--- a/src/main/java/kr/santanrudolph/everyvent/global/entity/BaseEntity.java
+++ b/src/main/java/kr/santanrudolph/everyvent/global/entity/BaseEntity.java
@@ -3,12 +3,12 @@ package kr.santanrudolph.everyvent.global.entity;
 import jakarta.persistence.Column;
 import jakarta.persistence.EntityListeners;
 import jakarta.persistence.MappedSuperclass;
+import java.time.Instant;
 import lombok.Getter;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
-import java.time.LocalDateTime;
 
 @Getter
 @MappedSuperclass
@@ -17,9 +17,9 @@ public abstract class BaseEntity {
 
   @CreatedDate
   @Column(nullable = false, updatable = false)
-  private LocalDateTime createdAt;
+  private Instant createdAt;
 
   @LastModifiedDate
   @Column(nullable = false)
-  private LocalDateTime updatedAt;
+  private Instant updatedAt;
 }


### PR DESCRIPTION
## 📝 무엇을 했나요?
- AuthController, BaseEntity, BlacklistedToken, BlacklistedTokenRepository, Oauth2SuccessHandler, RefreshToken, User 등에서 LocalDateTime을 Instant로 변경
- 토큰 만료 시간 계산을 Instant.now().plusMillis()로 수정

## 💭 고민 지점과 리뷰 포인트
LocalDateTime은 타임존 정보를 포함하지 않아서, 서버거 어느 타임존에 있느냐에 따라 값이 달라질 수 있습니다.
Instant는 UTC를 기준으로 항상 동일한 시간을 나타내므로, 위치와 상관없이 DB에 일관되게 저장할 수 있습니다.
긴급 pr이므로 @coderabbitai는 리뷰를 생략해주세요.