### PR TITLE
fix: @RequestParam value 명시로 OAuth 로그인 오류 수정

### DIFF
--- a/src/main/java/kr/santanrudolph/everyvent/auth/controller/OAuth2TestController.java
+++ b/src/main/java/kr/santanrudolph/everyvent/auth/controller/OAuth2TestController.java
@@ -110,8 +110,8 @@ public class OAuth2TestController {
     @GetMapping("/oauth/callback")
     @ResponseBody
     public String oauthCallback(
-            @RequestParam(required = false) String accessToken,
-            @RequestParam(required = false) String refreshToken) {
+            @RequestParam(required = false, value = "accessToken") String accessToken,
+            @RequestParam(required = false, value = "refreshToken") String refreshToken) {
         log.info("OAuth2 Callback - AccessToken: {}, RefreshToken: {}", accessToken, refreshToken);
 
         return """


### PR DESCRIPTION
## 📝 무엇을 했나요?
이전 작업 중 develop 브랜치에 문제가 있어,, 현재 develop 브랜치에서 로그인 시 `INTERNAL_SERVER_ERROR`가 발생하고 있습니다...

문제의 원인은 @RequestParam에 value 속성을 명시하지 않아, 컴파일러에 -parameters 플래그가 없는 환경에서 파라미터 이름을 인식하지 못한 것이었습니다. 🥲🥲🥲

이를 해결하기 위해 accessToken과 refreshToken 파라미터에 @RequestParam(value = "...")를 명시하여 정상적으로 바인딩되도록 수정했습니다!

@NYoungLEE 다음부터는 꼼꼼히 확인하고 pr 올리도록 하겠습니다 죄송합니당...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * OAuth2 테스트 컨트롤러의 요청 파라미터 바인딩이 개선되었습니다.

---

**참고**: 이 변경사항은 내부 코드 개선으로, 사용자에게 직접적인 영향은 없습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->