### PR TITLE
feat(follow): 팔로우 관련 기능 구현 및 테스트 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,10 @@ repositories {
     mavenCentral()
 }
 
+tasks.withType(JavaCompile) {
+    options.compilerArgs += ["-parameters"]
+}
+
 dependencies {
     // Spring Boot Starters
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'

--- a/src/main/java/kr/santanrudolph/everyvent/auth/controller/DevAuthController.java
+++ b/src/main/java/kr/santanrudolph/everyvent/auth/controller/DevAuthController.java
@@ -1,0 +1,94 @@
+package kr.santanrudolph.everyvent.auth.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import kr.santanrudolph.everyvent.auth.dto.TokenResponse;
+import kr.santanrudolph.everyvent.auth.security.JwtTokenProvider;
+import kr.santanrudolph.everyvent.domain.user.User;
+import kr.santanrudolph.everyvent.domain.user.UserRepository;
+import kr.santanrudolph.everyvent.global.exception.ErrorCode;
+import kr.santanrudolph.everyvent.global.exception.EveryventException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Profile;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "[개발용] 인증", description = "개발 환경에서만 사용 가능한 테스트용 인증 API")
+@Slf4j
+@Profile("dev") // dev 프로파일에서만 활성화
+@RestController
+@RequestMapping("/api/dev/auth")
+@RequiredArgsConstructor
+public class DevAuthController {
+
+  private final UserRepository userRepository;
+  private final JwtTokenProvider jwtTokenProvider;
+
+  @Operation(
+      summary = "[개발용] userId로 즉시 로그인",
+      description = "userId를 받아서 JWT 토큰을 즉시 발급합니다. 개발 환경에서만 사용 가능합니다."
+  )
+  @GetMapping("/login/{userId}")
+  public ResponseEntity<TokenResponse> loginByUserId(
+      @Parameter(description = "사용자 ID", example = "1", required = true)
+      @PathVariable("userId") Long userId) {
+    log.info("[DEV] 개발용 로그인 요청: userId={}", userId);
+
+    User user = userRepository.findById(userId)
+        .orElseThrow(() -> new EveryventException(ErrorCode.NOT_FOUND, "존재하지 않는 유저입니다."));
+
+    if (user.isDeleted()) {
+      throw new EveryventException(ErrorCode.NOT_FOUND, "탈퇴한 유저입니다.");
+    }
+
+    String accessToken = jwtTokenProvider.createAccessToken(userId);
+    String refreshToken = jwtTokenProvider.createRefreshToken(userId);
+
+    log.info("[DEV] 토큰 발급 완료: userId={}, nickname={}", userId, user.getNickname());
+
+    TokenResponse response = TokenResponse.builder()
+        .accessToken(accessToken)
+        .refreshToken(refreshToken)
+        .tokenType("Bearer")
+        .expiresIn(3600L)
+        .build();
+
+    return ResponseEntity.ok(response);
+  }
+
+  @Operation(
+      summary = "[개발용] 이메일로 즉시 로그인",
+      description = "이메일을 받아서 해당 유저의 JWT 토큰을 즉시 발급합니다. 개발 환경에서만 사용 가능합니다."
+  )
+  @GetMapping("/login/email/{email}")
+  public ResponseEntity<TokenResponse> loginByEmail(@PathVariable("email") String email) {
+    log.info("[DEV] 개발용 로그인 요청: email={}", email);
+
+    User user = userRepository.findByEmail(email)
+        .orElseThrow(() -> new EveryventException(ErrorCode.NOT_FOUND));
+
+    if (user.isDeleted()) {
+      throw new EveryventException(ErrorCode.NOT_FOUND);
+    }
+
+    String accessToken = jwtTokenProvider.createAccessToken(user.getId());
+    String refreshToken = jwtTokenProvider.createRefreshToken(user.getId());
+
+    log.info("[DEV] 토큰 발급 완료: email={}, userId={}, nickname={}", email, user.getId(),
+        user.getNickname());
+
+    TokenResponse response = TokenResponse.builder()
+        .accessToken(accessToken)
+        .refreshToken(refreshToken)
+        .tokenType("Bearer")
+        .expiresIn(3600L)
+        .build();
+
+    return ResponseEntity.ok(response);
+  }
+}

--- a/src/main/java/kr/santanrudolph/everyvent/auth/service/KakaoOAuthService.java
+++ b/src/main/java/kr/santanrudolph/everyvent/auth/service/KakaoOAuthService.java
@@ -1,7 +1,7 @@
 package kr.santanrudolph.everyvent.auth.service;
 
 import kr.santanrudolph.everyvent.auth.security.EveryventOAuth2User;
-import kr.santanrudolph.everyvent.domain.user.SocialProvider;
+import kr.santanrudolph.everyvent.domain.user.enums.SocialProvider;
 import kr.santanrudolph.everyvent.domain.user.User;
 import kr.santanrudolph.everyvent.domain.user.UserRepository;
 import kr.santanrudolph.everyvent.global.exception.ErrorCode;

--- a/src/main/java/kr/santanrudolph/everyvent/domain/follow/Follow.java
+++ b/src/main/java/kr/santanrudolph/everyvent/domain/follow/Follow.java
@@ -1,0 +1,65 @@
+package kr.santanrudolph.everyvent.domain.follow;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.Index;
+import kr.santanrudolph.everyvent.domain.user.User;
+import kr.santanrudolph.everyvent.global.entity.BaseEntity;
+import kr.santanrudolph.everyvent.global.exception.ErrorCode;
+import kr.santanrudolph.everyvent.global.exception.EveryventException;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(
+    name = "follows",
+    indexes = {
+        @Index(name = "idx_follow_follower", columnList = "follower_id"),
+        @Index(name = "idx_follow_target", columnList = "target_id"),
+        @Index(name = "idx_follow_follower_target", columnList = "follower_id, target_id", unique = true)
+    }
+)
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Follow extends BaseEntity {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "follower_id", nullable = false)
+  private User follower;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "target_id", nullable = false)
+  private User target;
+
+
+  public static Follow create(User follower, User target) {
+    if (follower == null) {
+      throw new EveryventException(ErrorCode.INVALID_INPUT, "팔로워가 null 입니다.");
+    }
+
+    if (target == null) {
+      throw new EveryventException(ErrorCode.INVALID_INPUT, "팔로우 대상이 null 입니다.");
+    }
+
+    if (follower.equals(target)) {
+      throw new EveryventException(ErrorCode.INVALID_INPUT, "자기 자신을 팔로우할 수 없습니다.");
+    }
+
+    Follow follow = new Follow();
+    follow.follower = follower;
+    follow.target = target;
+    return follow;
+  }
+}

--- a/src/main/java/kr/santanrudolph/everyvent/domain/follow/FollowController.java
+++ b/src/main/java/kr/santanrudolph/everyvent/domain/follow/FollowController.java
@@ -41,7 +41,7 @@ public class FollowController {
   )
   @ApiResponses({
       @ApiResponse(responseCode = "201", description = "팔로우 생성 성공"),
-      @ApiResponse(responseCode = "400", description = "BAD_REQUEST: 자기 자신을 팔로우할 수 없음 | INVALID_INPUT: 요청 형식 오류"),
+      @ApiResponse(responseCode = "400", description = "INVALID_INPUT: 요청 형식 오류"),
       @ApiResponse(responseCode = "404", description = "NOT_FOUND: 팔로우 대상 사용자를 찾을 수 없음"),
       @ApiResponse(responseCode = "409", description = "ALREADY_EXIST: 이미 팔로우 중")
   })

--- a/src/main/java/kr/santanrudolph/everyvent/domain/follow/FollowController.java
+++ b/src/main/java/kr/santanrudolph/everyvent/domain/follow/FollowController.java
@@ -1,0 +1,148 @@
+package kr.santanrudolph.everyvent.domain.follow;
+
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import kr.santanrudolph.everyvent.auth.AuthenticationUtil;
+import kr.santanrudolph.everyvent.domain.follow.command.FollowCreateCommand;
+import kr.santanrudolph.everyvent.domain.follow.dto.FollowCreateRequest;
+import kr.santanrudolph.everyvent.domain.follow.dto.FollowCreateResponse;
+import kr.santanrudolph.everyvent.domain.follow.dto.FollowResponse;
+import kr.santanrudolph.everyvent.global.exception.ErrorCode;
+import kr.santanrudolph.everyvent.global.exception.EveryventException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import java.util.List;
+
+@Tag(name = "팔로우", description = "팔로우 관련 API")
+@Slf4j
+@RestController
+@RequestMapping("/api/me")
+@RequiredArgsConstructor
+public class FollowController {
+
+  private final FollowService followService;
+
+  @Operation(
+      summary = "팔로우 생성",
+      description = "다른 사용자를 팔로우합니다. 자기 자신은 팔로우할 수 없습니다."
+  )
+  @ApiResponses({
+      @ApiResponse(responseCode = "201", description = "팔로우 생성 성공"),
+      @ApiResponse(responseCode = "400", description = "BAD_REQUEST: 자기 자신을 팔로우할 수 없음 | INVALID_INPUT: 요청 형식 오류"),
+      @ApiResponse(responseCode = "404", description = "NOT_FOUND: 팔로우 대상 사용자를 찾을 수 없음"),
+      @ApiResponse(responseCode = "409", description = "ALREADY_EXIST: 이미 팔로우 중")
+  })
+  @PostMapping("/followings")
+  public ResponseEntity<FollowCreateResponse> createFollow(
+      @Valid @RequestBody FollowCreateRequest request
+  ) {
+    Long currentUserId = AuthenticationUtil.getCurrentUserId();
+
+    // 자기 자신 팔로우 방지
+    if (currentUserId.equals(request.getTargetId())) {
+      throw new EveryventException(ErrorCode.INVALID_INPUT, "자기 자신을 팔로우할 수 없습니다.");
+    }
+
+    FollowCreateCommand command = new FollowCreateCommand(currentUserId, request.getTargetId());
+    FollowCreateResponse response = followService.createFollow(command);
+
+    log.info("Follow created - follower: {}, target: {}", currentUserId, request.getTargetId());
+
+    return ResponseEntity.status(HttpStatus.CREATED).body(response);
+  }
+
+
+  @Operation(
+      summary = "내 팔로워 목록 조회",
+      description = "나를 팔로우하는 사용자 목록을 조회합니다."
+  )
+  @ApiResponses({
+      @ApiResponse(responseCode = "200", description = "팔로워 목록 조회 성공"),
+      @ApiResponse(responseCode = "404", description = "NOT_FOUND: 사용자를 찾을 수 없음")
+  })
+  @GetMapping("/followers")
+  public ResponseEntity<List<FollowResponse>> getMyFollowers() {
+    Long currentUserId = AuthenticationUtil.getCurrentUserId();
+
+    List<FollowResponse> followers = followService.getFollowers(currentUserId);
+
+    log.debug("Followers retrieved for user: {}, count: {}", currentUserId, followers.size());
+
+    return ResponseEntity.ok(followers);
+  }
+
+  @Operation(
+      summary = "내 팔로잉 목록 조회",
+      description = "내가 팔로우하는 사용자 목록을 조회합니다."
+  )
+  @ApiResponses({
+      @ApiResponse(responseCode = "200", description = "팔로잉 목록 조회 성공"),
+      @ApiResponse(responseCode = "404", description = "NOT_FOUND: 사용자를 찾을 수 없음")
+  })
+  @GetMapping("/followings")
+  public ResponseEntity<List<FollowResponse>> getMyFollowings() {
+    Long currentUserId = AuthenticationUtil.getCurrentUserId();
+
+    List<FollowResponse> followings = followService.getFollowings(currentUserId);
+
+    log.debug("Followings retrieved for user: {}, count: {}", currentUserId, followings.size());
+
+    return ResponseEntity.ok(followings);
+  }
+
+  @Operation(
+      summary = "언팔로우 (팔로잉 제거)",
+      description = "내가 팔로우한 사용자를 언팔로우합니다."
+  )
+  @ApiResponses({
+      @ApiResponse(responseCode = "204", description = "언팔로우 성공"),
+      @ApiResponse(responseCode = "404", description = "NOT_FOUND: 팔로워 또는 팔로우 대상 사용자를 찾을 수 없음 | 팔로우 관계가 존재하지 않음")
+  })
+  @DeleteMapping("/followings/{targetId}")
+  public ResponseEntity<Void> unfollowUser(
+      @PathVariable Long targetId
+  ) {
+    Long currentUserId = AuthenticationUtil.getCurrentUserId();
+
+    followService.deleteFollow(currentUserId, targetId);
+
+    log.info("Unfollow - follower: {}, target: {}", currentUserId, targetId);
+
+    return ResponseEntity.noContent().build();
+  }
+
+  @Operation(
+      summary = "팔로워 제거",
+      description = "나를 팔로우하는 사용자를 제거합니다."
+  )
+  @ApiResponses({
+      @ApiResponse(responseCode = "204", description = "팔로워 제거 성공"),
+      @ApiResponse(responseCode = "404", description = "NOT_FOUND: 팔로워 또는 팔로우 대상 사용자를 찾을 수 없음 | 팔로우 관계가 존재하지 않음")
+  })
+  @DeleteMapping("/followers/{followerId}")
+  public ResponseEntity<Void> removeFollower(
+      @PathVariable Long followerId
+  ) {
+    Long currentUserId = AuthenticationUtil.getCurrentUserId();
+
+    followService.deleteFollow(followerId, currentUserId);
+
+    log.info("Follower removed - follower: {}, target: {}", followerId, currentUserId);
+
+    return ResponseEntity.noContent().build();
+  }
+
+}

--- a/src/main/java/kr/santanrudolph/everyvent/domain/follow/FollowRepository.java
+++ b/src/main/java/kr/santanrudolph/everyvent/domain/follow/FollowRepository.java
@@ -1,7 +1,7 @@
 package kr.santanrudolph.everyvent.domain.follow;
 
 import java.util.List;
-import kr.santanrudolph.everyvent.domain.user.dto.response.UserBasicResponse;
+import kr.santanrudolph.everyvent.domain.follow.dto.FollowResponse;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -12,16 +12,16 @@ public interface FollowRepository extends JpaRepository<Follow, Long> {
 
   boolean existsByFollowerIdAndTargetId(Long followerId, Long targetId);
 
-  @Query("SELECT new kr.santanrudolph.everyvent.domain.user.dto.response.UserBasicResponse(u.id, u.nickname) " +
+  @Query("SELECT  new kr.santanrudolph.everyvent.domain.follow.dto.FollowResponse(f.id, u.id, u.nickname)" +
       "FROM Follow f " +
-      "JOIN f.follower u " +
+      "JOIN FETCH f.follower u " +
       "WHERE f.target.id = :targetId AND u.deletedAt IS NULL")
-  List<UserBasicResponse> findActiveFollowersBasicByTargetId(@Param("targetId") Long targetId);
+  List<FollowResponse> findActiveFollowersByTargetId(@Param("targetId") Long targetId);
 
-  @Query("SELECT new kr.santanrudolph.everyvent.domain.user.dto.response.UserBasicResponse(u.id, u.nickname) " +
+  @Query("SELECT new kr.santanrudolph.everyvent.domain.follow.dto.FollowResponse(f.id, u.id, u.nickname) " +
       "FROM Follow f " +
       "JOIN f.target u " +
       "WHERE f.follower.id = :followerId AND u.deletedAt IS NULL")
-  List<UserBasicResponse> findActiveFollowingsBasicByFollowerId(@Param("followerId") Long followerId);
+  List<FollowResponse> findActiveFollowingsBasicByFollowerId(@Param("followerId") Long followerId);
 
 }

--- a/src/main/java/kr/santanrudolph/everyvent/domain/follow/FollowRepository.java
+++ b/src/main/java/kr/santanrudolph/everyvent/domain/follow/FollowRepository.java
@@ -12,9 +12,9 @@ public interface FollowRepository extends JpaRepository<Follow, Long> {
 
   boolean existsByFollowerIdAndTargetId(Long followerId, Long targetId);
 
-  @Query("SELECT  new kr.santanrudolph.everyvent.domain.follow.dto.FollowResponse(f.id, u.id, u.nickname)" +
+  @Query("SELECT new kr.santanrudolph.everyvent.domain.follow.dto.FollowResponse(f.id, u.id, u.nickname) " +
       "FROM Follow f " +
-      "JOIN FETCH f.follower u " +
+      "JOIN f.follower u " +
       "WHERE f.target.id = :targetId AND u.deletedAt IS NULL")
   List<FollowResponse> findActiveFollowersByTargetId(@Param("targetId") Long targetId);
 
@@ -22,6 +22,6 @@ public interface FollowRepository extends JpaRepository<Follow, Long> {
       "FROM Follow f " +
       "JOIN f.target u " +
       "WHERE f.follower.id = :followerId AND u.deletedAt IS NULL")
-  List<FollowResponse> findActiveFollowingsBasicByFollowerId(@Param("followerId") Long followerId);
+  List<FollowResponse> findActiveFollowingsByFollowerId(@Param("followerId") Long followerId);
 
 }

--- a/src/main/java/kr/santanrudolph/everyvent/domain/follow/FollowRepository.java
+++ b/src/main/java/kr/santanrudolph/everyvent/domain/follow/FollowRepository.java
@@ -1,10 +1,27 @@
 package kr.santanrudolph.everyvent.domain.follow;
 
+import java.util.List;
+import kr.santanrudolph.everyvent.domain.user.dto.response.UserBasicResponse;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface FollowRepository extends JpaRepository<Follow, Long> {
 
   boolean existsByFollowerIdAndTargetId(Long followerId, Long targetId);
+
+  @Query("SELECT new kr.santanrudolph.everyvent.domain.user.dto.response.UserBasicResponse(u.id, u.nickname) " +
+      "FROM Follow f " +
+      "JOIN f.follower u " +
+      "WHERE f.target.id = :targetId AND u.deletedAt IS NULL")
+  List<UserBasicResponse> findFollowersBasicByTargetId(@Param("targetId") Long targetId);
+
+  @Query("SELECT new kr.santanrudolph.everyvent.domain.user.dto.response.UserBasicResponse(u.id, u.nickname) " +
+      "FROM Follow f " +
+      "JOIN f.target u " +
+      "WHERE f.follower.id = :followerId AND u.deletedAt IS NULL")
+  List<UserBasicResponse> findFollowingsBasicByFollowerId(@Param("followerId") Long followerId);
+
 }

--- a/src/main/java/kr/santanrudolph/everyvent/domain/follow/FollowRepository.java
+++ b/src/main/java/kr/santanrudolph/everyvent/domain/follow/FollowRepository.java
@@ -1,0 +1,10 @@
+package kr.santanrudolph.everyvent.domain.follow;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface FollowRepository extends JpaRepository<Follow, Long> {
+
+  boolean existsByFollowerIdAndTargetId(Long followerId, Long targetId);
+}

--- a/src/main/java/kr/santanrudolph/everyvent/domain/follow/FollowRepository.java
+++ b/src/main/java/kr/santanrudolph/everyvent/domain/follow/FollowRepository.java
@@ -16,12 +16,12 @@ public interface FollowRepository extends JpaRepository<Follow, Long> {
       "FROM Follow f " +
       "JOIN f.follower u " +
       "WHERE f.target.id = :targetId AND u.deletedAt IS NULL")
-  List<UserBasicResponse> findFollowersBasicByTargetId(@Param("targetId") Long targetId);
+  List<UserBasicResponse> findActiveFollowersBasicByTargetId(@Param("targetId") Long targetId);
 
   @Query("SELECT new kr.santanrudolph.everyvent.domain.user.dto.response.UserBasicResponse(u.id, u.nickname) " +
       "FROM Follow f " +
       "JOIN f.target u " +
       "WHERE f.follower.id = :followerId AND u.deletedAt IS NULL")
-  List<UserBasicResponse> findFollowingsBasicByFollowerId(@Param("followerId") Long followerId);
+  List<UserBasicResponse> findActiveFollowingsBasicByFollowerId(@Param("followerId") Long followerId);
 
 }

--- a/src/main/java/kr/santanrudolph/everyvent/domain/follow/FollowRepository.java
+++ b/src/main/java/kr/santanrudolph/everyvent/domain/follow/FollowRepository.java
@@ -2,7 +2,9 @@ package kr.santanrudolph.everyvent.domain.follow;
 
 import java.util.List;
 import kr.santanrudolph.everyvent.domain.follow.dto.FollowResponse;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
@@ -24,4 +26,10 @@ public interface FollowRepository extends JpaRepository<Follow, Long> {
       "WHERE f.follower.id = :followerId AND u.deletedAt IS NULL")
   List<FollowResponse> findActiveFollowingsByFollowerId(@Param("followerId") Long followerId);
 
+  Optional<Follow> findByFollowerIdAndTargetId(Long followerId, Long targetId);
+
+  @Modifying
+  @Query("DELETE FROM Follow f WHERE f.follower.id = :followerId AND f.target.id = :targetId")
+  int deleteByFollowerIdAndTargetId(@Param("followerId") Long followerId,
+      @Param("targetId") Long targetId);
 }

--- a/src/main/java/kr/santanrudolph/everyvent/domain/follow/FollowService.java
+++ b/src/main/java/kr/santanrudolph/everyvent/domain/follow/FollowService.java
@@ -70,7 +70,7 @@ public class FollowService {
             "팔로잉 정보를 가져올 대상 사용자가 존재하지 않습니다. (ID: " + followerId + ")"
         ));
 
-    return followRepository.findActiveFollowingsBasicByFollowerId(followerId);
+    return followRepository.findActiveFollowingsByFollowerId(followerId);
 
   }
 

--- a/src/main/java/kr/santanrudolph/everyvent/domain/follow/FollowService.java
+++ b/src/main/java/kr/santanrudolph/everyvent/domain/follow/FollowService.java
@@ -6,7 +6,7 @@ import kr.santanrudolph.everyvent.domain.follow.dto.FollowResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.transaction.annotation.Transactional;
-import kr.santanrudolph.everyvent.domain.follow.dto.FollowCreateCommand;
+import kr.santanrudolph.everyvent.domain.follow.command.FollowCreateCommand;
 import kr.santanrudolph.everyvent.domain.follow.dto.FollowCreateResponse;
 import kr.santanrudolph.everyvent.domain.user.User;
 import kr.santanrudolph.everyvent.domain.user.UserRepository;

--- a/src/main/java/kr/santanrudolph/everyvent/domain/follow/FollowService.java
+++ b/src/main/java/kr/santanrudolph/everyvent/domain/follow/FollowService.java
@@ -1,6 +1,8 @@
 package kr.santanrudolph.everyvent.domain.follow;
 
 
+import java.util.List;
+import kr.santanrudolph.everyvent.domain.user.dto.response.UserBasicResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.transaction.annotation.Transactional;
@@ -27,9 +29,11 @@ public class FollowService {
     User follower = userRepository.findByIdAndDeletedAtIsNull(command.followerId())
         .orElseThrow(() -> new EveryventException(
             ErrorCode.NOT_FOUND, "팔로워 id를 찾을 수 없습니다."));
+
     User target = userRepository.findByIdAndDeletedAtIsNull(command.targetId())
         .orElseThrow(() -> new EveryventException(
             ErrorCode.NOT_FOUND, "팔로우 대상 id를 찾을 수 없습니다."));
+
     if (followRepository.existsByFollowerIdAndTargetId(
         command.followerId(),
         command.targetId()
@@ -45,5 +49,30 @@ public class FollowService {
 
     return FollowCreateResponse.from(saved);
   }
+
+  public List<UserBasicResponse> getFollowers(Long targetId) {
+
+    userRepository.findByIdAndDeletedAtIsNull(targetId)
+        .orElseThrow(() -> new EveryventException(
+            ErrorCode.NOT_FOUND,
+            "팔로워 정보를 가져올 대상 사용자가 존재하지 않습니다. (ID: " + targetId + ")"
+        ));
+
+    return followRepository.findFollowersBasicByTargetId(targetId);
+
+  }
+
+  public List<UserBasicResponse> getFollowings(Long followerId) {
+
+    userRepository.findByIdAndDeletedAtIsNull(followerId)
+        .orElseThrow(() -> new EveryventException(
+            ErrorCode.NOT_FOUND,
+            "팔로잉 정보를 가져올 대상 사용자가 존재하지 않습니다. (ID: " + followerId + ")"
+        ));
+
+    return followRepository.findFollowingsBasicByFollowerId(followerId);
+
+  }
+
 
 }

--- a/src/main/java/kr/santanrudolph/everyvent/domain/follow/FollowService.java
+++ b/src/main/java/kr/santanrudolph/everyvent/domain/follow/FollowService.java
@@ -74,5 +74,32 @@ public class FollowService {
 
   }
 
+  @Transactional
+  public void deleteFollow(Long followerId, Long targetId) {
+    if (!userRepository.existsByIdAndDeletedAtIsNull(followerId)) {
+      throw new EveryventException(
+          ErrorCode.NOT_FOUND,
+          "삭제할 팔로워 사용자를 찾을 수 없습니다. (ID: " + followerId + ")"
+      );
+    }
+
+    if (!userRepository.existsByIdAndDeletedAtIsNull(targetId)) {
+      throw new EveryventException(
+          ErrorCode.NOT_FOUND,
+          "삭제할 팔로우 대상 사용자를 찾을 수 없습니다. (ID: " + targetId + ")"
+      );
+    }
+
+    int deletedCount = followRepository.deleteByFollowerIdAndTargetId(followerId, targetId);
+
+    if (deletedCount == 0) {
+      throw new EveryventException(
+          ErrorCode.NOT_FOUND,
+          "삭제할 팔로우 관계가 존재하지 않습니다."
+      );
+    }
+
+    log.info("Follow deleted - follower: {}, target: {}", followerId, targetId);
+  }
 
 }

--- a/src/main/java/kr/santanrudolph/everyvent/domain/follow/FollowService.java
+++ b/src/main/java/kr/santanrudolph/everyvent/domain/follow/FollowService.java
@@ -2,7 +2,7 @@ package kr.santanrudolph.everyvent.domain.follow;
 
 
 import java.util.List;
-import kr.santanrudolph.everyvent.domain.user.dto.response.UserBasicResponse;
+import kr.santanrudolph.everyvent.domain.follow.dto.FollowResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.transaction.annotation.Transactional;
@@ -50,7 +50,7 @@ public class FollowService {
     return FollowCreateResponse.from(saved);
   }
 
-  public List<UserBasicResponse> getFollowers(Long targetId) {
+  public List<FollowResponse> getFollowers(Long targetId) {
 
     userRepository.findByIdAndDeletedAtIsNull(targetId)
         .orElseThrow(() -> new EveryventException(
@@ -58,11 +58,11 @@ public class FollowService {
             "팔로워 정보를 가져올 대상 사용자가 존재하지 않습니다. (ID: " + targetId + ")"
         ));
 
-    return followRepository.findActiveFollowersBasicByTargetId(targetId);
+    return followRepository.findActiveFollowersByTargetId(targetId);
 
   }
 
-  public List<UserBasicResponse> getFollowings(Long followerId) {
+  public List<FollowResponse> getFollowings(Long followerId) {
 
     userRepository.findByIdAndDeletedAtIsNull(followerId)
         .orElseThrow(() -> new EveryventException(

--- a/src/main/java/kr/santanrudolph/everyvent/domain/follow/FollowService.java
+++ b/src/main/java/kr/santanrudolph/everyvent/domain/follow/FollowService.java
@@ -1,0 +1,49 @@
+package kr.santanrudolph.everyvent.domain.follow;
+
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.transaction.annotation.Transactional;
+import kr.santanrudolph.everyvent.domain.follow.dto.FollowCreateCommand;
+import kr.santanrudolph.everyvent.domain.follow.dto.FollowCreateResponse;
+import kr.santanrudolph.everyvent.domain.user.User;
+import kr.santanrudolph.everyvent.domain.user.UserRepository;
+import kr.santanrudolph.everyvent.global.exception.ErrorCode;
+import kr.santanrudolph.everyvent.global.exception.EveryventException;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class FollowService {
+
+  private final FollowRepository followRepository;
+  private final UserRepository userRepository;
+
+
+  @Transactional
+  public FollowCreateResponse createFollow(FollowCreateCommand command) {
+    User follower = userRepository.findByIdAndDeletedAtIsNull(command.followerId())
+        .orElseThrow(() -> new EveryventException(
+            ErrorCode.NOT_FOUND, "팔로워 id를 찾을 수 없습니다."));
+    User target = userRepository.findByIdAndDeletedAtIsNull(command.targetId())
+        .orElseThrow(() -> new EveryventException(
+            ErrorCode.NOT_FOUND, "팔로우 대상 id를 찾을 수 없습니다."));
+    if (followRepository.existsByFollowerIdAndTargetId(
+        command.followerId(),
+        command.targetId()
+    )) {
+      throw new EveryventException(ErrorCode.ALREADY_EXIST, "이미 팔로우 중입니다.");
+    }
+
+    Follow follow = Follow.create(follower, target);
+    Follow saved = followRepository.save(follow);
+
+    log.info("Follow created - follower: {}, target: {}, follow: {}",
+        command.followerId(), command.targetId(), follow.getId());
+
+    return FollowCreateResponse.from(saved);
+  }
+
+}

--- a/src/main/java/kr/santanrudolph/everyvent/domain/follow/FollowService.java
+++ b/src/main/java/kr/santanrudolph/everyvent/domain/follow/FollowService.java
@@ -58,7 +58,7 @@ public class FollowService {
             "팔로워 정보를 가져올 대상 사용자가 존재하지 않습니다. (ID: " + targetId + ")"
         ));
 
-    return followRepository.findFollowersBasicByTargetId(targetId);
+    return followRepository.findActiveFollowersBasicByTargetId(targetId);
 
   }
 
@@ -70,7 +70,7 @@ public class FollowService {
             "팔로잉 정보를 가져올 대상 사용자가 존재하지 않습니다. (ID: " + followerId + ")"
         ));
 
-    return followRepository.findFollowingsBasicByFollowerId(followerId);
+    return followRepository.findActiveFollowingsBasicByFollowerId(followerId);
 
   }
 

--- a/src/main/java/kr/santanrudolph/everyvent/domain/follow/command/FollowCreateCommand.java
+++ b/src/main/java/kr/santanrudolph/everyvent/domain/follow/command/FollowCreateCommand.java
@@ -14,6 +14,8 @@ public record FollowCreateCommand(
       throw new EveryventException(ErrorCode.INVALID_INPUT, "팔로워 유저의 ID는 1 이상의 값이어야 합니다.");
     } else if (targetId <= 0) {
       throw new EveryventException(ErrorCode.INVALID_INPUT, "팔로우 대상 유저의 ID는 1 이상의 값이어야 합니다.");
+    } else if (followerId == targetId) {
+      throw new EveryventException(ErrorCode.INVALID_INPUT, "자기 자신을 팔로우할 수 없습니다.");
     }
   }
 }

--- a/src/main/java/kr/santanrudolph/everyvent/domain/follow/command/FollowCreateCommand.java
+++ b/src/main/java/kr/santanrudolph/everyvent/domain/follow/command/FollowCreateCommand.java
@@ -10,12 +10,39 @@ public record FollowCreateCommand(
 ) {
 
   public FollowCreateCommand {
-    if (followerId <= 0) {
-      throw new EveryventException(ErrorCode.INVALID_INPUT, "팔로워 유저의 ID는 1 이상의 값이어야 합니다.");
-    } else if (targetId <= 0) {
-      throw new EveryventException(ErrorCode.INVALID_INPUT, "팔로우 대상 유저의 ID는 1 이상의 값이어야 합니다.");
-    } else if (followerId.equals(targetId)) {
-      throw new EveryventException(ErrorCode.INVALID_INPUT, "자기 자신을 팔로우할 수 없습니다.");
+    validateNotNull(followerId, "팔로워 유저의 ID");
+    validateNotNull(targetId, "팔로우 대상 유저의 ID");
+
+    validatePositive(followerId, "팔로워 유저의 ID");
+    validatePositive(targetId, "팔로우 대상 유저의 ID");
+
+    validateNotSelfFollow(followerId, targetId);
+  }
+
+  private void validateNotNull(Long id, String fieldName) {
+    if (id == null) {
+      throw new EveryventException(
+          ErrorCode.INVALID_INPUT,
+          fieldName + "는 null일 수 없습니다."
+      );
+    }
+  }
+
+  private void validatePositive(Long id, String fieldName) {
+    if (id <= 0) {
+      throw new EveryventException(
+          ErrorCode.INVALID_INPUT,
+          fieldName + "는 1 이상의 값이어야 합니다."
+      );
+    }
+  }
+
+  private void validateNotSelfFollow(Long followerId, Long targetId) {
+    if (followerId.equals(targetId)) {
+      throw new EveryventException(
+          ErrorCode.INVALID_INPUT,
+          "자기 자신을 팔로우할 수 없습니다."
+      );
     }
   }
 }

--- a/src/main/java/kr/santanrudolph/everyvent/domain/follow/command/FollowCreateCommand.java
+++ b/src/main/java/kr/santanrudolph/everyvent/domain/follow/command/FollowCreateCommand.java
@@ -1,4 +1,4 @@
-package kr.santanrudolph.everyvent.domain.follow.dto;
+package kr.santanrudolph.everyvent.domain.follow.command;
 
 
 import kr.santanrudolph.everyvent.global.exception.ErrorCode;

--- a/src/main/java/kr/santanrudolph/everyvent/domain/follow/command/FollowCreateCommand.java
+++ b/src/main/java/kr/santanrudolph/everyvent/domain/follow/command/FollowCreateCommand.java
@@ -14,7 +14,7 @@ public record FollowCreateCommand(
       throw new EveryventException(ErrorCode.INVALID_INPUT, "팔로워 유저의 ID는 1 이상의 값이어야 합니다.");
     } else if (targetId <= 0) {
       throw new EveryventException(ErrorCode.INVALID_INPUT, "팔로우 대상 유저의 ID는 1 이상의 값이어야 합니다.");
-    } else if (followerId == targetId) {
+    } else if (followerId.equals(targetId)) {
       throw new EveryventException(ErrorCode.INVALID_INPUT, "자기 자신을 팔로우할 수 없습니다.");
     }
   }

--- a/src/main/java/kr/santanrudolph/everyvent/domain/follow/dto/FollowCreateCommand.java
+++ b/src/main/java/kr/santanrudolph/everyvent/domain/follow/dto/FollowCreateCommand.java
@@ -1,0 +1,19 @@
+package kr.santanrudolph.everyvent.domain.follow.dto;
+
+
+import kr.santanrudolph.everyvent.global.exception.ErrorCode;
+import kr.santanrudolph.everyvent.global.exception.EveryventException;
+
+public record FollowCreateCommand(
+    Long followerId,
+    Long targetId
+) {
+
+  public FollowCreateCommand {
+    if (followerId <= 0) {
+      throw new EveryventException(ErrorCode.INVALID_INPUT, "팔로워 유저의 ID는 1 이상의 값이어야 합니다.");
+    } else if (targetId <= 0) {
+      throw new EveryventException(ErrorCode.INVALID_INPUT, "팔로우 대상 유저의 ID는 1 이상의 값이어야 합니다.");
+    }
+  }
+}

--- a/src/main/java/kr/santanrudolph/everyvent/domain/follow/dto/FollowCreateRequest.java
+++ b/src/main/java/kr/santanrudolph/everyvent/domain/follow/dto/FollowCreateRequest.java
@@ -1,0 +1,18 @@
+package kr.santanrudolph.everyvent.domain.follow.dto;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class FollowCreateRequest {
+
+  @NotNull(message = "팔로우 대상 ID는 필수입니다.")
+  @Min(value = 1, message = "팔로우 대상 ID는 1 이상이어야 합니다.")
+  private Long targetId;
+
+}

--- a/src/main/java/kr/santanrudolph/everyvent/domain/follow/dto/FollowCreateResponse.java
+++ b/src/main/java/kr/santanrudolph/everyvent/domain/follow/dto/FollowCreateResponse.java
@@ -1,0 +1,25 @@
+package kr.santanrudolph.everyvent.domain.follow.dto;
+
+
+import kr.santanrudolph.everyvent.domain.follow.Follow;
+import kr.santanrudolph.everyvent.global.exception.ErrorCode;
+import kr.santanrudolph.everyvent.global.exception.EveryventException;
+
+public record FollowCreateResponse(
+    Long followId,
+    Long followerId,
+    Long targetId
+) {
+
+  public static FollowCreateResponse from(Follow follow) {
+    if (follow == null) {
+      throw new EveryventException(ErrorCode.INVALID_INPUT, "Follow 객체가 null입니다.");
+    }
+
+    return new FollowCreateResponse(
+        follow.getId(),
+        follow.getFollower().getId(),
+        follow.getTarget().getId()
+    );
+  }
+}

--- a/src/main/java/kr/santanrudolph/everyvent/domain/follow/dto/FollowResponse.java
+++ b/src/main/java/kr/santanrudolph/everyvent/domain/follow/dto/FollowResponse.java
@@ -1,0 +1,13 @@
+package kr.santanrudolph.everyvent.domain.follow.dto;
+
+import kr.santanrudolph.everyvent.domain.user.dto.response.UserBasicResponse;
+
+public record FollowResponse(
+    Long id,
+    UserBasicResponse user
+) {
+
+  public FollowResponse(Long id, Long userId, String userNickname) {
+    this(id, new UserBasicResponse(userId, userNickname));
+  }
+}

--- a/src/main/java/kr/santanrudolph/everyvent/domain/user/User.java
+++ b/src/main/java/kr/santanrudolph/everyvent/domain/user/User.java
@@ -5,6 +5,8 @@ import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import java.time.Instant;
+import kr.santanrudolph.everyvent.domain.user.enums.Role;
+import kr.santanrudolph.everyvent.domain.user.enums.SocialProvider;
 import kr.santanrudolph.everyvent.global.entity.BaseEntity;
 import lombok.AccessLevel;
 import lombok.Getter;

--- a/src/main/java/kr/santanrudolph/everyvent/domain/user/UserRepository.java
+++ b/src/main/java/kr/santanrudolph/everyvent/domain/user/UserRepository.java
@@ -1,5 +1,6 @@
 package kr.santanrudolph.everyvent.domain.user;
 
+import kr.santanrudolph.everyvent.domain.user.enums.SocialProvider;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 

--- a/src/main/java/kr/santanrudolph/everyvent/domain/user/UserRepository.java
+++ b/src/main/java/kr/santanrudolph/everyvent/domain/user/UserRepository.java
@@ -17,4 +17,5 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
   Optional<User> findByEmail(String email);
 
+  boolean existsByIdAndDeletedAtIsNull(Long Id);
 }

--- a/src/main/java/kr/santanrudolph/everyvent/domain/user/dto/response/UserBasicResponse.java
+++ b/src/main/java/kr/santanrudolph/everyvent/domain/user/dto/response/UserBasicResponse.java
@@ -1,0 +1,18 @@
+package kr.santanrudolph.everyvent.domain.user.dto.response;
+
+
+import kr.santanrudolph.everyvent.domain.user.User;
+
+public record UserBasicResponse(
+
+    Long id,
+    String nickname
+) {
+
+  public static UserBasicResponse from(User user) {
+    return new UserBasicResponse(
+        user.getId(),
+        user.getNickname()
+    );
+  }
+}

--- a/src/main/java/kr/santanrudolph/everyvent/domain/user/dto/response/UserResponse.java
+++ b/src/main/java/kr/santanrudolph/everyvent/domain/user/dto/response/UserResponse.java
@@ -1,28 +1,26 @@
 package kr.santanrudolph.everyvent.domain.user.dto.response;
 
+
 import kr.santanrudolph.everyvent.domain.user.User;
-import lombok.Builder;
-import lombok.Getter;
 
-@Getter
-@Builder
-public class UserResponse {
+public record UserResponse(
 
-  private Long id;
-  private String nickname;
-  private String email;
-  private String introduction;
-  private String socialProvider;
-  private String role;
+    Long id,
+    String nickname,
+    String email,
+    String introduction,
+    String socialProvider,
+    String role
+) {
 
   public static UserResponse from(User user) {
-    return UserResponse.builder()
-        .id(user.getId())
-        .nickname(user.getNickname())
-        .email(user.getEmail())
-        .introduction(user.getIntroduction())
-        .socialProvider(user.getSocialProvider().name())
-        .role(user.getRole().name())
-        .build();
+    return new UserResponse(
+        user.getId(),
+        user.getNickname(),
+        user.getEmail(),
+        user.getIntroduction(),
+        user.getSocialProvider().name(),
+        user.getRole().name()
+    );
   }
 }

--- a/src/main/java/kr/santanrudolph/everyvent/domain/user/enums/Role.java
+++ b/src/main/java/kr/santanrudolph/everyvent/domain/user/enums/Role.java
@@ -1,4 +1,4 @@
-package kr.santanrudolph.everyvent.domain.user;
+package kr.santanrudolph.everyvent.domain.user.enums;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/kr/santanrudolph/everyvent/domain/user/enums/SocialProvider.java
+++ b/src/main/java/kr/santanrudolph/everyvent/domain/user/enums/SocialProvider.java
@@ -1,4 +1,4 @@
-package kr.santanrudolph.everyvent.domain.user;
+package kr.santanrudolph.everyvent.domain.user.enums;
 
 public enum SocialProvider {
   KAKAO, GOOGLE, NAVER

--- a/src/main/java/kr/santanrudolph/everyvent/global/config/DataLoader.java
+++ b/src/main/java/kr/santanrudolph/everyvent/global/config/DataLoader.java
@@ -1,0 +1,77 @@
+package kr.santanrudolph.everyvent.global.config;
+
+import kr.santanrudolph.everyvent.domain.user.User;
+import kr.santanrudolph.everyvent.domain.user.UserRepository;
+import kr.santanrudolph.everyvent.domain.user.enums.Role;
+import kr.santanrudolph.everyvent.domain.user.enums.SocialProvider;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@Profile("dev") // dev 프로파일에서만 실행
+@RequiredArgsConstructor
+public class DataLoader implements CommandLineRunner {
+
+  private final UserRepository userRepository;
+
+  @Override
+  public void run(String... args) {
+    // 이미 데이터가 있으면 생성하지 않음
+    if (userRepository.count() > 1) {
+      log.info("테스트 유저가 이미 존재합니다. 데이터 로딩을 건너뜁니다.");
+      return;
+    }
+
+    log.info("테스트 유저 데이터를 생성합니다...");
+
+    // 일반 유저 3명
+    User user1 = new User(
+        "kakao_12345",
+        SocialProvider.KAKAO,
+        "santa@example.com",
+        "산타클로스",
+        "크리스마스를 사랑하는 산타입니다 🎅",
+        Role.USER
+    );
+
+    User user2 = new User(
+        "google_67890",
+        SocialProvider.GOOGLE,
+        "rudolph@example.com",
+        "루돌프",
+        "빨간 코를 가진 루돌프예요!",
+        Role.USER
+    );
+
+    User user3 = new User(
+        "naver_11111",
+        SocialProvider.NAVER,
+        "snowman@example.com",
+        "눈사람",
+        "겨울이 좋아요 ⛄",
+        Role.USER
+    );
+
+    // 관리자 유저 1명
+    User admin = new User(
+        "kakao_99999",
+        SocialProvider.KAKAO,
+        "admin@example.com",
+        "관리자",
+        "EveryVent 관리자입니다",
+        Role.ADMIN
+    );
+
+    userRepository.save(user1);
+    userRepository.save(user2);
+    userRepository.save(user3);
+    userRepository.save(admin);
+
+    log.info("테스트 유저 데이터 생성 완료!");
+    log.info("생성된 유저: santa@example.com, rudolph@example.com, snowman@example.com, admin@example.com");
+  }
+}

--- a/src/main/java/kr/santanrudolph/everyvent/global/config/SecurityConfig.java
+++ b/src/main/java/kr/santanrudolph/everyvent/global/config/SecurityConfig.java
@@ -33,6 +33,7 @@ public class SecurityConfig {
             .requestMatchers("/", "/error", "/favicon.ico").permitAll()
             .requestMatchers("/h2-console/**").permitAll()
             .requestMatchers("/api/auth/**").permitAll()
+            .requestMatchers("/api/dev/**").permitAll() // 개발용 API
             .requestMatchers("/oauth2/**").permitAll()
             .requestMatchers("/login/**").permitAll()
             .requestMatchers("/oauth/callback", "/oauth/test").permitAll()

--- a/src/main/java/kr/santanrudolph/everyvent/global/config/SecurityConfig.java
+++ b/src/main/java/kr/santanrudolph/everyvent/global/config/SecurityConfig.java
@@ -6,11 +6,13 @@ import kr.santanrudolph.everyvent.auth.security.OAuth2SuccessHandler;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.env.Environment;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import java.util.Arrays;
 
 @Configuration
 @EnableWebSecurity
@@ -20,6 +22,7 @@ public class SecurityConfig {
   private final KakaoOAuthService kakaoOAuthService;
   private final OAuth2SuccessHandler oAuth2SuccessHandler;
   private final JwtAuthenticationFilter jwtAuthenticationFilter;
+  private final Environment environment;
 
   @Bean
   public SecurityFilterChain securityFilterChain(HttpSecurity http, CorsConfig corsConfig)
@@ -29,16 +32,25 @@ public class SecurityConfig {
         .csrf(csrf -> csrf.disable())
         .sessionManagement(session -> session
             .sessionCreationPolicy(SessionCreationPolicy.STATELESS))
-        .authorizeHttpRequests(auth -> auth
-            .requestMatchers("/", "/error", "/favicon.ico").permitAll()
-            .requestMatchers("/h2-console/**").permitAll()
-            .requestMatchers("/api/auth/**").permitAll()
-            .requestMatchers("/api/dev/**").permitAll() // 개발용 API
-            .requestMatchers("/oauth2/**").permitAll()
-            .requestMatchers("/login/**").permitAll()
-            .requestMatchers("/oauth/callback", "/oauth/test").permitAll()
-            .requestMatchers("/swagger-ui/**", "/v3/api-docs/**").permitAll()
-            .anyRequest().authenticated())
+        .authorizeHttpRequests(auth -> {
+          auth
+              .requestMatchers("/", "/error", "/favicon.ico").permitAll()
+              .requestMatchers("/h2-console/**").permitAll()
+              .requestMatchers("/api/auth/**").permitAll();
+
+          // dev 또는 local 프로파일일 때만 개발용 API 허용
+          if (Arrays.asList(environment.getActiveProfiles()).contains("dev") ||
+              Arrays.asList(environment.getActiveProfiles()).contains("local")) {
+            auth.requestMatchers("/api/dev/**").permitAll();
+          }
+
+          auth
+              .requestMatchers("/oauth2/**").permitAll()
+              .requestMatchers("/login/**").permitAll()
+              .requestMatchers("/oauth/callback", "/oauth/test").permitAll()
+              .requestMatchers("/swagger-ui/**", "/v3/api-docs/**").permitAll()
+              .anyRequest().authenticated();
+        })
         .headers(headers -> headers
             .frameOptions(frameOptions -> frameOptions.sameOrigin()))
         .oauth2Login(oauth2 -> oauth2

--- a/src/main/java/kr/santanrudolph/everyvent/global/config/SecurityConfig.java
+++ b/src/main/java/kr/santanrudolph/everyvent/global/config/SecurityConfig.java
@@ -12,7 +12,6 @@ import org.springframework.security.config.annotation.web.configuration.EnableWe
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
-import java.util.Arrays;
 
 @Configuration
 @EnableWebSecurity
@@ -38,9 +37,8 @@ public class SecurityConfig {
               .requestMatchers("/h2-console/**").permitAll()
               .requestMatchers("/api/auth/**").permitAll();
 
-          // dev 또는 local 프로파일일 때만 개발용 API 허용
-          if (Arrays.asList(environment.getActiveProfiles()).contains("dev") ||
-              Arrays.asList(environment.getActiveProfiles()).contains("local")) {
+          // dev 또는 local 프로파일일 때만 개발용 API 허용 (활성/기본 프로파일 모두 고려)
+          if (environment.acceptsProfiles("dev", "local")) {
             auth.requestMatchers("/api/dev/**").permitAll();
           }
 

--- a/src/main/java/kr/santanrudolph/everyvent/global/exception/ErrorCode.java
+++ b/src/main/java/kr/santanrudolph/everyvent/global/exception/ErrorCode.java
@@ -73,15 +73,6 @@ public enum ErrorCode {
   /*                                                                                                 */
   /*=================================================================================================*/
 
-  // 공통 에러
-  @Deprecated INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST, "잘못된 입력값입니다."),
-  @Deprecated INVALID_TYPE_VALUE(HttpStatus.BAD_REQUEST, "잘못된 타입입니다."),
-  @Deprecated HANDLE_ACCESS_DENIED(HttpStatus.FORBIDDEN, "접근이 거부되었습니다."),
-
-  // 사용자 에러
-  @Deprecated USER_ALREADY_DELETED(HttpStatus.BAD_REQUEST, "이미 탈퇴한 사용자입니다."),
-  @Deprecated INVALID_USER_INFO(HttpStatus.BAD_REQUEST, "잘못된 사용자 정보입니다."),
-
   // 캘린더 에러
   @Deprecated CALENDAR_NOT_FOUND(HttpStatus.NOT_FOUND, "캘린더를 찾을 수 없습니다."),
   @Deprecated MAX_CALENDAR_EXCEEDED(HttpStatus.BAD_REQUEST, "캘린더는 최대 3개까지 생성할 수 있습니다."),
@@ -95,23 +86,7 @@ public enum ErrorCode {
   @Deprecated TASK_NOT_ACCESSIBLE_YET(HttpStatus.BAD_REQUEST, "아직 열람할 수 없는 태스크입니다."),
   @Deprecated INVALID_TASK_DATE(HttpStatus.BAD_REQUEST, "유효하지 않은 태스크 날짜입니다. (1-25일)"),
   @Deprecated TASK_ALREADY_COMPLETED(HttpStatus.BAD_REQUEST, "이미 완료된 태스크입니다."),
-  @Deprecated TASK_ACCESS_DENIED(HttpStatus.FORBIDDEN, "태스크에 접근할 권한이 없습니다."),
-
-  // 스크랩 에러
-  @Deprecated SCRAP_NOT_FOUND(HttpStatus.NOT_FOUND, "스크랩을 찾을 수 없습니다."),
-  @Deprecated ALREADY_SCRAPPED(HttpStatus.BAD_REQUEST, "이미 스크랩한 캘린더입니다."),
-  @Deprecated CANNOT_SCRAP_OWN_CALENDAR(HttpStatus.BAD_REQUEST, "본인의 캘린더는 스크랩할 수 없습니다."),
-  @Deprecated SCRAP_NOT_AVAILABLE_YET(HttpStatus.BAD_REQUEST, "스크랩할 수 있는 기간이 아닙니다."),
-
-  // 팔로우 에러
-  @Deprecated FOLLOW_NOT_FOUND(HttpStatus.NOT_FOUND, "팔로우 관계를 찾을 수 없습니다."),
-  @Deprecated ALREADY_FOLLOWING(HttpStatus.BAD_REQUEST, "이미 팔로우한 사용자입니다."),
-  @Deprecated CANNOT_FOLLOW_SELF(HttpStatus.BAD_REQUEST, "자기 자신을 팔로우할 수 없습니다."),
-
-  // OAuth 에러
-  @Deprecated OAUTH_PROVIDER_NOT_SUPPORTED(HttpStatus.BAD_REQUEST, "지원하지 않는 소셜 로그인입니다."),
-  @Deprecated OAUTH_AUTHENTICATION_FAILED(HttpStatus.UNAUTHORIZED, "소셜 로그인에 실패했습니다."),
-  @Deprecated OAUTH_USER_INFO_FETCH_FAILED(HttpStatus.BAD_REQUEST, "사용자 정보를 가져오는데 실패했습니다.");
+  @Deprecated TASK_ACCESS_DENIED(HttpStatus.FORBIDDEN, "태스크에 접근할 권한이 없습니다.");
 
   private final HttpStatus httpStatus;
   private final String message;

--- a/src/test/java/kr/santanrudolph/everyvent/domain/follow/FollowRepositoryTest.java
+++ b/src/test/java/kr/santanrudolph/everyvent/domain/follow/FollowRepositoryTest.java
@@ -9,7 +9,6 @@ import kr.santanrudolph.everyvent.domain.user.SocialProvider;
 import kr.santanrudolph.everyvent.domain.user.User;
 import kr.santanrudolph.everyvent.domain.user.UserRepository;
 import kr.santanrudolph.everyvent.global.config.JpaConfig;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -100,7 +99,6 @@ class FollowRepositoryTest {
 
       // then
       assertThat(result).isEmpty();
-
     }
 
     @DisplayName("탈퇴하지 않은 팔로워와의 관계만 반환한다.")
@@ -129,20 +127,64 @@ class FollowRepositoryTest {
 
   @Nested
   @DisplayName("팔로잉 목록 조회 테스트")
-  class findFollowingsTest {
-
-
-    @BeforeEach
-    void setUp() {
-      User follower = createAndSaveUser("follower");
-    }
-
+  class FindFollowingsTest {
 
     @DisplayName("팔로잉하는 사람의 id와 닉네임 목록을 조회한다.")
     @Test
     public void findFollowings() {
+      // given
+      User follower = createAndSaveUser("follower");
+      User target1 = createAndSaveUser("target1");
+      User target2 = createAndSaveUser("target2");
 
+      Follow follow1 = createAndSaveFollow(follower, target1);
+      Follow follow2 = createAndSaveFollow(follower, target2);
+
+      // when
+      List<FollowResponse> result = followRepository.findActiveFollowingsByFollowerId(
+          follower.getId());
+
+      // then
+      assertThat(result).hasSize(2)
+          .extracting("id", "user.id", "user.nickname")
+          .containsExactlyInAnyOrder(
+              tuple(follow1.getId(), target1.getId(), target1.getNickname()),
+              tuple(follow2.getId(), target2.getId(), target2.getNickname()));
     }
+
+    @DisplayName("팔로잉 하는 사람이 없으면 빈 리스트를 반환한다.")
+    @Test
+    public void findFollowings_whenNoFollowings_thenReturnsEmptyList() {
+      // given
+      User follower = createAndSaveUser("follower");
+
+      // when
+      List<FollowResponse> result = followRepository.findActiveFollowingsByFollowerId(follower.getId());
+
+      // then
+      assertThat(result).isEmpty();
+    }
+
+    @DisplayName("탈퇴하지 않은 팔로잉 대상과의 관계만 반환한다.")
+    @Test
+    public void findFollowings_whenFollowingDeleted_thenReturnsOnlyActiveFollowings() {
+      // given
+      User follower = createAndSaveUser("follower");
+      User target1 = createAndSaveUser("target1");
+      User target2 = createAndSaveDeletedUser("target2");
+
+      Follow follow1 = createAndSaveFollow(follower, target1);
+      Follow follow2 = createAndSaveFollow(follower, target2);
+
+      // when
+      List<FollowResponse> result = followRepository.findActiveFollowingsByFollowerId(follower.getId());
+
+      // then
+      assertThat(result).hasSize(1)
+          .extracting("id", "user.id", "user.nickname")
+          .containsExactly(tuple(follow1.getId(), target1.getId(), target1.getNickname()));
+    }
+
   }
 
 

--- a/src/test/java/kr/santanrudolph/everyvent/domain/follow/FollowRepositoryTest.java
+++ b/src/test/java/kr/santanrudolph/everyvent/domain/follow/FollowRepositoryTest.java
@@ -4,10 +4,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.tuple;
 
 import java.util.List;
+import kr.santanrudolph.everyvent.domain.follow.dto.FollowResponse;
 import kr.santanrudolph.everyvent.domain.user.SocialProvider;
 import kr.santanrudolph.everyvent.domain.user.User;
 import kr.santanrudolph.everyvent.domain.user.UserRepository;
-import kr.santanrudolph.everyvent.domain.user.dto.response.UserBasicResponse;
 import kr.santanrudolph.everyvent.global.config.JpaConfig;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -65,7 +65,7 @@ class FollowRepositoryTest {
   @DisplayName("팔로워 목록 조회 테스트")
   class FindFollowersTest {
 
-    @DisplayName("팔로워의 id와 닉네임 목록을 조회한다.")
+    @DisplayName("Follow id, 팔로워의 id, 닉네임 목록을 조회한다.")
     @Test
     public void findFollowers() {
       // given
@@ -77,15 +77,15 @@ class FollowRepositoryTest {
       Follow follow2 = createAndSaveFollow(follower2, target);
 
       // when
-      List<UserBasicResponse> result = followRepository.findActiveFollowersBasicByTargetId(
+      List<FollowResponse> result = followRepository.findActiveFollowersByTargetId(
           target.getId());
 
       // then
       assertThat(result).hasSize(2)
-          .extracting("id", "nickname")
+          .extracting("id", "user.id", "user.nickname")
           .containsExactlyInAnyOrder(
-              tuple(follower1.getId(), "follower1"),
-              tuple(follower2.getId(), "follower2"));
+              tuple(follow1.getId(), follower1.getId(), "follower1"),
+              tuple(follow2.getId(), follower2.getId(), "follower2"));
     }
 
     @DisplayName("팔로워가 없으면 빈 리스트를 반환한다.")
@@ -95,7 +95,7 @@ class FollowRepositoryTest {
       User target = createAndSaveUser("target");
 
       // when
-      List<UserBasicResponse> result = followRepository.findActiveFollowersBasicByTargetId(
+      List<FollowResponse> result = followRepository.findActiveFollowersByTargetId(
           target.getId());
 
       // then
@@ -115,13 +115,13 @@ class FollowRepositoryTest {
       Follow follow2 = createAndSaveFollow(deletedUser, target);
 
       // when
-      List<UserBasicResponse> result = followRepository.findActiveFollowersBasicByTargetId(
+      List<FollowResponse> result = followRepository.findActiveFollowersByTargetId(
           target.getId());
 
       // then
       assertThat(result).hasSize(1)
-          .extracting("nickname")
-          .containsExactly("activeUser");
+          .extracting("id", "user.id", "user.nickname")
+          .containsExactly(tuple(follow1.getId(), activeUser.getId(), activeUser.getNickname()));
 
     }
 
@@ -130,7 +130,6 @@ class FollowRepositoryTest {
   @Nested
   @DisplayName("팔로잉 목록 조회 테스트")
   class findFollowingsTest {
-
 
 
     @BeforeEach

--- a/src/test/java/kr/santanrudolph/everyvent/domain/follow/FollowRepositoryTest.java
+++ b/src/test/java/kr/santanrudolph/everyvent/domain/follow/FollowRepositoryTest.java
@@ -1,0 +1,130 @@
+package kr.santanrudolph.everyvent.domain.follow;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.tuple;
+
+import java.util.List;
+import kr.santanrudolph.everyvent.domain.user.SocialProvider;
+import kr.santanrudolph.everyvent.domain.user.User;
+import kr.santanrudolph.everyvent.domain.user.UserRepository;
+import kr.santanrudolph.everyvent.domain.user.dto.response.UserBasicResponse;
+import kr.santanrudolph.everyvent.global.config.JpaConfig;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.context.annotation.Import;
+
+@DataJpaTest
+@DisplayName("FollowRepository 테스트")
+@Import(JpaConfig.class) // DataJpaTest는 JPA 관련 빈만 로딩한다. Config 빈은 따로 임포트 필요
+class FollowRepositoryTest {
+
+  @Autowired
+  private FollowRepository followRepository;
+
+  @Autowired
+  private UserRepository userRepository;
+
+  @Autowired
+  private TestEntityManager entityManager;
+
+  // helper methods
+  private User createAndSaveUser(String nickname) {
+    User user = User.createFromOAuth(
+        "social_id_" + nickname,
+        SocialProvider.KAKAO,
+        nickname + "@test.com",
+        nickname
+    );
+    return userRepository.save(user);
+  }
+
+  private User createAndSaveDeletedUser(String nickname) {
+    User user = User.createFromOAuth(
+        "social_id_" + nickname,
+        SocialProvider.KAKAO,
+        nickname + "@test.com",
+        nickname
+    );
+    user.softDelete();
+    return userRepository.save(user);
+  }
+
+  private Follow createAndSaveFollow(User follower, User target) {
+    Follow follow = Follow.create(follower, target);
+    entityManager.persist(follow);
+    entityManager.flush();
+    return follow;
+  }
+
+  @Nested
+  @DisplayName("팔로워 목록 조회 테스트")
+  class FindFollowersTest {
+
+    @DisplayName("팔로워의 id와 닉네임 목록을 조회한다.")
+    @Test
+    public void findFollowers() {
+      // given
+      User target = createAndSaveUser("target");
+      User follower1 = createAndSaveUser("follower1");
+      User follower2 = createAndSaveUser("follower2");
+
+      Follow follow1 = createAndSaveFollow(follower1, target);
+      Follow follow2 = createAndSaveFollow(follower2, target);
+
+      // when
+      List<UserBasicResponse> result = followRepository.findActiveFollowersBasicByTargetId(
+          target.getId());
+
+      // then
+      assertThat(result).hasSize(2)
+          .extracting("id", "nickname")
+          .containsExactlyInAnyOrder(
+              tuple(follower1.getId(), "follower1"),
+              tuple(follower2.getId(), "follower2"));
+    }
+
+    @DisplayName("팔로워가 없으면 빈 리스트를 반환한다.")
+    @Test
+    public void findFollowers_whenNoFollowers_returnsEmptyList() {
+      // given
+      User target = createAndSaveUser("target");
+
+      // when
+      List<UserBasicResponse> result = followRepository.findActiveFollowersBasicByTargetId(
+          target.getId());
+
+      // then
+      assertThat(result).isEmpty();
+
+    }
+
+    @DisplayName("탈퇴하지 않은 팔로워와의 관계만 반환한다.")
+    @Test
+    public void findFollowers_whenFollowerDeleted_thenReturnsOnlyActiveFollowers() {
+      // given
+      User target = createAndSaveUser("target");
+      User activeUser = createAndSaveUser("activeUser");
+      User deletedUser = createAndSaveDeletedUser("deletedUser");
+
+      Follow follow1 = createAndSaveFollow(activeUser, target);
+      Follow follow2 = createAndSaveFollow(deletedUser, target);
+
+      // when
+      List<UserBasicResponse> result = followRepository.findActiveFollowersBasicByTargetId(
+          target.getId());
+
+      // then
+      assertThat(result).hasSize(1)
+          .extracting("nickname")
+          .containsExactly("activeUser");
+
+    }
+
+  }
+
+
+}

--- a/src/test/java/kr/santanrudolph/everyvent/domain/follow/FollowRepositoryTest.java
+++ b/src/test/java/kr/santanrudolph/everyvent/domain/follow/FollowRepositoryTest.java
@@ -5,7 +5,7 @@ import static org.assertj.core.api.AssertionsForClassTypes.tuple;
 
 import java.util.List;
 import kr.santanrudolph.everyvent.domain.follow.dto.FollowResponse;
-import kr.santanrudolph.everyvent.domain.user.SocialProvider;
+import kr.santanrudolph.everyvent.domain.user.enums.SocialProvider;
 import kr.santanrudolph.everyvent.domain.user.User;
 import kr.santanrudolph.everyvent.domain.user.UserRepository;
 import kr.santanrudolph.everyvent.global.config.JpaConfig;
@@ -64,9 +64,9 @@ class FollowRepositoryTest {
   @DisplayName("팔로워 목록 조회 테스트")
   class FindFollowersTest {
 
-    @DisplayName("Follow id, 팔로워의 id, 닉네임 목록을 조회한다.")
+    @DisplayName("follow_id, follower_id, follower_nickname 목록을 조회한다.")
     @Test
-    public void findFollowers() {
+    void findFollowers_Success() {
       // given
       User target = createAndSaveUser("target");
       User follower1 = createAndSaveUser("follower1");
@@ -89,7 +89,7 @@ class FollowRepositoryTest {
 
     @DisplayName("팔로워가 없으면 빈 리스트를 반환한다.")
     @Test
-    public void findFollowers_whenNoFollowers_returnsEmptyList() {
+    void findFollowers_whenNoFollowers_returnsEmptyList() {
       // given
       User target = createAndSaveUser("target");
 
@@ -103,7 +103,7 @@ class FollowRepositoryTest {
 
     @DisplayName("탈퇴하지 않은 팔로워와의 관계만 반환한다.")
     @Test
-    public void findFollowers_whenFollowerDeleted_thenReturnsOnlyActiveFollowers() {
+    void findFollowers_whenFollowerDeleted_thenReturnsOnlyActiveFollowers() {
       // given
       User target = createAndSaveUser("target");
       User activeUser = createAndSaveUser("activeUser");
@@ -129,9 +129,9 @@ class FollowRepositoryTest {
   @DisplayName("팔로잉 목록 조회 테스트")
   class FindFollowingsTest {
 
-    @DisplayName("팔로잉하는 사람의 id와 닉네임 목록을 조회한다.")
+    @DisplayName("follow_id, target_id, target_nickname 목록을 조회한다.")
     @Test
-    public void findFollowings() {
+    void findFollowings_Success() {
       // given
       User follower = createAndSaveUser("follower");
       User target1 = createAndSaveUser("target1");
@@ -154,12 +154,13 @@ class FollowRepositoryTest {
 
     @DisplayName("팔로잉 하는 사람이 없으면 빈 리스트를 반환한다.")
     @Test
-    public void findFollowings_whenNoFollowings_thenReturnsEmptyList() {
+    void findFollowings_whenNoFollowings_thenReturnsEmptyList() {
       // given
       User follower = createAndSaveUser("follower");
 
       // when
-      List<FollowResponse> result = followRepository.findActiveFollowingsByFollowerId(follower.getId());
+      List<FollowResponse> result = followRepository.findActiveFollowingsByFollowerId(
+          follower.getId());
 
       // then
       assertThat(result).isEmpty();
@@ -167,7 +168,7 @@ class FollowRepositoryTest {
 
     @DisplayName("탈퇴하지 않은 팔로잉 대상과의 관계만 반환한다.")
     @Test
-    public void findFollowings_whenFollowingDeleted_thenReturnsOnlyActiveFollowings() {
+    void findFollowings_whenFollowingDeleted_thenReturnsOnlyActiveFollowings() {
       // given
       User follower = createAndSaveUser("follower");
       User target1 = createAndSaveUser("target1");
@@ -177,7 +178,8 @@ class FollowRepositoryTest {
       Follow follow2 = createAndSaveFollow(follower, target2);
 
       // when
-      List<FollowResponse> result = followRepository.findActiveFollowingsByFollowerId(follower.getId());
+      List<FollowResponse> result = followRepository.findActiveFollowingsByFollowerId(
+          follower.getId());
 
       // then
       assertThat(result).hasSize(1)
@@ -186,6 +188,5 @@ class FollowRepositoryTest {
     }
 
   }
-
 
 }

--- a/src/test/java/kr/santanrudolph/everyvent/domain/follow/FollowRepositoryTest.java
+++ b/src/test/java/kr/santanrudolph/everyvent/domain/follow/FollowRepositoryTest.java
@@ -9,6 +9,7 @@ import kr.santanrudolph.everyvent.domain.user.User;
 import kr.santanrudolph.everyvent.domain.user.UserRepository;
 import kr.santanrudolph.everyvent.domain.user.dto.response.UserBasicResponse;
 import kr.santanrudolph.everyvent.global.config.JpaConfig;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -124,6 +125,25 @@ class FollowRepositoryTest {
 
     }
 
+  }
+
+  @Nested
+  @DisplayName("팔로잉 목록 조회 테스트")
+  class findFollowingsTest {
+
+
+
+    @BeforeEach
+    void setUp() {
+      User follower = createAndSaveUser("follower");
+    }
+
+
+    @DisplayName("팔로잉하는 사람의 id와 닉네임 목록을 조회한다.")
+    @Test
+    public void findFollowings() {
+
+    }
   }
 
 

--- a/src/test/java/kr/santanrudolph/everyvent/domain/follow/FollowServiceTest.java
+++ b/src/test/java/kr/santanrudolph/everyvent/domain/follow/FollowServiceTest.java
@@ -13,7 +13,7 @@ import static org.mockito.Mockito.times;
 import java.lang.reflect.Field;
 import java.util.List;
 import java.util.Optional;
-import kr.santanrudolph.everyvent.domain.follow.dto.FollowCreateCommand;
+import kr.santanrudolph.everyvent.domain.follow.command.FollowCreateCommand;
 import kr.santanrudolph.everyvent.domain.follow.dto.FollowCreateResponse;
 import kr.santanrudolph.everyvent.domain.follow.dto.FollowResponse;
 import kr.santanrudolph.everyvent.domain.user.enums.SocialProvider;

--- a/src/test/java/kr/santanrudolph/everyvent/domain/follow/FollowServiceTest.java
+++ b/src/test/java/kr/santanrudolph/everyvent/domain/follow/FollowServiceTest.java
@@ -1,0 +1,201 @@
+package kr.santanrudolph.everyvent.domain.follow;
+
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+
+import java.lang.reflect.Field;
+import java.util.Optional;
+import kr.santanrudolph.everyvent.domain.follow.dto.FollowCreateCommand;
+import kr.santanrudolph.everyvent.domain.follow.dto.FollowCreateResponse;
+import kr.santanrudolph.everyvent.domain.user.SocialProvider;
+import kr.santanrudolph.everyvent.domain.user.User;
+import kr.santanrudolph.everyvent.domain.user.UserRepository;
+import kr.santanrudolph.everyvent.global.exception.ErrorCode;
+import kr.santanrudolph.everyvent.global.exception.EveryventException;
+import org.apache.commons.lang3.reflect.FieldUtils;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("FollowService 단위 테스트")
+class FollowServiceTest {
+
+  @Mock
+  private FollowRepository followRepository;
+  @Mock
+  private UserRepository userRepository;
+  @InjectMocks
+  private FollowService followService;
+
+  // reflection field
+  private static final Field USER_ID_FIELD;
+  private static final Field FOLLOW_ID_FIELD;
+
+  static {
+    USER_ID_FIELD = FieldUtils.getField(User.class, "id", true);
+    USER_ID_FIELD.setAccessible(true);
+    FOLLOW_ID_FIELD = FieldUtils.getField(Follow.class, "id", true);
+    FOLLOW_ID_FIELD.setAccessible(true);
+  }
+
+
+  // helper method
+  private User createUser(Long id, String nickname) {
+    User user = User.createFromOAuth(
+        "test_socail_id_" + id,
+        SocialProvider.KAKAO,
+        nickname + "@test.com",
+        nickname
+    );
+
+    try {
+      USER_ID_FIELD.set(user, id);
+    } catch (IllegalAccessException e) {
+      throw new RuntimeException("테스트를 위한 유저 id 세팅에 실패했습니다.", e);
+    }
+
+    return user;
+  }
+
+  private Follow createFollow(User follower, User target, Long followId) {
+    Follow follow = Follow.create(follower, target);
+    try {
+      FOLLOW_ID_FIELD.set(follow, followId);
+    } catch (IllegalAccessException e) {
+      throw new RuntimeException("테스트용 Follow id 설정 실패", e);
+    }
+    return follow;
+  }
+
+
+  @DisplayName("팔로우 관계를 생성한다.")
+  @Test
+  void createFollow_Success() {
+    // given
+    Long followerId = 1L;
+    Long targetId = 2L;
+    Long followId = 3L;
+    FollowCreateCommand command = new FollowCreateCommand(followerId, targetId);
+
+    User follower = createUser(1L, "follower");
+    User target = createUser(2L, "target");
+    Follow expectedFollow = createFollow(follower, target, followId);
+
+    given(userRepository.findByIdAndDeletedAtIsNull(followerId)).willReturn(Optional.of(follower));
+    given(userRepository.findByIdAndDeletedAtIsNull(targetId)).willReturn(Optional.of(target));
+    given(followRepository.existsByFollowerIdAndTargetId(followerId, targetId)).willReturn(false);
+    given(followRepository.save(any(Follow.class))).willReturn(expectedFollow);
+
+    // when
+    FollowCreateResponse response = followService.createFollow(command);
+
+    // then
+    assertThat(response).isNotNull();
+    assertThat(response.followerId()).isEqualTo(followerId);
+    assertThat(response.targetId()).isEqualTo(targetId);
+    assertThat(response.followId()).isEqualTo(followId);
+
+    then(userRepository).should(times(1)).findByIdAndDeletedAtIsNull(followerId);
+    then(userRepository).should(times(1)).findByIdAndDeletedAtIsNull(targetId);
+    then(followRepository).should(times(1)).existsByFollowerIdAndTargetId(followerId, targetId);
+    ArgumentCaptor<Follow> followCaptor = ArgumentCaptor.forClass(Follow.class);
+    then(followRepository).should(times(1)).save(followCaptor.capture());
+    Follow savedFollow = followCaptor.getValue();
+    assertThat(savedFollow).isNotNull();
+    assertThat(savedFollow.getFollower()).isEqualTo(follower);
+    assertThat(savedFollow.getTarget()).isEqualTo(target);
+  }
+
+  @DisplayName("팔로우 생성 시 팔로워를 찾을 수 없으면 예외를 던진다.")
+  @Test
+  void createFollow_whenFollowerNotFound_thenThrowsException() {
+    // given
+    Long followerId = 1L;
+    Long targetId = 2L;
+    FollowCreateCommand command = new FollowCreateCommand(followerId, targetId);
+
+    given(userRepository.findByIdAndDeletedAtIsNull(followerId)).willReturn(Optional.empty());
+
+    // when & then
+    assertThatThrownBy(() -> followService.createFollow(command))
+        .isInstanceOf(EveryventException.class)
+        .extracting("errorCode", "detail")
+        .containsExactly(
+            ErrorCode.NOT_FOUND,
+            "팔로워 id를 찾을 수 없습니다."
+        );
+
+    then(userRepository).should(times(1)).findByIdAndDeletedAtIsNull(followerId);
+    then(userRepository).should(never()).findByIdAndDeletedAtIsNull(targetId);
+    then(followRepository).should(never()).existsByFollowerIdAndTargetId(any(), any());
+    then(followRepository).should(never()).save(any(Follow.class));
+  }
+
+  @DisplayName("팔로우 생성 시 팔로우 대상을 찾을 수 없으면 예외를 던진다.")
+  @Test
+  void createFollow_whenTargetNotFound_thenThrowsException() {
+    // given
+    Long followerId = 1L;
+    Long targetId = 2L;
+    FollowCreateCommand command = new FollowCreateCommand(followerId, targetId);
+    User follower = createUser(1L, "follower");
+
+    given(userRepository.findByIdAndDeletedAtIsNull(followerId)).willReturn(Optional.of(follower));
+    given(userRepository.findByIdAndDeletedAtIsNull(targetId)).willReturn(Optional.empty());
+
+    // when & then
+    assertThatThrownBy(() -> followService.createFollow(command))
+        .isInstanceOf(EveryventException.class)
+        .extracting("errorCode", "detail")
+        .containsExactly(
+            ErrorCode.NOT_FOUND,
+            "팔로우 대상 id를 찾을 수 없습니다."
+        );
+
+    then(userRepository).should(times(1)).findByIdAndDeletedAtIsNull(followerId);
+    then(userRepository).should(times(1)).findByIdAndDeletedAtIsNull(targetId);
+    then(followRepository).should(never()).existsByFollowerIdAndTargetId(any(), any());
+    then(followRepository).should(never()).save(any(Follow.class));
+  }
+
+  @DisplayName("팔로우 생성 시 이미 팔로우 중이면 예외를 던진다.")
+  @Test
+  void createFollow_whenFollowExists_thenThrowsException() {
+    // given
+    Long followerId = 1L;
+    Long targetId = 2L;
+    FollowCreateCommand command = new FollowCreateCommand(followerId, targetId);
+    User follower = createUser(1L, "follower");
+    User target = createUser(2L, "target");
+
+    given(userRepository.findByIdAndDeletedAtIsNull(followerId)).willReturn(Optional.of(follower));
+    given(userRepository.findByIdAndDeletedAtIsNull(targetId)).willReturn(Optional.of(target));
+    given(followRepository.existsByFollowerIdAndTargetId(followerId, targetId)).willReturn(true);
+
+    // when & then
+    assertThatThrownBy(() -> followService.createFollow(command))
+        .isInstanceOf(EveryventException.class)
+        .extracting("errorCode", "detail")
+        .containsExactly(
+            ErrorCode.ALREADY_EXIST,
+            "이미 팔로우 중입니다."
+        );
+
+    then(userRepository).should(times(1)).findByIdAndDeletedAtIsNull(followerId);
+    then(userRepository).should(times(1)).findByIdAndDeletedAtIsNull(targetId);
+    then(followRepository).should(times(1)).existsByFollowerIdAndTargetId(followerId, targetId);
+    then(followRepository).should(never()).save(any(Follow.class));
+  }
+
+}

--- a/src/test/java/kr/santanrudolph/everyvent/domain/follow/FollowServiceTest.java
+++ b/src/test/java/kr/santanrudolph/everyvent/domain/follow/FollowServiceTest.java
@@ -19,7 +19,9 @@ import kr.santanrudolph.everyvent.domain.user.UserRepository;
 import kr.santanrudolph.everyvent.global.exception.ErrorCode;
 import kr.santanrudolph.everyvent.global.exception.EveryventException;
 import org.apache.commons.lang3.reflect.FieldUtils;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
@@ -41,13 +43,21 @@ class FollowServiceTest {
   // reflection field
   private static final Field USER_ID_FIELD;
   private static final Field FOLLOW_ID_FIELD;
-
   static {
     USER_ID_FIELD = FieldUtils.getField(User.class, "id", true);
     USER_ID_FIELD.setAccessible(true);
     FOLLOW_ID_FIELD = FieldUtils.getField(Follow.class, "id", true);
     FOLLOW_ID_FIELD.setAccessible(true);
   }
+
+  private static final Long FOLLOWER_ID = 1L;
+  private static final Long TARGET_ID = 2L;
+  private static final Long FOLLOW_ID = 3L;
+
+  // Test fixtures
+  private FollowCreateCommand command;
+  private User follower;
+  private User target;
 
 
   // helper method
@@ -78,124 +88,120 @@ class FollowServiceTest {
     return follow;
   }
 
+  @Nested
+  @DisplayName("Follow 관계 생성 테스트")
+  class CreateFollowTest{
+    @BeforeEach
+    void setUp() {
+      // 공통 테스트 픽스쳐 초기화
+      command = new FollowCreateCommand(FOLLOWER_ID, TARGET_ID);
 
-  @DisplayName("팔로우 관계를 생성한다.")
-  @Test
-  void createFollow_Success() {
-    // given
-    Long followerId = 1L;
-    Long targetId = 2L;
-    Long followId = 3L;
-    FollowCreateCommand command = new FollowCreateCommand(followerId, targetId);
+      follower = createUser(FOLLOWER_ID, "follower");
+      target = createUser(TARGET_ID, "target");
+    }
 
-    User follower = createUser(1L, "follower");
-    User target = createUser(2L, "target");
-    Follow expectedFollow = createFollow(follower, target, followId);
+    @DisplayName("팔로우 관계를 생성한다.")
+    @Test
+    void createFollow_Success() {
+      // given
+      Follow expectedFollow = createFollow(follower, target, FOLLOW_ID);
 
-    given(userRepository.findByIdAndDeletedAtIsNull(followerId)).willReturn(Optional.of(follower));
-    given(userRepository.findByIdAndDeletedAtIsNull(targetId)).willReturn(Optional.of(target));
-    given(followRepository.existsByFollowerIdAndTargetId(followerId, targetId)).willReturn(false);
-    given(followRepository.save(any(Follow.class))).willReturn(expectedFollow);
+      given(userRepository.findByIdAndDeletedAtIsNull(FOLLOWER_ID)).willReturn(Optional.of(follower));
+      given(userRepository.findByIdAndDeletedAtIsNull(TARGET_ID)).willReturn(Optional.of(target));
+      given(followRepository.existsByFollowerIdAndTargetId(FOLLOWER_ID, TARGET_ID)).willReturn(false);
+      given(followRepository.save(any(Follow.class))).willReturn(expectedFollow);
 
-    // when
-    FollowCreateResponse response = followService.createFollow(command);
+      // when
+      FollowCreateResponse response = followService.createFollow(command);
 
-    // then
-    assertThat(response).isNotNull();
-    assertThat(response.followerId()).isEqualTo(followerId);
-    assertThat(response.targetId()).isEqualTo(targetId);
-    assertThat(response.followId()).isEqualTo(followId);
+      // then
+      assertThat(response).isNotNull();
+      assertThat(response.followerId()).isEqualTo(FOLLOWER_ID);
+      assertThat(response.targetId()).isEqualTo(TARGET_ID);
+      assertThat(response.followId()).isEqualTo(FOLLOW_ID);
 
-    then(userRepository).should(times(1)).findByIdAndDeletedAtIsNull(followerId);
-    then(userRepository).should(times(1)).findByIdAndDeletedAtIsNull(targetId);
-    then(followRepository).should(times(1)).existsByFollowerIdAndTargetId(followerId, targetId);
-    ArgumentCaptor<Follow> followCaptor = ArgumentCaptor.forClass(Follow.class);
-    then(followRepository).should(times(1)).save(followCaptor.capture());
-    Follow savedFollow = followCaptor.getValue();
-    assertThat(savedFollow).isNotNull();
-    assertThat(savedFollow.getFollower()).isEqualTo(follower);
-    assertThat(savedFollow.getTarget()).isEqualTo(target);
+      then(userRepository).should(times(1)).findByIdAndDeletedAtIsNull(FOLLOWER_ID);
+      then(userRepository).should(times(1)).findByIdAndDeletedAtIsNull(TARGET_ID);
+
+      then(followRepository).should(times(1)).existsByFollowerIdAndTargetId(FOLLOWER_ID, TARGET_ID);
+      ArgumentCaptor<Follow> followCaptor = ArgumentCaptor.forClass(Follow.class);
+      then(followRepository).should(times(1)).save(followCaptor.capture());
+      Follow savedFollow = followCaptor.getValue();
+      assertThat(savedFollow).isNotNull();
+      assertThat(savedFollow.getFollower()).isEqualTo(follower);
+      assertThat(savedFollow.getTarget()).isEqualTo(target);
+    }
+
+    @DisplayName("팔로워를 찾을 수 없으면 예외를 던진다.")
+    @Test
+    void createFollow_whenFollowerNotFound_thenThrowsException() {
+      // given
+      given(userRepository.findByIdAndDeletedAtIsNull(FOLLOWER_ID)).willReturn(Optional.empty());
+
+      // when & then
+      assertThatThrownBy(() -> followService.createFollow(command))
+          .isInstanceOf(EveryventException.class)
+          .extracting("errorCode", "detail")
+          .containsExactly(
+              ErrorCode.NOT_FOUND,
+              "팔로워 id를 찾을 수 없습니다."
+          );
+
+      then(userRepository).should(times(1)).findByIdAndDeletedAtIsNull(FOLLOWER_ID);
+      then(userRepository).should(never()).findByIdAndDeletedAtIsNull(TARGET_ID);
+
+      then(followRepository).should(never()).existsByFollowerIdAndTargetId(any(), any());
+      then(followRepository).should(never()).save(any(Follow.class));
+    }
+
+    @DisplayName("팔로우 대상을 찾을 수 없으면 예외를 던진다.")
+    @Test
+    void createFollow_whenTargetNotFound_thenThrowsException() {
+      // given
+      given(userRepository.findByIdAndDeletedAtIsNull(FOLLOWER_ID)).willReturn(Optional.of(follower));
+      given(userRepository.findByIdAndDeletedAtIsNull(TARGET_ID)).willReturn(Optional.empty());
+
+      // when & then
+      assertThatThrownBy(() -> followService.createFollow(command))
+          .isInstanceOf(EveryventException.class)
+          .extracting("errorCode", "detail")
+          .containsExactly(
+              ErrorCode.NOT_FOUND,
+              "팔로우 대상 id를 찾을 수 없습니다."
+          );
+
+      then(userRepository).should(times(1)).findByIdAndDeletedAtIsNull(FOLLOWER_ID);
+      then(userRepository).should(times(1)).findByIdAndDeletedAtIsNull(TARGET_ID);
+
+      then(followRepository).should(never()).existsByFollowerIdAndTargetId(any(), any());
+      then(followRepository).should(never()).save(any(Follow.class));
+    }
+
+    @DisplayName("이미 팔로우 중이면 예외를 던진다.")
+    @Test
+    void createFollow_whenFollowExists_thenThrowsException() {
+      // given
+      given(userRepository.findByIdAndDeletedAtIsNull(FOLLOWER_ID)).willReturn(Optional.of(follower));
+      given(userRepository.findByIdAndDeletedAtIsNull(TARGET_ID)).willReturn(Optional.of(target));
+      given(followRepository.existsByFollowerIdAndTargetId(FOLLOWER_ID, TARGET_ID)).willReturn(true);
+
+      // when & then
+      assertThatThrownBy(() -> followService.createFollow(command))
+          .isInstanceOf(EveryventException.class)
+          .extracting("errorCode", "detail")
+          .containsExactly(
+              ErrorCode.ALREADY_EXIST,
+              "이미 팔로우 중입니다."
+          );
+
+      then(userRepository).should(times(1)).findByIdAndDeletedAtIsNull(FOLLOWER_ID);
+      then(userRepository).should(times(1)).findByIdAndDeletedAtIsNull(TARGET_ID);
+
+      then(followRepository).should(times(1)).existsByFollowerIdAndTargetId(FOLLOWER_ID, TARGET_ID);
+      then(followRepository).should(never()).save(any(Follow.class));
+    }
   }
 
-  @DisplayName("팔로우 생성 시 팔로워를 찾을 수 없으면 예외를 던진다.")
-  @Test
-  void createFollow_whenFollowerNotFound_thenThrowsException() {
-    // given
-    Long followerId = 1L;
-    Long targetId = 2L;
-    FollowCreateCommand command = new FollowCreateCommand(followerId, targetId);
 
-    given(userRepository.findByIdAndDeletedAtIsNull(followerId)).willReturn(Optional.empty());
-
-    // when & then
-    assertThatThrownBy(() -> followService.createFollow(command))
-        .isInstanceOf(EveryventException.class)
-        .extracting("errorCode", "detail")
-        .containsExactly(
-            ErrorCode.NOT_FOUND,
-            "팔로워 id를 찾을 수 없습니다."
-        );
-
-    then(userRepository).should(times(1)).findByIdAndDeletedAtIsNull(followerId);
-    then(userRepository).should(never()).findByIdAndDeletedAtIsNull(targetId);
-    then(followRepository).should(never()).existsByFollowerIdAndTargetId(any(), any());
-    then(followRepository).should(never()).save(any(Follow.class));
-  }
-
-  @DisplayName("팔로우 생성 시 팔로우 대상을 찾을 수 없으면 예외를 던진다.")
-  @Test
-  void createFollow_whenTargetNotFound_thenThrowsException() {
-    // given
-    Long followerId = 1L;
-    Long targetId = 2L;
-    FollowCreateCommand command = new FollowCreateCommand(followerId, targetId);
-    User follower = createUser(1L, "follower");
-
-    given(userRepository.findByIdAndDeletedAtIsNull(followerId)).willReturn(Optional.of(follower));
-    given(userRepository.findByIdAndDeletedAtIsNull(targetId)).willReturn(Optional.empty());
-
-    // when & then
-    assertThatThrownBy(() -> followService.createFollow(command))
-        .isInstanceOf(EveryventException.class)
-        .extracting("errorCode", "detail")
-        .containsExactly(
-            ErrorCode.NOT_FOUND,
-            "팔로우 대상 id를 찾을 수 없습니다."
-        );
-
-    then(userRepository).should(times(1)).findByIdAndDeletedAtIsNull(followerId);
-    then(userRepository).should(times(1)).findByIdAndDeletedAtIsNull(targetId);
-    then(followRepository).should(never()).existsByFollowerIdAndTargetId(any(), any());
-    then(followRepository).should(never()).save(any(Follow.class));
-  }
-
-  @DisplayName("팔로우 생성 시 이미 팔로우 중이면 예외를 던진다.")
-  @Test
-  void createFollow_whenFollowExists_thenThrowsException() {
-    // given
-    Long followerId = 1L;
-    Long targetId = 2L;
-    FollowCreateCommand command = new FollowCreateCommand(followerId, targetId);
-    User follower = createUser(1L, "follower");
-    User target = createUser(2L, "target");
-
-    given(userRepository.findByIdAndDeletedAtIsNull(followerId)).willReturn(Optional.of(follower));
-    given(userRepository.findByIdAndDeletedAtIsNull(targetId)).willReturn(Optional.of(target));
-    given(followRepository.existsByFollowerIdAndTargetId(followerId, targetId)).willReturn(true);
-
-    // when & then
-    assertThatThrownBy(() -> followService.createFollow(command))
-        .isInstanceOf(EveryventException.class)
-        .extracting("errorCode", "detail")
-        .containsExactly(
-            ErrorCode.ALREADY_EXIST,
-            "이미 팔로우 중입니다."
-        );
-
-    then(userRepository).should(times(1)).findByIdAndDeletedAtIsNull(followerId);
-    then(userRepository).should(times(1)).findByIdAndDeletedAtIsNull(targetId);
-    then(followRepository).should(times(1)).existsByFollowerIdAndTargetId(followerId, targetId);
-    then(followRepository).should(never()).save(any(Follow.class));
-  }
 
 }

--- a/src/test/java/kr/santanrudolph/everyvent/domain/follow/FollowServiceTest.java
+++ b/src/test/java/kr/santanrudolph/everyvent/domain/follow/FollowServiceTest.java
@@ -3,6 +3,7 @@ package kr.santanrudolph.everyvent.domain.follow;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.AssertionsForClassTypes.tuple;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
@@ -10,10 +11,12 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 
 import java.lang.reflect.Field;
+import java.util.List;
 import java.util.Optional;
 import kr.santanrudolph.everyvent.domain.follow.dto.FollowCreateCommand;
 import kr.santanrudolph.everyvent.domain.follow.dto.FollowCreateResponse;
-import kr.santanrudolph.everyvent.domain.user.SocialProvider;
+import kr.santanrudolph.everyvent.domain.follow.dto.FollowResponse;
+import kr.santanrudolph.everyvent.domain.user.enums.SocialProvider;
 import kr.santanrudolph.everyvent.domain.user.User;
 import kr.santanrudolph.everyvent.domain.user.UserRepository;
 import kr.santanrudolph.everyvent.global.exception.ErrorCode;
@@ -43,6 +46,7 @@ class FollowServiceTest {
   // reflection field
   private static final Field USER_ID_FIELD;
   private static final Field FOLLOW_ID_FIELD;
+
   static {
     USER_ID_FIELD = FieldUtils.getField(User.class, "id", true);
     USER_ID_FIELD.setAccessible(true);
@@ -90,7 +94,8 @@ class FollowServiceTest {
 
   @Nested
   @DisplayName("Follow 관계 생성 테스트")
-  class CreateFollowTest{
+  class CreateFollowTest {
+
     @BeforeEach
     void setUp() {
       // 공통 테스트 픽스쳐 초기화
@@ -106,9 +111,11 @@ class FollowServiceTest {
       // given
       Follow expectedFollow = createFollow(follower, target, FOLLOW_ID);
 
-      given(userRepository.findByIdAndDeletedAtIsNull(FOLLOWER_ID)).willReturn(Optional.of(follower));
+      given(userRepository.findByIdAndDeletedAtIsNull(FOLLOWER_ID)).willReturn(Optional.of(
+          follower));
       given(userRepository.findByIdAndDeletedAtIsNull(TARGET_ID)).willReturn(Optional.of(target));
-      given(followRepository.existsByFollowerIdAndTargetId(FOLLOWER_ID, TARGET_ID)).willReturn(false);
+      given(followRepository.existsByFollowerIdAndTargetId(FOLLOWER_ID, TARGET_ID)).willReturn(
+          false);
       given(followRepository.save(any(Follow.class))).willReturn(expectedFollow);
 
       // when
@@ -123,7 +130,8 @@ class FollowServiceTest {
       then(userRepository).should(times(1)).findByIdAndDeletedAtIsNull(FOLLOWER_ID);
       then(userRepository).should(times(1)).findByIdAndDeletedAtIsNull(TARGET_ID);
 
-      then(followRepository).should(times(1)).existsByFollowerIdAndTargetId(FOLLOWER_ID, TARGET_ID);
+      then(followRepository).should(times(1)).existsByFollowerIdAndTargetId(FOLLOWER_ID,
+          TARGET_ID);
       ArgumentCaptor<Follow> followCaptor = ArgumentCaptor.forClass(Follow.class);
       then(followRepository).should(times(1)).save(followCaptor.capture());
       Follow savedFollow = followCaptor.getValue();
@@ -158,7 +166,8 @@ class FollowServiceTest {
     @Test
     void createFollow_whenTargetNotFound_thenThrowsException() {
       // given
-      given(userRepository.findByIdAndDeletedAtIsNull(FOLLOWER_ID)).willReturn(Optional.of(follower));
+      given(userRepository.findByIdAndDeletedAtIsNull(FOLLOWER_ID)).willReturn(Optional.of(
+          follower));
       given(userRepository.findByIdAndDeletedAtIsNull(TARGET_ID)).willReturn(Optional.empty());
 
       // when & then
@@ -181,9 +190,11 @@ class FollowServiceTest {
     @Test
     void createFollow_whenFollowExists_thenThrowsException() {
       // given
-      given(userRepository.findByIdAndDeletedAtIsNull(FOLLOWER_ID)).willReturn(Optional.of(follower));
+      given(userRepository.findByIdAndDeletedAtIsNull(FOLLOWER_ID)).willReturn(Optional.of(
+          follower));
       given(userRepository.findByIdAndDeletedAtIsNull(TARGET_ID)).willReturn(Optional.of(target));
-      given(followRepository.existsByFollowerIdAndTargetId(FOLLOWER_ID, TARGET_ID)).willReturn(true);
+      given(followRepository.existsByFollowerIdAndTargetId(FOLLOWER_ID, TARGET_ID)).willReturn(
+          true);
 
       // when & then
       assertThatThrownBy(() -> followService.createFollow(command))
@@ -197,11 +208,155 @@ class FollowServiceTest {
       then(userRepository).should(times(1)).findByIdAndDeletedAtIsNull(FOLLOWER_ID);
       then(userRepository).should(times(1)).findByIdAndDeletedAtIsNull(TARGET_ID);
 
-      then(followRepository).should(times(1)).existsByFollowerIdAndTargetId(FOLLOWER_ID, TARGET_ID);
+      then(followRepository).should(times(1)).existsByFollowerIdAndTargetId(FOLLOWER_ID,
+          TARGET_ID);
       then(followRepository).should(never()).save(any(Follow.class));
     }
   }
 
+  @Nested
+  @DisplayName("팔로워 목록 조회 테스트")
+  class GetFollowersTest {
 
+    @DisplayName("TARGET_ID로 팔로워 목록을 조회한다.")
+    @Test
+    void getFollowers_Success() {
+      // given
+      Long FOLLOWER_ID2 = 4L;
+      Long FOLLOW_ID2 = 5L;
+
+      target = createUser(TARGET_ID, "target");
+
+      List<FollowResponse> expectedFollowers = List.of(
+          new FollowResponse(FOLLOW_ID, FOLLOWER_ID, "follower1"),
+          new FollowResponse(FOLLOW_ID2, FOLLOWER_ID2, "follower2")
+      );
+
+      given(userRepository.findByIdAndDeletedAtIsNull(TARGET_ID)).willReturn(Optional.of(target));
+      given(followRepository.findActiveFollowersByTargetId(TARGET_ID)).willReturn(
+          expectedFollowers);
+
+      // when
+      List<FollowResponse> result = followService.getFollowers(TARGET_ID);
+
+      // then
+      assertThat(result)
+          .hasSize(2)
+          .extracting("id", "user.id", "user.nickname")
+          .containsExactly(
+              tuple(FOLLOW_ID, FOLLOWER_ID, "follower1"),
+              tuple(FOLLOW_ID2, FOLLOWER_ID2, "follower2"));
+      then(userRepository).should(times(1)).findByIdAndDeletedAtIsNull(TARGET_ID);
+      then(followRepository).should(times(1)).findActiveFollowersByTargetId(TARGET_ID);
+    }
+
+    @DisplayName("팔로워가 없으면 빈 리스트를 반환한다.")
+    @Test
+    void getFollowers_whenNoFollowers_thenReturnsEmptyList() {
+      // given
+      target = createUser(TARGET_ID, "target");
+      given(userRepository.findByIdAndDeletedAtIsNull(TARGET_ID)).willReturn(Optional.of(target));
+      given(followRepository.findActiveFollowersByTargetId(TARGET_ID)).willReturn(List.of());
+
+      // when
+      List<FollowResponse> result = followService.getFollowers(TARGET_ID);
+
+      // then
+      assertThat(result).isEmpty();
+      then(userRepository).should(times(1)).findByIdAndDeletedAtIsNull(TARGET_ID);
+      then(followRepository).should(times(1)).findActiveFollowersByTargetId(TARGET_ID);
+    }
+
+    @DisplayName("팔로워 정보를 가져올 사용자가 존재하지 않으면 예외를 던진다.")
+    @Test
+    void getFollowers_whenTargetNotFound_thenThrowsException() {
+      // given
+      given(userRepository.findByIdAndDeletedAtIsNull(TARGET_ID)).willReturn(Optional.empty());
+
+      // when & then
+      assertThatThrownBy(() -> followService.getFollowers(TARGET_ID))
+          .isInstanceOf(EveryventException.class)
+          .extracting("errorCode", "detail")
+          .containsExactly(ErrorCode.NOT_FOUND,
+              "팔로워 정보를 가져올 대상 사용자가 존재하지 않습니다. (ID: " + TARGET_ID + ")");
+      then(userRepository).should(times(1)).findByIdAndDeletedAtIsNull(TARGET_ID);
+      then(followRepository).should(never()).findActiveFollowersByTargetId(any());
+    }
+
+  }
+
+  @Nested
+  @DisplayName("팔로잉 목록 조회 테스트")
+  class GetFollowingsTest {
+
+    @DisplayName("FOLLOWER_ID로 팔로잉 목록을 조회한다.")
+    @Test
+    void getFollowings_Success() {
+      // given
+      Long TARGET_ID2 = 4L;
+      Long FOLLOW_ID2 = 5L;
+
+      follower = createUser(FOLLOWER_ID, "follower");
+
+      List<FollowResponse> expectedFollowings = List.of(
+          new FollowResponse(FOLLOW_ID, TARGET_ID, "target1"),
+          new FollowResponse(FOLLOW_ID2, TARGET_ID2, "target2")
+      );
+
+      given(userRepository.findByIdAndDeletedAtIsNull(FOLLOWER_ID)).willReturn(
+          Optional.of(follower));
+      given(followRepository.findActiveFollowingsByFollowerId(FOLLOWER_ID)).willReturn(
+          expectedFollowings);
+
+      // when
+      List<FollowResponse> result = followService.getFollowings(FOLLOWER_ID);
+
+      // then
+      assertThat(result)
+          .hasSize(2)
+          .extracting("id", "user.id", "user.nickname")
+          .containsExactly(
+              tuple(FOLLOW_ID, TARGET_ID, "target1"),
+              tuple(FOLLOW_ID2, TARGET_ID2, "target2"));
+      then(userRepository).should(times(1)).findByIdAndDeletedAtIsNull(FOLLOWER_ID);
+      then(followRepository).should(times(1)).findActiveFollowingsByFollowerId(FOLLOWER_ID);
+    }
+
+    @DisplayName("팔로잉하는 사람이 없으면 빈 리스트를 반환한다.")
+    @Test
+    void getFollowings_whenNoFollowings_thenReturnsEmptyList() {
+      // given
+      follower = createUser(FOLLOWER_ID, "follower");
+      given(userRepository.findByIdAndDeletedAtIsNull(FOLLOWER_ID)).willReturn(
+          Optional.of(follower));
+      given(followRepository.findActiveFollowingsByFollowerId(FOLLOWER_ID)).willReturn(List.of());
+
+      // when
+      List<FollowResponse> result = followService.getFollowings(FOLLOWER_ID);
+
+      // then
+      assertThat(result).isEmpty();
+      then(userRepository).should(times(1)).findByIdAndDeletedAtIsNull(FOLLOWER_ID);
+      then(followRepository).should(times(1)).findActiveFollowingsByFollowerId(FOLLOWER_ID);
+    }
+
+    @DisplayName("팔로잉 정보를 가져올 사용자가 존재하지 않으면 예외를 던진다.")
+    @Test
+    void getFollowings_whenFollowerNotFound_thenThrowsException() {
+      // given
+      given(userRepository.findByIdAndDeletedAtIsNull(FOLLOWER_ID)).willReturn(Optional.empty());
+
+      // when & then
+      assertThatThrownBy(() -> followService.getFollowings(FOLLOWER_ID))
+          .isInstanceOf(EveryventException.class)
+          .extracting("errorCode", "detail")
+          .containsExactly(ErrorCode.NOT_FOUND,
+              "팔로잉 정보를 가져올 대상 사용자가 존재하지 않습니다. (ID: " + FOLLOWER_ID + ")"
+          );
+      then(userRepository).should(times(1)).findByIdAndDeletedAtIsNull(FOLLOWER_ID);
+      then(followRepository).should(never()).findActiveFollowingsByFollowerId(any());
+    }
+
+  }
 
 }

--- a/src/test/java/kr/santanrudolph/everyvent/domain/follow/FollowServiceTest.java
+++ b/src/test/java/kr/santanrudolph/everyvent/domain/follow/FollowServiceTest.java
@@ -359,4 +359,89 @@ class FollowServiceTest {
 
   }
 
+  @Nested
+  @DisplayName("팔로우 관계 삭제 테스트")
+  class DeleteFollowTest {
+
+    @DisplayName("팔로우 관계를 삭제한다.")
+    @Test
+    void deleteFollow_Success() {
+      // given
+      given(userRepository.existsByIdAndDeletedAtIsNull(FOLLOWER_ID)).willReturn(true);
+      given(userRepository.existsByIdAndDeletedAtIsNull(TARGET_ID)).willReturn(true);
+      given(followRepository.deleteByFollowerIdAndTargetId(FOLLOWER_ID, TARGET_ID)).willReturn(1);
+
+      // when
+      followService.deleteFollow(FOLLOWER_ID, TARGET_ID);
+
+      // then
+      then(userRepository).should(times(1)).existsByIdAndDeletedAtIsNull(FOLLOWER_ID);
+      then(userRepository).should(times(1)).existsByIdAndDeletedAtIsNull(TARGET_ID);
+      then(followRepository).should(times(1)).deleteByFollowerIdAndTargetId(FOLLOWER_ID, TARGET_ID);
+    }
+
+    @DisplayName("팔로워 사용자가 존재하지 않으면 예외를 던진다.")
+    @Test
+    void deleteFollow_whenFollowerNotFound_throwsException() {
+      // given
+      given(userRepository.existsByIdAndDeletedAtIsNull(FOLLOWER_ID)).willReturn(false);
+
+      // when & then
+      assertThatThrownBy(() -> followService.deleteFollow(FOLLOWER_ID, TARGET_ID))
+          .isInstanceOf(EveryventException.class)
+          .extracting("errorCode", "detail")
+          .containsExactly(
+              ErrorCode.NOT_FOUND,
+              "삭제할 팔로워 사용자를 찾을 수 없습니다. (ID: " + FOLLOWER_ID + ")"
+          );
+
+      then(userRepository).should(times(1)).existsByIdAndDeletedAtIsNull(FOLLOWER_ID);
+      then(userRepository).should(never()).existsByIdAndDeletedAtIsNull(TARGET_ID);
+      then(followRepository).should(never()).deleteByFollowerIdAndTargetId(any(), any());
+    }
+
+    @DisplayName("팔로우 대상 사용자가 존재하지 않으면 예외를 던진다.")
+    @Test
+    void deleteFollow_whenTargetNotFound_throwsException() {
+      // given
+      given(userRepository.existsByIdAndDeletedAtIsNull(FOLLOWER_ID)).willReturn(true);
+      given(userRepository.existsByIdAndDeletedAtIsNull(TARGET_ID)).willReturn(false);
+
+      // when & then
+      assertThatThrownBy(() -> followService.deleteFollow(FOLLOWER_ID, TARGET_ID))
+          .isInstanceOf(EveryventException.class)
+          .extracting("errorCode", "detail")
+          .containsExactly(
+              ErrorCode.NOT_FOUND,
+              "삭제할 팔로우 대상 사용자를 찾을 수 없습니다. (ID: " + TARGET_ID + ")"
+          );
+
+      then(userRepository).should(times(1)).existsByIdAndDeletedAtIsNull(FOLLOWER_ID);
+      then(userRepository).should(times(1)).existsByIdAndDeletedAtIsNull(TARGET_ID);
+      then(followRepository).should(never()).deleteByFollowerIdAndTargetId(any(), any());
+    }
+
+    @DisplayName("삭제할 팔로우 관계가 존재하지 않으면 예외를 던진다.")
+    @Test
+    void deleteFollow_whenFollowNotFound_throwsException() {
+      // given
+      given(userRepository.existsByIdAndDeletedAtIsNull(FOLLOWER_ID)).willReturn(true);
+      given(userRepository.existsByIdAndDeletedAtIsNull(TARGET_ID)).willReturn(true);
+      given(followRepository.deleteByFollowerIdAndTargetId(FOLLOWER_ID, TARGET_ID)).willReturn(0);
+
+      // when & then
+      assertThatThrownBy(() -> followService.deleteFollow(FOLLOWER_ID, TARGET_ID))
+          .isInstanceOf(EveryventException.class)
+          .extracting("errorCode", "detail")
+          .containsExactly(
+              ErrorCode.NOT_FOUND,
+              "삭제할 팔로우 관계가 존재하지 않습니다."
+          );
+
+      then(userRepository).should(times(1)).existsByIdAndDeletedAtIsNull(FOLLOWER_ID);
+      then(userRepository).should(times(1)).existsByIdAndDeletedAtIsNull(TARGET_ID);
+      then(followRepository).should(times(1)).deleteByFollowerIdAndTargetId(FOLLOWER_ID, TARGET_ID);
+    }
+
+  }
 }


### PR DESCRIPTION
## 📝 무엇을 했나요?

팔로우 관련 기능을 구현하고, Service 단위 테스트와 JPQL(`@Query`) 메서드에 한하여 Repository 테스트를 진행했습니다.

### RESTful API 엔드포인트 (`/api/me` 패턴)

- `POST /api/me/followings` : 팔로우 생성 (201 Created)  
- `GET /api/me/followers` : 내 팔로워 목록 조회 (200 OK)  
- `GET /api/me/followings` : 내 팔로잉 목록 조회 (200 OK)  
- `DELETE /api/me/followings/{targetId}` : 언팔로우 (204 No Content)  
- `DELETE /api/me/followers/{followerId}` : 팔로워 제거 (204 No Content)  

### 테스트 커버리지 (총 20개)

- **FollowRepositoryTest** (6개)  
  - 팔로워 조회 3개: 정상 조회, 빈 목록, soft deleted 유저 제외  
  - 팔로잉 조회 3개: 정상 조회, 빈 목록, soft deleted 유저 제외  

- **FollowServiceTest** (14개)  
  - 팔로우 생성 4개: 성공, 팔로워 없음, 대상 없음, 중복  
  - 팔로워 조회 3개: 성공, 빈 목록, 대상 유저 없음  
  - 팔로잉 조회 3개: 성공, 빈 목록, 팔로워 유저 없음  
  - 팔로우 삭제 4개: 성공, 팔로워 없음, 대상 없음, 관계 없음  

---

## 💭 고민 지점과 리뷰 포인트

- 팔로워/팔로잉 목록 조회는 아직 페이징을 적용하지 않았습니다.  
  초기 MVP에서는 전체 목록을 그대로 반환하도록 설계했고, 필요해지면 페이징 기능을 추가할 계획입니다.  

- 맞팔 여부를 확인하는 기능이 필요하다면, 그때 추가하도록 하겠습니다.

## 🔗 관련 이슈
#7 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 팔로우 시스템 추가: 팔로우/언팔로우, 내 팔로워·팔로잉 조회, 팔로우 관련 API 및 응답 DTO 제공.
  * 개발 전용 간편 로그인 엔드포인트 추가(개발 환경에서만 사용).
* **보안/설정**
  * 환경 기반으로 개발 전용 엔드포인트 접근 허용 설정 추가(/api/dev/**).
* **테스트**
  * 팔로우 도메인 단위·통합 테스트 추가.
* **빌드**
  * 컴파일러에 파라미터 이름 보존 옵션(-parameters) 추가.
* **리팩터**
  * 에러 코드 정리 및 일부 응답 DTO를 불변 타입으로 전환.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->