### PR TITLE
feat(follow): 팔로우/맞팔 여부 조회 기능 추가

### DIFF
--- a/src/main/java/kr/santanrudolph/everyvent/domain/follow/FollowService.java
+++ b/src/main/java/kr/santanrudolph/everyvent/domain/follow/FollowService.java
@@ -124,7 +124,7 @@ public class FollowService {
   }
 
   public boolean isFollowing(Long followerId, Long targetId) {
-    return followRepository.findByFollowerIdAndTargetId(followerId, targetId).isPresent();
+    return followRepository.existsByFollowerIdAndTargetId(followerId, targetId);
   }
 
   public boolean isMutualFollow(Long userId1, Long userId2) {

--- a/src/main/java/kr/santanrudolph/everyvent/domain/follow/FollowService.java
+++ b/src/main/java/kr/santanrudolph/everyvent/domain/follow/FollowService.java
@@ -123,4 +123,12 @@ public class FollowService {
     log.info("Follow deleted - follower: {}, target: {}", followerId, targetId);
   }
 
+  public boolean isFollowing(Long followerId, Long targetId) {
+    return followRepository.findByFollowerIdAndTargetId(followerId, targetId).isPresent();
+  }
+
+  public boolean isMutualFollow(Long userId1, Long userId2) {
+    return isFollowing(userId1, userId2) && isFollowing(userId2, userId1);
+  }
+
 }

--- a/src/test/java/kr/santanrudolph/everyvent/domain/follow/FollowServiceTest.java
+++ b/src/test/java/kr/santanrudolph/everyvent/domain/follow/FollowServiceTest.java
@@ -514,4 +514,115 @@ class FollowServiceTest {
     }
 
   }
+
+  @Nested
+  @DisplayName("팔로우 여부 확인 테스트")
+  class IsFollowingTest {
+
+    @DisplayName("팔로우 중이면 true를 반환한다.")
+    @Test
+    void isFollowing_whenFollowing_thenReturnsTrue() {
+      // given
+      follower = createUser(FOLLOWER_ID, "follower");
+      target = createUser(TARGET_ID, "target");
+      Follow follow = createFollow(follower, target, FOLLOW_ID);
+
+      given(followRepository.findByFollowerIdAndTargetId(FOLLOWER_ID, TARGET_ID))
+          .willReturn(Optional.of(follow));
+
+      // when
+      boolean result = followService.isFollowing(FOLLOWER_ID, TARGET_ID);
+
+      // then
+      assertThat(result).isTrue();
+      then(followRepository).should(times(1)).findByFollowerIdAndTargetId(FOLLOWER_ID, TARGET_ID);
+    }
+
+    @DisplayName("팔로우 중이 아니면 false를 반환한다.")
+    @Test
+    void isFollowing_whenNotFollowing_thenReturnsFalse() {
+      // given
+      given(followRepository.findByFollowerIdAndTargetId(FOLLOWER_ID, TARGET_ID))
+          .willReturn(Optional.empty());
+
+      // when
+      boolean result = followService.isFollowing(FOLLOWER_ID, TARGET_ID);
+
+      // then
+      assertThat(result).isFalse();
+      then(followRepository).should(times(1)).findByFollowerIdAndTargetId(FOLLOWER_ID, TARGET_ID);
+    }
+
+  }
+
+  @Nested
+  @DisplayName("맞팔로우 여부 확인 테스트")
+  class IsMutualFollowTest {
+
+    private static final Long USER_ID_1 = 1L;
+    private static final Long USER_ID_2 = 2L;
+
+    @DisplayName("맞팔로우 관계이면 true를 반환한다.")
+    @Test
+    void isMutualFollow_whenMutual_thenReturnsTrue() {
+      // given
+      User user1 = createUser(USER_ID_1, "user1");
+      User user2 = createUser(USER_ID_2, "user2");
+      Follow follow1 = createFollow(user1, user2, 1L);
+      Follow follow2 = createFollow(user2, user1, 2L);
+
+      given(followRepository.findByFollowerIdAndTargetId(USER_ID_1, USER_ID_2))
+          .willReturn(Optional.of(follow1));
+      given(followRepository.findByFollowerIdAndTargetId(USER_ID_2, USER_ID_1))
+          .willReturn(Optional.of(follow2));
+
+      // when
+      boolean result = followService.isMutualFollow(USER_ID_1, USER_ID_2);
+
+      // then
+      assertThat(result).isTrue();
+      then(followRepository).should(times(1)).findByFollowerIdAndTargetId(USER_ID_1, USER_ID_2);
+      then(followRepository).should(times(1)).findByFollowerIdAndTargetId(USER_ID_2, USER_ID_1);
+    }
+
+    @DisplayName("일방향 팔로우만 있으면 false를 반환한다.")
+    @Test
+    void isMutualFollow_whenOneWay_thenReturnsFalse() {
+      // given
+      User user1 = createUser(USER_ID_1, "user1");
+      User user2 = createUser(USER_ID_2, "user2");
+      Follow follow1 = createFollow(user1, user2, 1L);
+
+      given(followRepository.findByFollowerIdAndTargetId(USER_ID_1, USER_ID_2))
+          .willReturn(Optional.of(follow1));
+      given(followRepository.findByFollowerIdAndTargetId(USER_ID_2, USER_ID_1))
+          .willReturn(Optional.empty());
+
+      // when
+      boolean result = followService.isMutualFollow(USER_ID_1, USER_ID_2);
+
+      // then
+      assertThat(result).isFalse();
+      then(followRepository).should(times(1)).findByFollowerIdAndTargetId(USER_ID_1, USER_ID_2);
+      then(followRepository).should(times(1)).findByFollowerIdAndTargetId(USER_ID_2, USER_ID_1);
+    }
+
+    @DisplayName("팔로우 관계가 전혀 없으면 false를 반환한다.")
+    @Test
+    void isMutualFollow_whenNoFollow_thenReturnsFalse() {
+      // given
+      given(followRepository.findByFollowerIdAndTargetId(USER_ID_1, USER_ID_2))
+          .willReturn(Optional.empty());
+
+      // when
+      boolean result = followService.isMutualFollow(USER_ID_1, USER_ID_2);
+
+      // then
+      assertThat(result).isFalse();
+      then(followRepository).should(times(1)).findByFollowerIdAndTargetId(USER_ID_1, USER_ID_2);
+      // Short-circuit으로 두 번째 쿼리는 실행되지 않음
+      then(followRepository).should(never()).findByFollowerIdAndTargetId(USER_ID_2, USER_ID_1);
+    }
+
+  }
 }


### PR DESCRIPTION
## 📝 무엇을 했나요?
캘린더 공개범위 설정에 따른 조회 제약을 체크하기 위한, 팔로우/맞팔 여부 조회 메서드를 추가했어요.


## 🔗 관련 이슈
Close #14

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 특정 사용자가 다른 사용자를 팔로우하고 있는지 조회하는 기능 추가
  * 두 사용자 간의 상호 팔로우 여부를 확인하는 기능 추가

* **테스트**
  * 새 팔로우 조회 기능들의 정확성과 안정성을 검증하는 포괄적 테스트 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->