### PR TITLE
feat: 캘린더 관련 API 구현

### DIFF
--- a/src/main/java/kr/santanrudolph/everyvent/domain/calendar/Calendar.java
+++ b/src/main/java/kr/santanrudolph/everyvent/domain/calendar/Calendar.java
@@ -4,6 +4,8 @@ import jakarta.persistence.*;
 import jakarta.validation.constraints.Pattern;
 import kr.santanrudolph.everyvent.domain.user.User;
 import kr.santanrudolph.everyvent.global.entity.BaseEntity;
+import kr.santanrudolph.everyvent.global.exception.ErrorCode;
+import kr.santanrudolph.everyvent.global.exception.EveryventException;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -101,19 +103,19 @@ public abstract class Calendar extends BaseEntity {
     // === 공통 검증 메서드 ===
     protected void validateHexColor(String color) {
         if (!color.matches(HEX_COLOR_PATTERN)) {
-            throw new IllegalArgumentException("유효한 HEX 색상 코드여야 합니다");
+            throw new EveryventException(ErrorCode.INVALID_COLOR);
         }
     }
 
     protected void validateNotNull(Object value, String fieldName) {
         if (value == null || (value instanceof String s && s.isBlank())) {
-            throw new IllegalArgumentException(fieldName + "은(는) 필수값입니다");
+            throw new EveryventException(ErrorCode.REQUIRED_FIELD, fieldName);
         }
     }
 
     protected void validateDateRange(Instant startDate, Instant endDate) {
         if (startDate.isAfter(endDate)) {
-            throw new IllegalArgumentException("시작일은 종료일보다 이전이어야 합니다");
+            throw new EveryventException(ErrorCode.INVALID_DATE_RANGE);
         }
     }
 }

--- a/src/main/java/kr/santanrudolph/everyvent/domain/calendar/Calendar.java
+++ b/src/main/java/kr/santanrudolph/everyvent/domain/calendar/Calendar.java
@@ -55,6 +55,9 @@ public abstract class Calendar extends BaseEntity {
     @Column(nullable = false)
     private Category category;
 
+    @Column
+    private Instant deletedAt;
+
     protected Calendar(User user, String title, String description, Instant startDate, Instant endDate, Visibility visibility, String color, Category category) {
         this.user = user;
         this.title = title;
@@ -67,6 +70,10 @@ public abstract class Calendar extends BaseEntity {
     }
 
     public abstract boolean isScrapable();
+
+    public void softDelete() {
+        this.deletedAt = Instant.now();
+    }
 
     // === 속성 변경 메서드 ===
     public void changeColor(String newColor) {

--- a/src/main/java/kr/santanrudolph/everyvent/domain/calendar/Calendar.java
+++ b/src/main/java/kr/santanrudolph/everyvent/domain/calendar/Calendar.java
@@ -1,0 +1,120 @@
+package kr.santanrudolph.everyvent.domain.calendar;
+
+import jakarta.persistence.*;
+import jakarta.validation.constraints.Pattern;
+import kr.santanrudolph.everyvent.domain.user.User;
+import kr.santanrudolph.everyvent.global.entity.BaseEntity;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.Instant;
+
+@Entity
+@Inheritance(strategy = InheritanceType.SINGLE_TABLE)
+@DiscriminatorColumn(name = "type")
+@Table(name = "calendar")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public abstract class Calendar extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Column(nullable = false)
+    private String title;
+
+    @Column(columnDefinition = "TEXT")
+    private String description;
+
+    @Column(nullable = false)
+    private Instant startDate;
+
+    @Column(nullable = false)
+    private Instant endDate;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private Visibility visibility;
+
+    private static final String HEX_COLOR_PATTERN = "^#([0-9A-Fa-f]{3}|[0-9A-Fa-f]{6})$";
+
+    @Column(nullable = false)
+    @Pattern(
+            regexp = HEX_COLOR_PATTERN,
+            message = "유효한 HEX 색상 코드여야 합니다 (예: #FFF, #FFFFFF)"
+    )
+    private String color;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private Category category;
+
+    protected Calendar(User user, String title, String description, Instant startDate, Instant endDate, Visibility visibility, String color, Category category) {
+        this.user = user;
+        this.title = title;
+        this.description = description;
+        this.startDate = startDate;
+        this.endDate = endDate;
+        this.visibility = visibility;
+        this.color = color;
+        this.category = category;
+    }
+
+    public abstract boolean isScrapable();
+
+    // === 속성 변경 메서드 ===
+    public void changeColor(String newColor) {
+        validateHexColor(newColor);
+        this.color = newColor;
+    }
+
+    public void changeVisibility(Visibility newVisibility) {
+        if (newVisibility == null) {
+            throw new IllegalArgumentException("공개 범위는 필수입니다");
+        }
+        this.visibility = newVisibility;
+    }
+
+    public void updateDetails(String title, String description, Instant startDate, Instant endDate, Category category) {
+        validateTitle(title);
+        validateDateRange(startDate, endDate);
+        validateCategory(category);
+
+        this.title = title;
+        this.description = description;
+        this.startDate = startDate;
+        this.endDate = endDate;
+        this.category = category;
+    }
+
+    // === 공통 검증 메서드 ===
+    protected void validateHexColor(String color) {
+        if (!color.matches(HEX_COLOR_PATTERN)) {
+            throw new IllegalArgumentException("유효한 HEX 색상 코드여야 합니다");
+        }
+    }
+
+    protected void validateTitle(String title) {
+        if (title == null || title.isBlank()) {
+            throw new IllegalArgumentException("제목은 필수입니다");
+        }
+    }
+
+    protected void validateDateRange(Instant startDate, Instant endDate) {
+        if (startDate.isAfter(endDate)) {
+            throw new IllegalArgumentException("시작일은 종료일보다 이전이어야 합니다");
+        }
+    }
+
+    protected void validateCategory(Category category) {
+        if (category == null) {
+            throw new IllegalArgumentException("카테고리는 필수입니다");
+        }
+    }
+}

--- a/src/main/java/kr/santanrudolph/everyvent/domain/calendar/Calendar.java
+++ b/src/main/java/kr/santanrudolph/everyvent/domain/calendar/Calendar.java
@@ -82,16 +82,14 @@ public abstract class Calendar extends BaseEntity {
     }
 
     public void changeVisibility(Visibility newVisibility) {
-        if (newVisibility == null) {
-            throw new IllegalArgumentException("공개 범위는 필수입니다");
-        }
+        validateNotNull(newVisibility, "공개 범위");
         this.visibility = newVisibility;
     }
 
     public void updateDetails(String title, String description, Instant startDate, Instant endDate, Category category) {
-        validateTitle(title);
+        validateNotNull(title, "제목");
         validateDateRange(startDate, endDate);
-        validateCategory(category);
+        validateNotNull(category, "카테고리");
 
         this.title = title;
         this.description = description;
@@ -107,21 +105,15 @@ public abstract class Calendar extends BaseEntity {
         }
     }
 
-    protected void validateTitle(String title) {
-        if (title == null || title.isBlank()) {
-            throw new IllegalArgumentException("제목은 필수입니다");
+    protected void validateNotNull(Object value, String fieldName) {
+        if (value == null || (value instanceof String s && s.isBlank())) {
+            throw new IllegalArgumentException(fieldName + "은(는) 필수값입니다");
         }
     }
 
     protected void validateDateRange(Instant startDate, Instant endDate) {
         if (startDate.isAfter(endDate)) {
             throw new IllegalArgumentException("시작일은 종료일보다 이전이어야 합니다");
-        }
-    }
-
-    protected void validateCategory(Category category) {
-        if (category == null) {
-            throw new IllegalArgumentException("카테고리는 필수입니다");
         }
     }
 }

--- a/src/main/java/kr/santanrudolph/everyvent/domain/calendar/CalendarController.java
+++ b/src/main/java/kr/santanrudolph/everyvent/domain/calendar/CalendarController.java
@@ -1,0 +1,156 @@
+package kr.santanrudolph.everyvent.domain.calendar;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import kr.santanrudolph.everyvent.auth.AuthenticationUtil;
+import kr.santanrudolph.everyvent.domain.calendar.dto.request.OriginalCalendarRequest;
+import kr.santanrudolph.everyvent.domain.calendar.dto.response.CalendarResponse;
+import kr.santanrudolph.everyvent.domain.calendar.dto.response.OriginalCalendarResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.ZoneId;
+import java.util.List;
+
+@Tag(name = "캘린더", description = "캘린더 관련 API")
+@RestController
+@RequestMapping("/api/calendars")
+@RequiredArgsConstructor
+public class CalendarController {
+
+    private final CalendarService calendarService;
+
+    @Operation(summary = "캘린더 생성", description = "로그인한 사용자가 새로운 캘린더를 생성합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "캘린더 생성 성공"),
+            @ApiResponse(responseCode = "400", description = "비즈니스 에러 (에러 코드로 구분)")
+    })
+    @PostMapping
+    public ResponseEntity<OriginalCalendarResponse> createCalendar(
+            @RequestHeader(value = "Time-Zone", defaultValue = "Asia/Seoul") String timeZone,
+            @Valid @RequestBody OriginalCalendarRequest request
+    ) {
+        Long userId = AuthenticationUtil.getCurrentUserId();
+        ZoneId userZone = ZoneId.of(timeZone);
+        OriginalCalendarResponse response = calendarService.createCalendar(userId, request, userZone);
+        return ResponseEntity.ok(response);
+    }
+
+    @Operation(summary = "공식 캘린더 생성 (관리자용)", description = "관리자가 새로운 공식 캘린더를 생성합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "공식 캘린더 생성 성공"),
+            @ApiResponse(responseCode = "400", description = "비즈니스 에러 (에러 코드로 구분)")
+    })
+    @PostMapping("/official")
+    public ResponseEntity<OriginalCalendarResponse> createOfficialCalendar(
+            @RequestHeader(value = "Time-Zone", defaultValue = "Asia/Seoul") String timeZone,
+            @Valid @RequestBody OriginalCalendarRequest request
+    ) {
+        Long adminId = AuthenticationUtil.getCurrentUserId();
+        ZoneId userZone = ZoneId.of(timeZone);
+        OriginalCalendarResponse response = calendarService.createOfficialCalendar(adminId, request, userZone);
+        return ResponseEntity.ok(response);
+    }
+
+    @Operation(summary = "공식 캘린더 배포", description = "관리자가 생성한 공식 캘린더를 모든 일반 사용자에게 배포합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "공식 캘린더 배포 성공"),
+            @ApiResponse(responseCode = "400", description = "비즈니스 에러 (에러 코드로 구분)")
+    })
+    @PostMapping("/{calendarId}/distribute")
+    public ResponseEntity<Void> distributeOfficialCalendar(
+            @PathVariable Long calendarId,
+            @RequestHeader(value = "Time-Zone", defaultValue = "Asia/Seoul") String timeZone
+    ) {
+        Long userId = AuthenticationUtil.getCurrentUserId();
+        ZoneId userZone = ZoneId.of(timeZone);
+        calendarService.distributeOfficialCalendar(userId, calendarId, userZone);
+
+        return ResponseEntity.ok().build();
+    }
+
+    @Operation(summary = "캘린더 상세 조회", description = "캘린더 ID로 특정 캘린더를 조회합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(responseCode = "400", description = "비즈니스 에러 (에러 코드로 구분)")
+    })
+    @GetMapping("/{calendarId}")
+    public ResponseEntity<CalendarResponse> getCalendar(
+            @PathVariable Long calendarId,
+            @RequestHeader(value = "Time-Zone", defaultValue = "Asia/Seoul") String timeZone
+    ) {
+        ZoneId userZone = ZoneId.of(timeZone);
+        CalendarResponse response = calendarService.getCalendar(calendarId, userZone);
+        return ResponseEntity.ok(response);
+    }
+
+    @Operation(summary = "내 캘린더 목록 조회", description = "현재 로그인한 사용자의 특정 년/월 캘린더 목록을 조회합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(responseCode = "400", description = "비즈니스 에러 (에러 코드로 구분)")
+    })
+    @GetMapping("/me")
+    public ResponseEntity<List<CalendarResponse>> getMyCalendars(
+            @RequestParam int year,
+            @RequestParam int month,
+            @RequestHeader(value = "Time-Zone", defaultValue = "Asia/Seoul") String timeZone
+    ) {
+        Long userId = AuthenticationUtil.getCurrentUserId();
+        ZoneId userZone = ZoneId.of(timeZone);
+        List<CalendarResponse> responses = calendarService.getMyCalendars(userId, year, month, userZone);
+        return ResponseEntity.ok(responses);
+    }
+
+    @Operation(summary = "다른 사용자 캘린더 조회", description = "다른 사용자의 캘린더 목록을 조회합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(responseCode = "400", description = "비즈니스 에러 (에러 코드로 구분)")
+    })
+    @GetMapping("/users/{targetId}")
+    public ResponseEntity<List<CalendarResponse>> getCalendars(
+            @PathVariable Long targetId,
+            @RequestParam int year,
+            @RequestParam int month,
+            @RequestHeader(value = "Time-Zone", defaultValue = "Asia/Seoul") String timeZone
+    ) {
+        Long viewerId = AuthenticationUtil.getCurrentUserId();
+        ZoneId userZone = ZoneId.of(timeZone);
+        List<CalendarResponse> responses = calendarService.getCalendars(viewerId, targetId, year, month, userZone);
+        return ResponseEntity.ok(responses);
+    }
+
+    @Operation(summary = "캘린더 수정", description = "내가 만든 캘린더 또는 관리자가 만든 공식 캘린더를 수정합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "수정 성공"),
+            @ApiResponse(responseCode = "400", description = "비즈니스 에러 (에러 코드로 구분)")
+    })
+    @PutMapping("/{calendarId}")
+    public ResponseEntity<CalendarResponse> updateCalendar(
+            @PathVariable Long calendarId,
+            @RequestHeader(value = "Time-Zone", defaultValue = "Asia/Seoul") String timeZone,
+            @Valid @RequestBody OriginalCalendarRequest request
+    ) {
+        Long userId = AuthenticationUtil.getCurrentUserId();
+        ZoneId userZone = ZoneId.of(timeZone);
+        CalendarResponse response = calendarService.updateCalendar(userId, calendarId, request, userZone);
+        return ResponseEntity.ok(response);
+    }
+
+    @Operation(summary = "캘린더 삭제", description = "내가 만든 캘린더 또는 공식 캘린더를 삭제합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "삭제 성공"),
+            @ApiResponse(responseCode = "400", description = "비즈니스 에러 (에러 코드로 구분)")
+    })
+    @DeleteMapping("/{calendarId}")
+    public ResponseEntity<Void> deleteCalendar(
+            @PathVariable Long calendarId
+    ) {
+        Long userId = AuthenticationUtil.getCurrentUserId();
+        calendarService.deleteCalendar(userId, calendarId);
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/kr/santanrudolph/everyvent/domain/calendar/CalendarRepository.java
+++ b/src/main/java/kr/santanrudolph/everyvent/domain/calendar/CalendarRepository.java
@@ -1,0 +1,53 @@
+package kr.santanrudolph.everyvent.domain.calendar;
+
+import kr.santanrudolph.everyvent.domain.user.Role;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface CalendarRepository extends JpaRepository<Calendar,Long> {
+
+    @Query("SELECT COUNT(c) FROM Calendar c " +
+            "WHERE c.user.id = :userId " +
+            "AND c.startDate = :startDate " +
+            "AND c.endDate = :endDate " +
+            "AND c.deletedAt IS NULL")
+    long countByUserIdInMonth(
+            @Param("userId") Long userId,
+            @Param("startDate") Instant startDate,
+            @Param("endDate") Instant endDate);
+
+    @Query("SELECT c FROM Calendar c " +
+            "WHERE c.user.id = :userId " +
+            "AND c.startDate = :startDate " +
+            "AND c.endDate = :endDate " +
+            "AND c.deletedAt IS NULL")
+    List<Calendar> findAllByUserIdInMonth(
+            @Param("userId") Long userId,
+            @Param("startDate") Instant startDate,
+            @Param("endDate") Instant endDate
+    );
+
+    @Query("SELECT c FROM OriginalCalendar c " +
+            "WHERE c.isOfficial = true AND c.user.role = :role " +
+            "AND c.user.id <> :userId " +
+            "AND c.startDate = :startDate " +
+            "AND c.endDate = :endDate " +
+            "AND c.deletedAt IS NULL")
+    List<Calendar> findAllOfficialCalendars(
+            @Param("userId") Long userId,
+            @Param("startDate") Instant startDate,
+            @Param("endDate") Instant endDate,
+            @Param("role") Role role
+    );
+
+    @Query("SELECT c.user.id FROM OriginalCalendar c " +
+            "WHERE c.officialId = :officialId")
+    List<Long> findUserIdsByOfficialId(@Param("officialId") Long officialId);
+}

--- a/src/main/java/kr/santanrudolph/everyvent/domain/calendar/CalendarRepository.java
+++ b/src/main/java/kr/santanrudolph/everyvent/domain/calendar/CalendarRepository.java
@@ -11,12 +11,12 @@ import java.util.List;
 import java.util.Optional;
 
 @Repository
-public interface CalendarRepository extends JpaRepository<Calendar,Long> {
+public interface CalendarRepository extends JpaRepository<Calendar, Long> {
 
     @Query("SELECT COUNT(c) FROM Calendar c " +
             "WHERE c.user.id = :userId " +
-            "AND c.startDate = :startDate " +
-            "AND c.endDate = :endDate " +
+            "AND c.startDate <= :endDate " +
+            "AND c.endDate >= :startDate " +
             "AND c.deletedAt IS NULL")
     long countByUserIdInMonth(
             @Param("userId") Long userId,
@@ -25,8 +25,8 @@ public interface CalendarRepository extends JpaRepository<Calendar,Long> {
 
     @Query("SELECT c FROM Calendar c " +
             "WHERE c.user.id = :userId " +
-            "AND c.startDate = :startDate " +
-            "AND c.endDate = :endDate " +
+            "AND c.startDate <= :endDate " +
+            "AND c.endDate >= :startDate " +
             "AND c.deletedAt IS NULL")
     List<Calendar> findAllByUserIdInMonth(
             @Param("userId") Long userId,
@@ -37,8 +37,8 @@ public interface CalendarRepository extends JpaRepository<Calendar,Long> {
     @Query("SELECT c FROM OriginalCalendar c " +
             "WHERE c.isOfficial = true AND c.user.role = :role " +
             "AND c.user.id <> :userId " +
-            "AND c.startDate = :startDate " +
-            "AND c.endDate = :endDate " +
+            "AND c.startDate <= :endDate " +
+            "AND c.endDate >= :startDate " +
             "AND c.deletedAt IS NULL")
     List<Calendar> findAllOfficialCalendars(
             @Param("userId") Long userId,

--- a/src/main/java/kr/santanrudolph/everyvent/domain/calendar/CalendarService.java
+++ b/src/main/java/kr/santanrudolph/everyvent/domain/calendar/CalendarService.java
@@ -36,77 +36,56 @@ public class CalendarService {
     @Transactional
     public OriginalCalendarResponse createCalendar(Long userId, OriginalCalendarRequest request, ZoneId userZone) {
 
-        // 사용자 존재 및 탈퇴 여부 확인
         User user = getUserOrThrow(userId);
 
-        // 공식 캘린더 생성 권한 검증 (관리자만 생성 가능)
         boolean isOfficial = request.getIsOfficial() != null ? request.getIsOfficial() : false;
         validateOfficialCalendarPermission(isOfficial, user);
 
-        // 해당 년도와 월에 대해 사용자가 생성한 달력 수 확인 (월 최대 3개 제한)
+        // 한 달에 생성할 수 있는 캘린더 개수 제한 (최대 3개)
         validateMonthlyCalendarLimit(userId, request.getYear(), request.getMonth(), userZone);
 
-        // 캘린더 기간 계산 (사용자 시간대 기준)
+        // 사용자 시간대 기준으로 캘린더 기간 계산
         InstantRange range = InstantRange.of(request.getYear(), request.getMonth(), userZone);
 
-        // OriginalCalendar 엔티티 객체 생성
         OriginalCalendar calendar = buildCalendar(user, request, range, isOfficial, userZone);
-
-        // JPA Repository를 통해 엔티티를 DB에 저장
         calendarRepository.save(calendar);
 
-        // 응답 DTO 생성 및 반환 (사용자 시간대 반영)
         return OriginalCalendarResponse.from(calendar, calendar.isScrapable(), userZone);
     }
 
     @Transactional
     public OriginalCalendarResponse createOfficialCalendar(Long adminId, OriginalCalendarRequest request, ZoneId userZone) {
 
-        // 관리자 존재 및 탈퇴 여부 확인
         User admin = getUserOrThrow(adminId);
-
-        // 관리자 권한 확인
         validateAdminRole(admin);
 
-        // 캘린더 기간 계산 (사용자 시간대 기준)
         InstantRange range = InstantRange.of(request.getYear(), request.getMonth(), userZone);
-
-        // OriginalCalendar 엔티티 객체 생성
         OriginalCalendar calendar = buildCalendar(admin, request, range, true, userZone);
-
-        // JPA Repository를 통해 엔티티를 DB에 저장
         calendarRepository.save(calendar);
 
-        // 응답 DTO 생성 및 반환 (사용자 시간대 반영)
         return OriginalCalendarResponse.from(calendar, false, userZone);
     }
 
     public CalendarResponse getCalendar(Long calendarId, ZoneId userZone) {
 
-        // 캘린더 존재 및 삭제 여부 확인
         Calendar calendar = getActiveCalendarOrThrow(calendarId);
-
-        // 캘린더 타입에 따른 응답 DTO 생성 및 반환 (사용자 시간대 반영)
         return toCalendarResponse(calendar, calendar.isScrapable(), userZone);
     }
 
     public List<CalendarResponse> getMyCalendars(Long userId, int year, int month, ZoneId userZone) {
 
-        // 사용자 존재 및 탈퇴 여부 확인
         User user = getUserOrThrow(userId);
 
-        // 조회 범위 계산 (사용자 시간대 기준)
         InstantRange range = InstantRange.of(year, month, userZone);
         log.info("조회 범위: {} ~ {}", range.start(), range.end());
 
-        // 해당 년도와 월의 캘린더 조회
         List<Calendar> calendars = calendarRepository.findAllByUserIdInMonth(user.getId(), range.start(), range.end());
         if (user.getRole() == Role.ADMIN) {
+            // 관리자일 경우, 본인 캘린더 외에도 공식 캘린더를 함께 조회
             List<Calendar> officialCalendars = calendarRepository.findAllOfficialCalendars(user.getId(), range.start(), range.end(), Role.ADMIN);
             calendars.addAll(officialCalendars);
         }
 
-        // 캘린더 타입별 응답 DTO 생성 및 반환 (사용자 시간대 반영)
         return calendars.stream()
                 .map(c -> toCalendarResponse(c, c.isScrapable(), userZone))
                 .collect(Collectors.toList());
@@ -114,19 +93,15 @@ public class CalendarService {
 
     public List<CalendarResponse> getCalendars(Long userId, Long targetId, int year, int month, ZoneId userZone) {
 
-        // 사용자 존재 및 탈퇴 여부 확인
         User viewer = getUserOrThrow(userId);
         User targetUser = getUserOrThrow(targetId);
 
-        // 조회 범위 계산 (사용자 시간대 기준)
         InstantRange range = InstantRange.of(year, month, userZone);
 
-        // 해당 년도와 월의 캘린더 조회
         List<Calendar> calendars = calendarRepository.findAllByUserIdInMonth(
                 targetUser.getId(), range.start(), range.end()
         );
 
-        // 캘린더 타입별 응답 DTO 생성 및 반환 (사용자 시간대 반영)
         return calendars.stream()
                 .filter(c -> canView(c, viewer, targetUser))
                 .map(c -> {
@@ -139,23 +114,19 @@ public class CalendarService {
     @Transactional
     public CalendarResponse updateCalendar(Long userId, Long calendarId, OriginalCalendarRequest request, ZoneId userZone) {
 
-        // 캘린더 존재 및 삭제 여부 확인
         Calendar calendar = getActiveCalendarOrThrow(calendarId);
 
-        // 수정 권한 확인 (본인 캘린더 또는 같은 관리자가 만든 공식 캘린더만 수정 가능)
         User viewer = getUserOrThrow(userId);
         validateUpdateOrDeletePermission(calendar, viewer);
 
-        // 캘린더 기간 및 미리보기 기간 계산 (사용자 시간대 기준)
+        // 사용자 시간대 기준으로 캘린더 및 미리보기 기간 계산
         InstantRange range = InstantRange.of(request.getYear(), request.getMonth(), userZone);
         Instant previewStartDate = request.getPreviewStartDate() != null ? toStartOfDayOrNull(request.getPreviewStartDate(), userZone) : null;
         Instant previewEndDate = request.getPreviewEndDate() != null ? toEndOfDayOrNull(request.getPreviewEndDate(), userZone) : null;
 
-        // Enum 필드 안전 변환
         Visibility visibility = EnumUtil.parseEnum(Visibility.class, request.getVisibility());
         Category category  = EnumUtil.parseEnum(Category.class, request.getCategory());
 
-        // 캘린더 타입별 캘린더 수정 및 응답 DTO 반환 (사용자 시간대 반영)
         if (calendar instanceof OriginalCalendar oc) {
             updateOriginalCalendar(oc, request, range, visibility, category, previewStartDate, previewEndDate, viewer);
             return OriginalCalendarResponse.from(oc, oc.isScrapable(), userZone);
@@ -170,46 +141,34 @@ public class CalendarService {
     @Transactional
     public void deleteCalendar(Long userId, Long calendarId) {
 
-        // 캘린더 존재 및 삭제 여부 확인
         Calendar calendar = getActiveCalendarOrThrow(calendarId);
 
-        // 삭제 권한 확인
         User viewer = getUserOrThrow(userId);
         validateUpdateOrDeletePermission(calendar, viewer);
-
-        // Soft Delete 처리
         calendar.softDelete();
 
-        // JPA Repository를 통해 삭제 시점을 DB에 반영
         calendarRepository.save(calendar);
     }
 
     @Transactional
     public void distributeOfficialCalendar(Long adminId, Long calendarId, ZoneId userZone) {
 
-        // 관리자 존재 및 탈퇴 여부 확인
         User admin = getUserOrThrow(adminId);
 
-        // 관리자 권한 확인
         validateAdminRole(admin);
 
-        // 캘린더 존재 및 삭제 여부 확인
         Calendar calendar = getActiveCalendarOrThrow(calendarId);
 
-        // OriginalCalendar 타입인지 검증
         if (!(calendar instanceof OriginalCalendar originalCalendar)) {
             throw new EveryventException(ErrorCode.CALENDAR_TYPE_INVALID);
         }
 
-        // 관리자가 만든 공식 캘린더인지 검증
         if (!originalCalendar.isOfficial()) {
             throw new EveryventException(ErrorCode.CALENDAR_NOT_OFFICIAL);
         }
 
-        // 탈퇴하지 않은 일반 사용자 조회
+        // 탈퇴하지 않은 일반 사용자 중, 아직 해당 공식 캘린더 복제본을 가지지 않은 대상에게 배포
         List<User> users = userRepository.findAllByRoleAndDeletedAtIsNull(Role.USER);
-
-        // 이미 해당 공식 캘린더 복제본을 가진 사용자 조회
         List<Long> existingUserIds = calendarRepository.findUserIdsByOfficialId(originalCalendar.getId());
 
         List<OriginalCalendar> calendarsToSave = users.stream()
@@ -217,7 +176,6 @@ public class CalendarService {
                 .map(user -> createDistributedCalendar(user, originalCalendar))
                 .collect(Collectors.toList());
 
-        // 한번에 DB에 저장
         if (!calendarsToSave.isEmpty()) {
             calendarRepository.saveAll(calendarsToSave);
         }

--- a/src/main/java/kr/santanrudolph/everyvent/domain/calendar/CalendarService.java
+++ b/src/main/java/kr/santanrudolph/everyvent/domain/calendar/CalendarService.java
@@ -1,0 +1,387 @@
+package kr.santanrudolph.everyvent.domain.calendar;
+
+import kr.santanrudolph.everyvent.domain.calendar.dto.request.OriginalCalendarRequest;
+import kr.santanrudolph.everyvent.domain.calendar.dto.response.CalendarResponse;
+import kr.santanrudolph.everyvent.domain.calendar.dto.response.OriginalCalendarResponse;
+import kr.santanrudolph.everyvent.domain.user.Role;
+import kr.santanrudolph.everyvent.domain.user.User;
+import kr.santanrudolph.everyvent.domain.user.UserRepository;
+import kr.santanrudolph.everyvent.global.exception.ErrorCode;
+import kr.santanrudolph.everyvent.global.exception.EveryventException;
+import kr.santanrudolph.everyvent.global.util.EnumUtil;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.time.ZoneId;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class CalendarService {
+
+    private static final int CALENDAR_START_DAY = 1;
+    private static final int CALENDAR_END_DAY = 25;
+
+    private final CalendarRepository calendarRepository;
+    private final UserRepository userRepository;
+
+    @Transactional
+    public OriginalCalendarResponse createCalendar(Long userId, OriginalCalendarRequest request, ZoneId userZone) {
+
+        // 사용자 존재 및 탈퇴 여부 확인
+        User user = getUserOrThrow(userId);
+
+        // 공식 캘린더 생성 권한 검증 (관리자만 생성 가능)
+        boolean isOfficial = request.getIsOfficial() != null ? request.getIsOfficial() : false;
+        validateOfficialCalendarPermission(isOfficial, user);
+
+        // 해당 년도와 월에 대해 사용자가 생성한 달력 수 확인 (월 최대 3개 제한)
+        validateMonthlyCalendarLimit(userId, request.getYear(), request.getMonth(), userZone);
+
+        // 캘린더 기간 계산 (사용자 시간대 기준)
+        InstantRange range = InstantRange.of(request.getYear(), request.getMonth(), userZone);
+
+        // OriginalCalendar 엔티티 객체 생성
+        OriginalCalendar calendar = buildCalendar(user, request, range, isOfficial, userZone);
+
+        // JPA Repository를 통해 엔티티를 DB에 저장
+        calendarRepository.save(calendar);
+
+        // 응답 DTO 생성 및 반환 (사용자 시간대 반영)
+        return OriginalCalendarResponse.from(calendar, calendar.isScrapable(), userZone);
+    }
+
+    @Transactional
+    public OriginalCalendarResponse createOfficialCalendar(Long adminId, OriginalCalendarRequest request, ZoneId userZone) {
+
+        // 관리자 존재 및 탈퇴 여부 확인
+        User admin = getUserOrThrow(adminId);
+
+        // 관리자 권한 확인
+        validateAdminRole(admin);
+
+        // 캘린더 기간 계산 (사용자 시간대 기준)
+        InstantRange range = InstantRange.of(request.getYear(), request.getMonth(), userZone);
+
+        // OriginalCalendar 엔티티 객체 생성
+        OriginalCalendar calendar = buildCalendar(admin, request, range, true, userZone);
+
+        // JPA Repository를 통해 엔티티를 DB에 저장
+        calendarRepository.save(calendar);
+
+        // 응답 DTO 생성 및 반환 (사용자 시간대 반영)
+        return OriginalCalendarResponse.from(calendar, false, userZone);
+    }
+
+    public CalendarResponse getCalendar(Long calendarId, ZoneId userZone) {
+
+        // 캘린더 존재 및 삭제 여부 확인
+        Calendar calendar = getActiveCalendarOrThrow(calendarId);
+
+        // 캘린더 타입에 따른 응답 DTO 생성 및 반환 (사용자 시간대 반영)
+        return toCalendarResponse(calendar, calendar.isScrapable(), userZone);
+    }
+
+    public List<CalendarResponse> getMyCalendars(Long userId, int year, int month, ZoneId userZone) {
+
+        // 사용자 존재 및 탈퇴 여부 확인
+        User user = getUserOrThrow(userId);
+
+        // 조회 범위 계산 (사용자 시간대 기준)
+        InstantRange range = InstantRange.of(year, month, userZone);
+        log.info("조회 범위: {} ~ {}", range.start(), range.end());
+
+        // 해당 년도와 월의 캘린더 조회
+        List<Calendar> calendars = calendarRepository.findAllByUserIdInMonth(user.getId(), range.start(), range.end());
+        if (user.getRole() == Role.ADMIN) {
+            List<Calendar> officialCalendars = calendarRepository.findAllOfficialCalendars(user.getId(), range.start(), range.end(), Role.ADMIN);
+            calendars.addAll(officialCalendars);
+        }
+
+        // 캘린더 타입별 응답 DTO 생성 및 반환 (사용자 시간대 반영)
+        return calendars.stream()
+                .map(c -> toCalendarResponse(c, c.isScrapable(), userZone))
+                .collect(Collectors.toList());
+    }
+
+    public List<CalendarResponse> getCalendars(Long userId, Long targetId, int year, int month, ZoneId userZone) {
+
+        // 사용자 존재 및 탈퇴 여부 확인
+        User viewer = getUserOrThrow(userId);
+        User targetUser = getUserOrThrow(targetId);
+
+        // 조회 범위 계산 (사용자 시간대 기준)
+        InstantRange range = InstantRange.of(year, month, userZone);
+
+        // 해당 년도와 월의 캘린더 조회
+        List<Calendar> calendars = calendarRepository.findAllByUserIdInMonth(
+                targetUser.getId(), range.start(), range.end()
+        );
+
+        // 캘린더 타입별 응답 DTO 생성 및 반환 (사용자 시간대 반영)
+        return calendars.stream()
+                .filter(c -> canView(c, viewer, targetUser))
+                .map(c -> {
+                    boolean isScrapable = c.isScrapable() && !c.getUser().getId().equals(viewer.getId());
+                    return toCalendarResponse(c, isScrapable, userZone);
+                })
+                .collect(Collectors.toList());
+    }
+
+    @Transactional
+    public CalendarResponse updateCalendar(Long userId, Long calendarId, OriginalCalendarRequest request, ZoneId userZone) {
+
+        // 캘린더 존재 및 삭제 여부 확인
+        Calendar calendar = getActiveCalendarOrThrow(calendarId);
+
+        // 수정 권한 확인 (본인 캘린더 또는 같은 관리자가 만든 공식 캘린더만 수정 가능)
+        User viewer = getUserOrThrow(userId);
+        validateUpdateOrDeletePermission(calendar, viewer);
+
+        // 캘린더 기간 및 미리보기 기간 계산 (사용자 시간대 기준)
+        InstantRange range = InstantRange.of(request.getYear(), request.getMonth(), userZone);
+        Instant previewStartDate = request.getPreviewStartDate() != null ? toStartOfDayOrNull(request.getPreviewStartDate(), userZone) : null;
+        Instant previewEndDate = request.getPreviewEndDate() != null ? toEndOfDayOrNull(request.getPreviewEndDate(), userZone) : null;
+
+        // Enum 필드 안전 변환
+        Visibility visibility = EnumUtil.parseEnum(Visibility.class, request.getVisibility());
+        Category category  = EnumUtil.parseEnum(Category.class, request.getCategory());
+
+        // 캘린더 타입별 캘린더 수정 및 응답 DTO 반환 (사용자 시간대 반영)
+        if (calendar instanceof OriginalCalendar oc) {
+            updateOriginalCalendar(oc, request, range, visibility, category, previewStartDate, previewEndDate, viewer);
+            return OriginalCalendarResponse.from(oc, oc.isScrapable(), userZone);
+        }
+
+        // TODO: 추후 ScrapCalendar 구현 시 추가
+        // else if (calendar instanceof ScrapCalendar sc) { ... }
+
+        throw new EveryventException(ErrorCode.INVALID_TYPE_VALUE);
+    }
+
+    @Transactional
+    public void deleteCalendar(Long userId, Long calendarId) {
+
+        // 캘린더 존재 및 삭제 여부 확인
+        Calendar calendar = getActiveCalendarOrThrow(calendarId);
+
+        // 삭제 권한 확인
+        User viewer = getUserOrThrow(userId);
+        validateUpdateOrDeletePermission(calendar, viewer);
+
+        // Soft Delete 처리
+        calendar.softDelete();
+
+        // JPA Repository를 통해 삭제 시점을 DB에 반영
+        calendarRepository.save(calendar);
+    }
+
+    @Transactional
+    public void distributeOfficialCalendar(Long adminId, Long calendarId, ZoneId userZone) {
+
+        // 관리자 존재 및 탈퇴 여부 확인
+        User admin = getUserOrThrow(adminId);
+
+        // 관리자 권한 확인
+        validateAdminRole(admin);
+
+        // 캘린더 존재 및 삭제 여부 확인
+        Calendar calendar = getActiveCalendarOrThrow(calendarId);
+
+        // OriginalCalendar 타입인지 검증
+        if (!(calendar instanceof OriginalCalendar originalCalendar)) {
+            throw new EveryventException(ErrorCode.CALENDAR_TYPE_INVALID);
+        }
+
+        // 관리자가 만든 공식 캘린더인지 검증
+        if (!originalCalendar.isOfficial()) {
+            throw new EveryventException(ErrorCode.CALENDAR_NOT_OFFICIAL);
+        }
+
+        // 탈퇴하지 않은 일반 사용자 조회
+        List<User> users = userRepository.findAllByRoleAndDeletedAtIsNull(Role.USER);
+
+        // 이미 해당 공식 캘린더 복제본을 가진 사용자 조회
+        List<Long> existingUserIds = calendarRepository.findUserIdsByOfficialId(originalCalendar.getId());
+
+        List<OriginalCalendar> calendarsToSave = users.stream()
+                .filter(user -> !existingUserIds.contains(user.getId()))
+                .map(user -> createDistributedCalendar(user, originalCalendar))
+                .collect(Collectors.toList());
+
+        // 한번에 DB에 저장
+        if (!calendarsToSave.isEmpty()) {
+            calendarRepository.saveAll(calendarsToSave);
+        }
+    }
+
+    // ==================== Private Helper Methods ====================
+
+    private User getUserOrThrow(Long userId) {
+        return userRepository.findByIdAndDeletedAtIsNull(userId)
+                .orElseThrow(() -> new EveryventException(ErrorCode.USER_NOT_FOUND));
+    }
+
+    private void validateAdminRole(User user) {
+        if (user.getRole() != Role.ADMIN) {
+            throw new EveryventException(ErrorCode.ACCESS_DENIED);
+        }
+    }
+
+    private Calendar getActiveCalendarOrThrow(Long calendarId) {
+        Calendar calendar = calendarRepository.findById(calendarId)
+                .orElseThrow(() -> new EveryventException(ErrorCode.CALENDAR_NOT_FOUND));
+
+        if (calendar.getDeletedAt() != null) {
+            throw new EveryventException(ErrorCode.CALENDAR_ALREADY_DELETED);
+        }
+
+        return calendar;
+    }
+
+    private void validateOfficialCalendarPermission(Boolean isOfficial, User user) {
+        if (Boolean.TRUE.equals(isOfficial) && user.getRole() != Role.ADMIN) {
+            throw new EveryventException(ErrorCode.ACCESS_DENIED);
+        }
+    }
+
+    private void validateMonthlyCalendarLimit(Long userId, int year, int month, ZoneId userZone) {
+        InstantRange range = InstantRange.of(year, month, userZone);
+        long userMonthlyCalendarCount = calendarRepository.countByUserIdInMonth(userId, range.start(), range.end());
+
+        if (userMonthlyCalendarCount >= 3) {
+            throw new EveryventException(ErrorCode.MAX_CALENDAR_EXCEEDED);
+        }
+    }
+
+    private void validateUpdateOrDeletePermission(Calendar calendar, User viewer) {
+        boolean isOwner = calendar.getUser().getId().equals(viewer.getId());
+        boolean isAdminEditingOfficial = viewer.getRole() == Role.ADMIN
+                && calendar instanceof OriginalCalendar oc
+                && oc.isOfficial();
+
+        if (!isOwner && !isAdminEditingOfficial) {
+            throw new EveryventException(ErrorCode.CALENDAR_ACCESS_DENIED);
+        }
+    }
+
+    private CalendarResponse toCalendarResponse(Calendar calendar, boolean isScrapable, ZoneId userZone) {
+        if (calendar instanceof OriginalCalendar oc) {
+            return OriginalCalendarResponse.from(oc, isScrapable, userZone);
+        }
+        // TODO: 추후 ScrapCalendar 구현 시 추가
+        throw new EveryventException(ErrorCode.INVALID_TYPE_VALUE);
+    }
+
+    private void updateOriginalCalendar(OriginalCalendar oc, OriginalCalendarRequest request,
+                                        InstantRange range, Visibility visibility, Category category,
+                                        Instant previewStartDate, Instant previewEndDate, User viewer) {
+        oc.ensureOfficialEditableByUser();
+        oc.updateDetails(request.getTitle(), request.getDescription(), range.start(), range.end(), category);
+        oc.changeColor(request.getColor());
+        oc.changeVisibility(visibility);
+        oc.setPreviewPeriod(previewStartDate, previewEndDate);
+
+        boolean isOfficial = request.getIsOfficial() != null ? request.getIsOfficial() : false;
+        if (viewer.getRole() == Role.ADMIN) {
+            oc.changeOfficialStatus(isOfficial);
+        }
+    }
+
+    private OriginalCalendar createDistributedCalendar(User user, OriginalCalendar calendar) {
+
+        OriginalCalendar userCalendar = OriginalCalendar.builder()
+                .user(user)
+                .title(calendar.getTitle())
+                .description(calendar.getDescription())
+                .startDate(calendar.getStartDate())
+                .endDate(calendar.getEndDate())
+                .visibility(calendar.getVisibility())
+                .color(calendar.getColor())
+                .category(calendar.getCategory())
+                .isOfficial(false)
+                .build();
+
+        if (calendar.getPreviewStartDate() != null && calendar.getPreviewEndDate() != null) {
+            userCalendar.setPreviewPeriod(calendar.getPreviewStartDate(), calendar.getPreviewEndDate());
+        }
+        userCalendar.enterOfficialId(calendar.getId());
+
+        return userCalendar;
+    }
+
+    private OriginalCalendar buildCalendar(User user, OriginalCalendarRequest request, InstantRange range,
+                                           boolean isOfficial, ZoneId userZone) {
+
+        Visibility visibility = EnumUtil.parseEnum(Visibility.class, request.getVisibility());
+        Category category  = EnumUtil.parseEnum(Category.class, request.getCategory());
+
+        Instant previewStartDate = request.getPreviewStartDate() != null ? toStartOfDayOrNull(request.getPreviewStartDate(), userZone) : null;
+        Instant previewEndDate = request.getPreviewEndDate() != null ? toEndOfDayOrNull(request.getPreviewEndDate(), userZone) : null;
+
+        OriginalCalendar calendar = OriginalCalendar.builder()
+                .user(user)
+                .title(request.getTitle())
+                .description(request.getDescription())
+                .startDate(range.start())
+                .endDate(range.end())
+                .visibility(visibility)
+                .color(request.getColor())
+                .category(category)
+                .isOfficial(isOfficial)
+                .build();
+
+        calendar.setPreviewPeriod(previewStartDate, previewEndDate);
+
+        return calendar;
+    }
+
+    private static Instant toStartOfDayOrNull(LocalDate date, ZoneId userZone) {
+        return date != null ? date.atStartOfDay(userZone).toInstant() : null;
+    }
+
+    private static Instant toEndOfDayOrNull(LocalDate date, ZoneId userZone) {
+        return date != null ? date.atTime(LocalTime.MAX).atZone(userZone).toInstant() : null;
+    }
+
+    private static class InstantRange {
+        private final Instant start;
+        private final Instant end;
+
+        private InstantRange(Instant start, Instant end) {
+            this.start = start;
+            this.end = end;
+        }
+
+        public static InstantRange of(int year, int month, ZoneId userZone) {
+            LocalDate startLocal = LocalDate.of(year, month, CALENDAR_START_DAY);
+            LocalDate endLocal = LocalDate.of(year, month, CALENDAR_END_DAY);
+            return new InstantRange(
+                    toStartOfDayOrNull(startLocal, userZone),
+                    toStartOfDayOrNull(endLocal.plusDays(1), userZone)
+            );
+        }
+
+        public Instant start() { return start; }
+        public Instant end() { return end; }
+    }
+
+    private boolean canView(Calendar calendar, User viewer, User targetUser) {
+        return switch (calendar.getVisibility()) {
+            case PUBLIC -> true;
+            case PRIVATE -> viewer.getId().equals(targetUser.getId());
+            // TODO: 추후 Follower 구현 시 추가
+            // case MUTUAL -> {...}
+            // case FOLLOWER -> {...}
+            default -> false;
+        };
+    }
+}

--- a/src/main/java/kr/santanrudolph/everyvent/domain/calendar/Category.java
+++ b/src/main/java/kr/santanrudolph/everyvent/domain/calendar/Category.java
@@ -1,0 +1,10 @@
+package kr.santanrudolph.everyvent.domain.calendar;
+
+public enum Category {
+    SELF_DEVELOPMENT,  // 자기계발
+    ROUTINE,           // 루틴·습관
+    HOBBY,             // 취미·창작
+    CHALLENGE,         // 챌린지
+    MEMORY,            // 추억·기록
+    ETC                // 기타
+}

--- a/src/main/java/kr/santanrudolph/everyvent/domain/calendar/OriginalCalendar.java
+++ b/src/main/java/kr/santanrudolph/everyvent/domain/calendar/OriginalCalendar.java
@@ -84,7 +84,7 @@ public class OriginalCalendar extends Calendar {
     // === 검증 관련 메서드 ===
     private void validateWithinCalendarPeriod(Instant start, Instant end) {
         if (start.isBefore(getStartDate()) || end.isAfter(getEndDate())) {
-            throw new IllegalArgumentException("미리보기 기간은 캘린더 기간 내에 있어야 합니다");
+            throw new EveryventException(ErrorCode.PREVIEW_PERIOD_OUT_OF_CALENDAR);
         }
     }
 

--- a/src/main/java/kr/santanrudolph/everyvent/domain/calendar/OriginalCalendar.java
+++ b/src/main/java/kr/santanrudolph/everyvent/domain/calendar/OriginalCalendar.java
@@ -1,7 +1,10 @@
 package kr.santanrudolph.everyvent.domain.calendar;
 
 import jakarta.persistence.*;
+import kr.santanrudolph.everyvent.domain.user.Role;
 import kr.santanrudolph.everyvent.domain.user.User;
+import kr.santanrudolph.everyvent.global.exception.ErrorCode;
+import kr.santanrudolph.everyvent.global.exception.EveryventException;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -82,6 +85,12 @@ public class OriginalCalendar extends Calendar {
     private void validateWithinCalendarPeriod(Instant start, Instant end) {
         if (start.isBefore(getStartDate()) || end.isAfter(getEndDate())) {
             throw new IllegalArgumentException("미리보기 기간은 캘린더 기간 내에 있어야 합니다");
+        }
+    }
+
+    public void ensureOfficialEditableByUser() {
+        if (this.isOfficial() && this.getUser().getRole() == Role.USER) {
+            throw new EveryventException(ErrorCode.OFFICIAL_CALENDAR_CANNOT_MODIFY);
         }
     }
 }

--- a/src/main/java/kr/santanrudolph/everyvent/domain/calendar/OriginalCalendar.java
+++ b/src/main/java/kr/santanrudolph/everyvent/domain/calendar/OriginalCalendar.java
@@ -1,0 +1,94 @@
+package kr.santanrudolph.everyvent.domain.calendar;
+
+import jakarta.persistence.*;
+import kr.santanrudolph.everyvent.domain.user.User;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.Instant;
+
+@Entity
+@DiscriminatorValue("ORIGINAL")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class OriginalCalendar extends Calendar {
+
+    private Instant previewStartDate; // 공개할 task 시작일
+    private Instant previewEndDate; // 공개할 task 종료일
+
+    @Column(nullable = false)
+    private boolean isOfficial; // 공식 캘린더 여부
+
+    @Builder
+    public OriginalCalendar(User user, String title, String description, Instant startDate, Instant endDate, Visibility visibility, String color, Category category,
+                            Instant previewStartDate, Instant previewEndDate, boolean isOfficial) {
+        super(user, title, description, startDate, endDate, visibility, color, category);
+        this.previewStartDate = previewStartDate;
+        this.previewEndDate = previewEndDate;
+        this.isOfficial = isOfficial;
+    }
+
+    @Override
+    public boolean isScrapable() {
+        return !isOfficial && getVisibility() != Visibility.PRIVATE;
+    }
+
+    // === 공식 캘린더 관련 메서드 ===
+    public void changeOfficialStatus(boolean isOfficial) {
+        this.isOfficial = isOfficial;
+        if (isOfficial) {
+            clearPreviewPeriod();
+        }
+    }
+
+    // === 미리보기 관련 메서드 ===
+    public void setPreviewPeriod(Instant previewStartDate, Instant previewEndDate) {
+        validatePreviewPeriod(previewStartDate, previewEndDate);
+        this.previewStartDate = previewStartDate;
+        this.previewEndDate = previewEndDate;
+    }
+
+    public boolean hasPreviewPeriod() {
+        return previewStartDate != null && previewEndDate != null;
+    }
+
+    public void clearPreviewPeriod() {
+        this.previewStartDate = null;
+        this.previewEndDate = null;
+    }
+
+    public boolean isTaskPreviewable(Instant taskDate) {
+        if (!hasPreviewPeriod()) {
+            return false;
+        }
+        return !taskDate.isBefore(previewStartDate) && !taskDate.isAfter(previewEndDate);
+    }
+
+    // === 검증 관련 메서드 ===
+    private void validatePreviewPeriod(Instant previewStartDate, Instant previewEndDate) {
+        validateNotOfficial();
+        validateNotPrivate();
+        validateDateRange(previewStartDate, previewEndDate);
+        validateWithinCalendarPeriod(previewStartDate, previewEndDate);
+    }
+
+    private void validateNotOfficial() {
+        if (isOfficial) {
+            throw new IllegalStateException("공식 캘린더는 미리보기를 설정할 수 없습니다");
+        }
+    }
+
+    private void validateNotPrivate() {
+        if (getVisibility() == Visibility.PRIVATE) {
+            throw new IllegalStateException("비공개 캘린더는 미리보기를 설정할 수 없습니다");
+        }
+    }
+
+    private void validateWithinCalendarPeriod(Instant start, Instant end) {
+        if (start.isBefore(getStartDate()) || end.isAfter(getEndDate())) {
+            throw new IllegalArgumentException("미리보기 기간은 캘린더 기간 내에 있어야 합니다");
+        }
+    }
+}

--- a/src/main/java/kr/santanrudolph/everyvent/domain/calendar/OriginalCalendar.java
+++ b/src/main/java/kr/santanrudolph/everyvent/domain/calendar/OriginalCalendar.java
@@ -30,8 +30,7 @@ public class OriginalCalendar extends Calendar {
     public OriginalCalendar(User user, String title, String description, Instant startDate, Instant endDate, Visibility visibility, String color, Category category,
                             Instant previewStartDate, Instant previewEndDate, boolean isOfficial, Long officialId) {
         super(user, title, description, startDate, endDate, visibility, color, category);
-        this.previewStartDate = previewStartDate;
-        this.previewEndDate = previewEndDate;
+        setPreviewPeriod(previewStartDate, previewEndDate);
         this.isOfficial = isOfficial;
         this.officialId = officialId;
     }

--- a/src/main/java/kr/santanrudolph/everyvent/domain/calendar/OriginalCalendar.java
+++ b/src/main/java/kr/santanrudolph/everyvent/domain/calendar/OriginalCalendar.java
@@ -59,8 +59,9 @@ public class OriginalCalendar extends Calendar {
 
     // === 미리보기 관련 메서드 ===
     public void setPreviewPeriod(Instant previewStartDate, Instant previewEndDate) {
-        if (isOfficial || getVisibility() == Visibility.PRIVATE) {
-            updatePreviewAvailability();
+        if (previewStartDate == null || previewEndDate == null) {
+            this.previewStartDate = null;
+            this.previewEndDate = null;
             return;
         }
         validateDateRange(previewStartDate, previewEndDate);

--- a/src/main/java/kr/santanrudolph/everyvent/domain/calendar/OriginalCalendar.java
+++ b/src/main/java/kr/santanrudolph/everyvent/domain/calendar/OriginalCalendar.java
@@ -35,17 +35,27 @@ public class OriginalCalendar extends Calendar {
         return !isOfficial && getVisibility() != Visibility.PRIVATE;
     }
 
+    @Override
+    public void changeVisibility(Visibility newVisibility) {
+        super.changeVisibility(newVisibility);
+        updatePreviewAvailability();
+    }
+
     // === 공식 캘린더 관련 메서드 ===
     public void changeOfficialStatus(boolean isOfficial) {
         this.isOfficial = isOfficial;
-        if (isOfficial) {
-            clearPreviewPeriod();
-        }
+        updatePreviewAvailability();
     }
 
     // === 미리보기 관련 메서드 ===
     public void setPreviewPeriod(Instant previewStartDate, Instant previewEndDate) {
-        validatePreviewPeriod(previewStartDate, previewEndDate);
+        if (isOfficial || getVisibility() == Visibility.PRIVATE) {
+            updatePreviewAvailability();
+            return;
+        }
+        validateDateRange(previewStartDate, previewEndDate);
+        validateWithinCalendarPeriod(previewStartDate, previewEndDate);
+
         this.previewStartDate = previewStartDate;
         this.previewEndDate = previewEndDate;
     }
@@ -54,9 +64,11 @@ public class OriginalCalendar extends Calendar {
         return previewStartDate != null && previewEndDate != null;
     }
 
-    public void clearPreviewPeriod() {
-        this.previewStartDate = null;
-        this.previewEndDate = null;
+    public void updatePreviewAvailability() {
+        if (isOfficial || getVisibility() == Visibility.PRIVATE) {
+            this.previewStartDate = null;
+            this.previewEndDate = null;
+        }
     }
 
     public boolean isTaskPreviewable(Instant taskDate) {
@@ -67,25 +79,6 @@ public class OriginalCalendar extends Calendar {
     }
 
     // === 검증 관련 메서드 ===
-    private void validatePreviewPeriod(Instant previewStartDate, Instant previewEndDate) {
-        validateNotOfficial();
-        validateNotPrivate();
-        validateDateRange(previewStartDate, previewEndDate);
-        validateWithinCalendarPeriod(previewStartDate, previewEndDate);
-    }
-
-    private void validateNotOfficial() {
-        if (isOfficial) {
-            throw new IllegalStateException("공식 캘린더는 미리보기를 설정할 수 없습니다");
-        }
-    }
-
-    private void validateNotPrivate() {
-        if (getVisibility() == Visibility.PRIVATE) {
-            throw new IllegalStateException("비공개 캘린더는 미리보기를 설정할 수 없습니다");
-        }
-    }
-
     private void validateWithinCalendarPeriod(Instant start, Instant end) {
         if (start.isBefore(getStartDate()) || end.isAfter(getEndDate())) {
             throw new IllegalArgumentException("미리보기 기간은 캘린더 기간 내에 있어야 합니다");

--- a/src/main/java/kr/santanrudolph/everyvent/domain/calendar/OriginalCalendar.java
+++ b/src/main/java/kr/santanrudolph/everyvent/domain/calendar/OriginalCalendar.java
@@ -24,13 +24,16 @@ public class OriginalCalendar extends Calendar {
     @Column(nullable = false)
     private boolean isOfficial; // 공식 캘린더 여부
 
+    private Long officialId; // 복제된 공식 캘린더의 원본 id
+
     @Builder
     public OriginalCalendar(User user, String title, String description, Instant startDate, Instant endDate, Visibility visibility, String color, Category category,
-                            Instant previewStartDate, Instant previewEndDate, boolean isOfficial) {
+                            Instant previewStartDate, Instant previewEndDate, boolean isOfficial, Long officialId) {
         super(user, title, description, startDate, endDate, visibility, color, category);
         this.previewStartDate = previewStartDate;
         this.previewEndDate = previewEndDate;
         this.isOfficial = isOfficial;
+        this.officialId = officialId;
     }
 
     @Override
@@ -48,6 +51,10 @@ public class OriginalCalendar extends Calendar {
     public void changeOfficialStatus(boolean isOfficial) {
         this.isOfficial = isOfficial;
         updatePreviewAvailability();
+    }
+
+    public void enterOfficialId(Long officialId) {
+        this.officialId = officialId;
     }
 
     // === 미리보기 관련 메서드 ===
@@ -89,7 +96,7 @@ public class OriginalCalendar extends Calendar {
     }
 
     public void ensureOfficialEditableByUser() {
-        if (this.isOfficial() && this.getUser().getRole() == Role.USER) {
+        if (this.officialId != null && this.getUser().getRole() == Role.USER) {
             throw new EveryventException(ErrorCode.OFFICIAL_CALENDAR_CANNOT_MODIFY);
         }
     }

--- a/src/main/java/kr/santanrudolph/everyvent/domain/calendar/Visibility.java
+++ b/src/main/java/kr/santanrudolph/everyvent/domain/calendar/Visibility.java
@@ -1,0 +1,8 @@
+package kr.santanrudolph.everyvent.domain.calendar;
+
+public enum Visibility {
+    PUBLIC,     // 전체 공개
+    FOLLOWER,   // 팔로워 공개
+    MUTUAL,     // 맞팔(서로 팔로우) 공개
+    PRIVATE     // 비공개
+}

--- a/src/main/java/kr/santanrudolph/everyvent/domain/calendar/dto/request/CalendarRequest.java
+++ b/src/main/java/kr/santanrudolph/everyvent/domain/calendar/dto/request/CalendarRequest.java
@@ -1,0 +1,31 @@
+package kr.santanrudolph.everyvent.domain.calendar.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class CalendarRequest {
+
+    @NotBlank
+    private String title;
+
+    private String description;
+
+    @NotNull
+    private Integer year;
+
+    @NotNull
+    private Integer month;
+
+    @NotBlank
+    private String visibility;
+
+    @NotBlank
+    private String color;
+
+    @NotBlank
+    private String category;
+}

--- a/src/main/java/kr/santanrudolph/everyvent/domain/calendar/dto/request/OriginalCalendarRequest.java
+++ b/src/main/java/kr/santanrudolph/everyvent/domain/calendar/dto/request/OriginalCalendarRequest.java
@@ -1,0 +1,17 @@
+package kr.santanrudolph.everyvent.domain.calendar.dto.request;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Getter
+@NoArgsConstructor
+public class OriginalCalendarRequest extends CalendarRequest {
+
+    private LocalDate previewStartDate;
+
+    private LocalDate previewEndDate;
+
+    private Boolean isOfficial;
+}

--- a/src/main/java/kr/santanrudolph/everyvent/domain/calendar/dto/response/CalendarResponse.java
+++ b/src/main/java/kr/santanrudolph/everyvent/domain/calendar/dto/response/CalendarResponse.java
@@ -1,0 +1,27 @@
+package kr.santanrudolph.everyvent.domain.calendar.dto.response;
+
+import lombok.Getter;
+import lombok.experimental.SuperBuilder;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneId;
+
+@Getter
+@SuperBuilder
+public abstract class CalendarResponse {
+
+    private Long id;
+    private String title;
+    private String description;
+    private LocalDate startDate;
+    private LocalDate endDate;
+    private String visibility;
+    private String color;
+    private String category;
+    private Boolean isScrapable;
+
+    protected static LocalDate toLocalDate(Instant instant, ZoneId userZone) {
+        return instant != null ? instant.atZone(userZone).toLocalDate() : null;
+    }
+}

--- a/src/main/java/kr/santanrudolph/everyvent/domain/calendar/dto/response/OriginalCalendarResponse.java
+++ b/src/main/java/kr/santanrudolph/everyvent/domain/calendar/dto/response/OriginalCalendarResponse.java
@@ -1,0 +1,38 @@
+package kr.santanrudolph.everyvent.domain.calendar.dto.response;
+
+import kr.santanrudolph.everyvent.domain.calendar.OriginalCalendar;
+import lombok.Getter;
+import lombok.experimental.SuperBuilder;
+
+import java.time.LocalDate;
+import java.time.ZoneId;
+
+@Getter
+@SuperBuilder
+public class OriginalCalendarResponse extends CalendarResponse {
+
+    private LocalDate previewStartDate;
+    private LocalDate previewEndDate;
+    private Boolean isOfficial;
+    private Long officialId;
+
+    public static OriginalCalendarResponse from(OriginalCalendar calendar, boolean isScrapable, ZoneId userZone) {
+        return OriginalCalendarResponse.builder()
+                .id(calendar.getId())
+                .title(calendar.getTitle())
+                .description(calendar.getDescription() != null ? calendar.getDescription() : "")
+                .startDate(toLocalDate(calendar.getStartDate(), userZone))
+                .endDate(toLocalDate(calendar.getEndDate(), userZone))
+                .visibility(calendar.getVisibility().name())
+                .color(calendar.getColor())
+                .category(calendar.getCategory().name())
+                .isScrapable(isScrapable)
+                .previewStartDate(calendar.getPreviewStartDate() != null
+                        ? toLocalDate(calendar.getPreviewStartDate(), userZone) : null)
+                .previewEndDate(calendar.getPreviewEndDate() != null
+                        ? toLocalDate(calendar.getPreviewEndDate(), userZone) : null)
+                .isOfficial(calendar.isOfficial())
+                .officialId(calendar.getOfficialId())
+                .build();
+    }
+}

--- a/src/main/java/kr/santanrudolph/everyvent/domain/user/UserRepository.java
+++ b/src/main/java/kr/santanrudolph/everyvent/domain/user/UserRepository.java
@@ -3,6 +3,7 @@ package kr.santanrudolph.everyvent.domain.user;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -18,4 +19,5 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
   Optional<User> findByEmail(String email);
 
+  List<User> findAllByRoleAndDeletedAtIsNull(Role role);
 }

--- a/src/main/java/kr/santanrudolph/everyvent/global/exception/ErrorCode.java
+++ b/src/main/java/kr/santanrudolph/everyvent/global/exception/ErrorCode.java
@@ -12,6 +12,7 @@ public enum ErrorCode {
   INTERNAL_SERVER_ERROR("서버 내부 오류가 발생했습니다."),
   INVALID_TYPE_VALUE("잘못된 타입입니다."),
   HANDLE_ACCESS_DENIED("접근이 거부되었습니다."),
+  REQUIRED_FIELD("은(는) 필수값입니다."),
 
   // 인증/인가 에러
   UNAUTHORIZED("인증이 필요합니다."),
@@ -33,6 +34,8 @@ public enum ErrorCode {
   CALENDAR_ALREADY_DELETED("이미 삭제된 캘린더입니다."),
   INVALID_CALENDAR_PERIOD("잘못된 캘린더 기간입니다."),
   OFFICIAL_CALENDAR_CANNOT_MODIFY("공식 캘린더는 수정할 수 없습니다."),
+  INVALID_COLOR("유효한 HEX 색상 코드여야 합니다."),
+  INVALID_DATE_RANGE("시작일은 종료일보다 이전이어야 합니다."),
 
   // 태스크 에러
   TASK_NOT_FOUND("태스크를 찾을 수 없습니다."),
@@ -41,6 +44,7 @@ public enum ErrorCode {
   INVALID_TASK_DATE("유효하지 않은 태스크 날짜입니다. (1-25일)"),
   TASK_ALREADY_COMPLETED("이미 완료된 태스크입니다."),
   TASK_ACCESS_DENIED("태스크에 접근할 권한이 없습니다."),
+  PREVIEW_PERIOD_OUT_OF_CALENDAR("미리보기 기간은 캘린더 기간 내에 있어야 합니다"),
 
   // 스크랩 에러
   SCRAP_NOT_FOUND("스크랩을 찾을 수 없습니다."),

--- a/src/main/java/kr/santanrudolph/everyvent/global/exception/ErrorCode.java
+++ b/src/main/java/kr/santanrudolph/everyvent/global/exception/ErrorCode.java
@@ -36,6 +36,8 @@ public enum ErrorCode {
   OFFICIAL_CALENDAR_CANNOT_MODIFY("공식 캘린더는 수정할 수 없습니다."),
   INVALID_COLOR("유효한 HEX 색상 코드여야 합니다."),
   INVALID_DATE_RANGE("시작일은 종료일보다 이전이어야 합니다."),
+  CALENDAR_NOT_OFFICIAL("관리자가 만든 공식 캘린더가 아닙니다."),
+  CALENDAR_TYPE_INVALID("잘못된 캘린더 유형입니다."),
 
   // 태스크 에러
   TASK_NOT_FOUND("태스크를 찾을 수 없습니다."),

--- a/src/main/java/kr/santanrudolph/everyvent/global/exception/EveryventException.java
+++ b/src/main/java/kr/santanrudolph/everyvent/global/exception/EveryventException.java
@@ -12,4 +12,9 @@ public class EveryventException extends RuntimeException {
     this.errorCode = errorCode;
   }
 
+  public EveryventException(ErrorCode errorCode, String fieldName) {
+    super(fieldName + errorCode.getMessage());
+    this.errorCode = errorCode;
+  }
+
 }

--- a/src/main/java/kr/santanrudolph/everyvent/global/util/EnumUtil.java
+++ b/src/main/java/kr/santanrudolph/everyvent/global/util/EnumUtil.java
@@ -1,0 +1,27 @@
+package kr.santanrudolph.everyvent.global.util;
+
+import kr.santanrudolph.everyvent.global.exception.ErrorCode;
+import kr.santanrudolph.everyvent.global.exception.EveryventException;
+
+public class EnumUtil {
+
+    /**
+     * 문자열을 Enum으로 안전하게 변환
+     * @param enumClass 변환할 Enum 클래스
+     * @param value 변환할 문자열
+     * @param <E> Enum 타입
+     * @return 변환된 Enum 값
+     * @throws EveryventException 잘못된 값이면 발생
+     */
+    public static <E extends Enum<E>> E parseEnum(Class<E> enumClass, String value) {
+        if (value == null || value.isBlank()) {
+            throw new EveryventException(ErrorCode.INVALID_INPUT_VALUE);
+        }
+
+        try {
+            return Enum.valueOf(enumClass, value.toUpperCase());
+        } catch (IllegalArgumentException e) {
+            throw new EveryventException(ErrorCode.INVALID_INPUT_VALUE);
+        }
+    }
+}


### PR DESCRIPTION
## 📝 무엇을 했나요?
캘린더 생성, 조회, 수정, 삭제 기능 구현
공식 캘린더 배포 기능 구현

## 💭 고민 지점과 리뷰 포인트
코드 중복을 최소화하여 가독성과 유지보수성을 고려한 최적화된 코드를 작성하려 노력했습니다.
오류 및 예외 처리 구조가 정해짐에 따라, ErrorCode 적용에 맞춰 리팩토링이 필요할 것으로 보입니다.
현재 Follower 기능은 미구현 상태로, 관련 로직은 TODO 주석으로 표시해두었습니다.
테스트 코드는 개발 속도를 우선하기 위해 추후 작성 예정입니다.

## 🔧 추후 개선 계획
Follower 기능 구현 후, 관련 비즈니스 로직 보완
테스트 코드 추가 작성 및 리팩토링

## 🔗 관련 이슈
#5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 개인 및 관리자(공식) 캘린더의 생성·조회·수정·삭제 및 공식 캘린더 배포 API 추가
  * 캘린더 공개범위(공개/팔로워/상호/비공개), 카테고리, HEX 색상 유효성 검사 지원
  * 캘린더 기간·미리보기 기간 설정 및 미리보기 노출 제어, 미리보기 유효성 검증 추가
  * 월별 생성 제한·권한 검사·시간대 처리 지원 및 응답 DTO 개선
  * 오류 코드·예외 메시지와 열거형 유틸리티 보강
<!-- end of auto-generated comment: release notes by coderabbit.ai -->