### PR TITLE
feat: Calendar/OriginalCalendar 리팩토링 및 DistributedCalendar 추가

### DIFF
--- a/src/main/java/kr/santanrudolph/everyvent/domain/calendar/Calendar.java
+++ b/src/main/java/kr/santanrudolph/everyvent/domain/calendar/Calendar.java
@@ -1,13 +1,11 @@
 package kr.santanrudolph.everyvent.domain.calendar;
 
 import jakarta.persistence.*;
-import jakarta.validation.constraints.Pattern;
 import kr.santanrudolph.everyvent.domain.calendar.enums.Category;
 import kr.santanrudolph.everyvent.domain.calendar.enums.Visibility;
+import kr.santanrudolph.everyvent.domain.calendar.validator.ValidColor;
 import kr.santanrudolph.everyvent.domain.user.User;
 import kr.santanrudolph.everyvent.global.entity.BaseEntity;
-import kr.santanrudolph.everyvent.global.exception.ErrorCode;
-import kr.santanrudolph.everyvent.global.exception.EveryventException;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -46,13 +44,8 @@ public abstract class Calendar extends BaseEntity {
     @Column(nullable = false)
     private Visibility visibility;
 
-    private static final String HEX_COLOR_PATTERN = "^#([0-9A-Fa-f]{3}|[0-9A-Fa-f]{6})$";
-
+    @ValidColor
     @Column(nullable = false)
-    @Pattern(
-            regexp = HEX_COLOR_PATTERN,
-            message = "유효한 HEX 색상 코드여야 합니다 (예: #FFF, #FFFFFF)"
-    )
     private String color;
 
     @Enumerated(EnumType.STRING)
@@ -62,7 +55,14 @@ public abstract class Calendar extends BaseEntity {
     @Column
     private Instant deletedAt;
 
-    protected Calendar(User user, String title, String description, Instant startDate, Instant endDate, Visibility visibility, String color, Category category) {
+    protected Calendar(User user,
+                       String title,
+                       String description,
+                       Instant startDate,
+                       Instant endDate,
+                       Visibility visibility,
+                       String color,
+                       Category category) {
         this.user = user;
         this.title = title;
         this.description = description;
@@ -79,45 +79,4 @@ public abstract class Calendar extends BaseEntity {
         this.deletedAt = Instant.now();
     }
 
-    // === 속성 변경 메서드 ===
-    public void changeColor(String newColor) {
-        validateHexColor(newColor);
-        this.color = newColor;
-    }
-
-    public void changeVisibility(Visibility newVisibility) {
-        validateNotNull(newVisibility, "공개 범위");
-        this.visibility = newVisibility;
-    }
-
-    public void updateDetails(String title, String description, Instant startDate, Instant endDate, Category category) {
-        validateNotNull(title, "제목");
-        validateDateRange(startDate, endDate);
-        validateNotNull(category, "카테고리");
-
-        this.title = title;
-        this.description = description;
-        this.startDate = startDate;
-        this.endDate = endDate;
-        this.category = category;
-    }
-
-    // === 공통 검증 메서드 ===
-    protected void validateHexColor(String color) {
-        if (!color.matches(HEX_COLOR_PATTERN)) {
-            throw new EveryventException(ErrorCode.INVALID_COLOR);
-        }
-    }
-
-    protected void validateNotNull(Object value, String fieldName) {
-        if (value == null || (value instanceof String s && s.isBlank())) {
-            throw new EveryventException(ErrorCode.REQUIRED_FIELD, fieldName);
-        }
-    }
-
-    protected void validateDateRange(Instant startDate, Instant endDate) {
-        if (startDate.isAfter(endDate)) {
-            throw new EveryventException(ErrorCode.INVALID_DATE_RANGE);
-        }
-    }
 }

--- a/src/main/java/kr/santanrudolph/everyvent/domain/calendar/DistributedCalendar.java
+++ b/src/main/java/kr/santanrudolph/everyvent/domain/calendar/DistributedCalendar.java
@@ -1,0 +1,49 @@
+package kr.santanrudolph.everyvent.domain.calendar;
+
+import jakarta.persistence.*;
+import kr.santanrudolph.everyvent.domain.calendar.enums.Category;
+import kr.santanrudolph.everyvent.domain.calendar.enums.Visibility;
+import kr.santanrudolph.everyvent.domain.user.User;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.Instant;
+
+@Entity
+@DiscriminatorValue("DISTRIBUTED")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class DistributedCalendar extends Calendar{
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "original_calendar_id", nullable = false)
+    private OriginalCalendar originalCalendar;
+
+    @Column(nullable = false)
+    private Instant distributedAt;
+
+    @Builder
+    public DistributedCalendar(
+            User user,
+            OriginalCalendar originalCalendar,
+            String title,
+            String description,
+            Instant startDate,
+            Instant endDate,
+            Visibility visibility,
+            String color,
+            Category category
+    ) {
+        super(user, title, description, startDate, endDate, visibility, color, category);
+        this.originalCalendar = originalCalendar;
+        this.distributedAt = Instant.now();
+    }
+
+    @Override
+    public boolean isScrapable() {
+        return false;
+    }
+
+}

--- a/src/main/java/kr/santanrudolph/everyvent/domain/calendar/OriginalCalendar.java
+++ b/src/main/java/kr/santanrudolph/everyvent/domain/calendar/OriginalCalendar.java
@@ -3,10 +3,7 @@ package kr.santanrudolph.everyvent.domain.calendar;
 import jakarta.persistence.*;
 import kr.santanrudolph.everyvent.domain.calendar.enums.Category;
 import kr.santanrudolph.everyvent.domain.calendar.enums.Visibility;
-import kr.santanrudolph.everyvent.domain.user.Role;
 import kr.santanrudolph.everyvent.domain.user.User;
-import kr.santanrudolph.everyvent.global.exception.ErrorCode;
-import kr.santanrudolph.everyvent.global.exception.EveryventException;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -26,15 +23,22 @@ public class OriginalCalendar extends Calendar {
     @Column(nullable = false)
     private boolean isOfficial; // 공식 캘린더 여부
 
-    private Long officialId; // 복제된 공식 캘린더의 원본 id
-
     @Builder
-    public OriginalCalendar(User user, String title, String description, Instant startDate, Instant endDate, Visibility visibility, String color, Category category,
-                            Instant previewStartDate, Instant previewEndDate, boolean isOfficial, Long officialId) {
+    public OriginalCalendar(User user,
+                            String title,
+                            String description,
+                            Instant startDate,
+                            Instant endDate,
+                            Visibility visibility,
+                            String color,
+                            Category category,
+                            Instant previewStartDate,
+                            Instant previewEndDate,
+                            boolean isOfficial) {
         super(user, title, description, startDate, endDate, visibility, color, category);
-        setPreviewPeriod(previewStartDate, previewEndDate);
+        this.previewStartDate = previewStartDate;
+        this.previewEndDate = previewEndDate;
         this.isOfficial = isOfficial;
-        this.officialId = officialId;
     }
 
     @Override
@@ -42,64 +46,4 @@ public class OriginalCalendar extends Calendar {
         return !isOfficial && getVisibility() != Visibility.PRIVATE;
     }
 
-    @Override
-    public void changeVisibility(Visibility newVisibility) {
-        super.changeVisibility(newVisibility);
-        updatePreviewAvailability();
-    }
-
-    // === 공식 캘린더 관련 메서드 ===
-    public void changeOfficialStatus(boolean isOfficial) {
-        this.isOfficial = isOfficial;
-        updatePreviewAvailability();
-    }
-
-    public void enterOfficialId(Long officialId) {
-        this.officialId = officialId;
-    }
-
-    // === 미리보기 관련 메서드 ===
-    public void setPreviewPeriod(Instant previewStartDate, Instant previewEndDate) {
-        if (previewStartDate == null || previewEndDate == null) {
-            this.previewStartDate = null;
-            this.previewEndDate = null;
-            return;
-        }
-        validateDateRange(previewStartDate, previewEndDate);
-        validateWithinCalendarPeriod(previewStartDate, previewEndDate);
-
-        this.previewStartDate = previewStartDate;
-        this.previewEndDate = previewEndDate;
-    }
-
-    public boolean hasPreviewPeriod() {
-        return previewStartDate != null && previewEndDate != null;
-    }
-
-    public void updatePreviewAvailability() {
-        if (isOfficial || getVisibility() == Visibility.PRIVATE) {
-            this.previewStartDate = null;
-            this.previewEndDate = null;
-        }
-    }
-
-    public boolean isTaskPreviewable(Instant taskDate) {
-        if (!hasPreviewPeriod()) {
-            return false;
-        }
-        return !taskDate.isBefore(previewStartDate) && !taskDate.isAfter(previewEndDate);
-    }
-
-    // === 검증 관련 메서드 ===
-    private void validateWithinCalendarPeriod(Instant start, Instant end) {
-        if (start.isBefore(getStartDate()) || end.isAfter(getEndDate())) {
-            throw new EveryventException(ErrorCode.PREVIEW_PERIOD_OUT_OF_CALENDAR);
-        }
-    }
-
-    public void ensureOfficialEditableByUser() {
-        if (this.officialId != null && this.getUser().getRole() == Role.USER) {
-            throw new EveryventException(ErrorCode.OFFICIAL_CALENDAR_CANNOT_MODIFY);
-        }
-    }
 }

--- a/src/main/java/kr/santanrudolph/everyvent/domain/calendar/validator/HexColorValidator.java
+++ b/src/main/java/kr/santanrudolph/everyvent/domain/calendar/validator/HexColorValidator.java
@@ -1,0 +1,15 @@
+package kr.santanrudolph.everyvent.domain.calendar.validator;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+
+public class HexColorValidator implements ConstraintValidator<ValidColor, String> {
+
+    private static final String HEX_COLOR_PATTERN = "^#([0-9A-Fa-f]{3}|[0-9A-Fa-f]{6})$";
+
+    @Override
+    public boolean isValid(String value, ConstraintValidatorContext context) {
+        return value != null && value.matches(HEX_COLOR_PATTERN);
+    }
+}
+

--- a/src/main/java/kr/santanrudolph/everyvent/domain/calendar/validator/ValidColor.java
+++ b/src/main/java/kr/santanrudolph/everyvent/domain/calendar/validator/ValidColor.java
@@ -1,0 +1,15 @@
+package kr.santanrudolph.everyvent.domain.calendar.validator;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+import java.lang.annotation.*;
+
+@Documented
+@Constraint(validatedBy = HexColorValidator.class)
+@Target({ElementType.FIELD })
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ValidColor {
+    String message() default "유효한 HEX 색상 코드여야 합니다 (예: #FFF, #FFFFFF)";
+    Class<?>[] groups() default {};
+    Class<? extends Payload>[] payload() default {};
+}


### PR DESCRIPTION
## 📝 무엇을 했나요?
1. Calendar / OriginalCalendar 리팩토링
- 엔티티는 조회/상태 필드 중심으로 간결하게 유지
- 비즈니스 로직(검증, 상태 변경 등)을 서비스 레이어로 이동하기 위해 메서드 제거
- color 필드에 @ValidColor 적용

2. DistributedCalendar 엔티티 추가
- 공식 캘린더를 일반 사용자에게 배포할 때 별도의 엔티티로 관리
- OriginalCalendar와 분리하여 책임과 데이터 관리 명확화
- distributedAt 필드로 배포 시점 기록
- isScrapable() 항상 false로 설정

3. HEX 색상 검증용 커스텀 어노테이션 @ValidColor와 HexColorValidator 추가
- #FFF 또는 #FFFFFF 형식만 허용

## 💭 고민 지점과 리뷰 포인트
1. DistributedCalendar 분리 여부
원래는 OriginalCalendar에 officialId를 두어 원본 캘린더와의 관계를 나타나게 하려 했습니다. 
하지만 복제된 캘린더를 '원본' 캘린더인 OriginalCalendar에 포함하는 것은 구조상 어색할 수 있어 OriginalCalendar에 배포 정보를 포함시키는 대신 별도의 엔티티로 분리했습니다.

2. @ValidColor 적용
팩토리 메서드에서 검증하는 방법 대신 Validator를 따로 선언해서 엔티티 및 DTO에서도 검증할 수 있도록 했습니다.

## 🔗 관련 이슈
#9 