### PR TITLE
feat: 프로덕션 환경 분리 및 RDS 도입

### DIFF
--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -1,0 +1,25 @@
+spring:
+  datasource:
+    driver-class-name: org.h2.Driver
+    url: jdbc:h2:file:./data/testdb
+    username: sa
+    password:
+
+  h2:
+    console:
+      enabled: true
+      path: /h2-console
+
+  jpa:
+    hibernate:
+      ddl-auto: update
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.H2Dialect
+        format_sql: true
+        show_sql: true
+
+logging:
+  level:
+    org.hibernate.SQL: debug
+    org.hibernate.type.descriptor.sql.BasicBinder: trace

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -1,0 +1,27 @@
+spring:
+  datasource:
+    driver-class-name: org.postgresql.Driver
+    url: jdbc:postgresql://${RDS_HOST}:${RDS_PORT}/${RDS_DB_NAME}
+    username: ${RDS_USERNAME}
+    password: ${RDS_PASSWORD}
+    hikari:
+      maximum-pool-size: 10
+      minimum-idle: 5
+      connection-timeout: 30000
+      idle-timeout: 600000
+      max-lifetime: 1800000
+
+  jpa:
+    hibernate:
+      ddl-auto: update # 아직 개발 중인 이슈로, 현재 테이블이 fix되지 않아 update로 두었습니다. 추후 validate로 변경할 예정입니다.
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.PostgreSQLDialect
+        format_sql: false
+        show_sql: false
+        default_batch_fetch_size: 100
+
+logging:
+  level:
+    org.hibernate.SQL: info
+    kr.santanrudolph.everyvent: info

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -4,24 +4,6 @@ server:
 spring:
   profiles:
     active: dev
-  datasource:
-    driver-class-name: org.h2.Driver
-    url: jdbc:h2:file:./data/testdb # 개발용 파일 기반 DB (재시작해도 데이터 유지)
-    username: sa # system administartor
-    password:
-
-  h2:
-    console:
-      enabled: true
-      path: /h2-console
-
-  jpa:
-    hibernate:
-      ddl-auto: update
-    properties:
-      hibernate:
-        format_sql: true
-        show_sql: true
 
   mvc:
     async:


### PR DESCRIPTION
## 📝 무엇을 했나요?
1차 배포를 위해 환경별 설정 파일을 분리했어요  
  - 공통: `application.yml`  
  - 개발: `application-dev.yml`  (H2 사용)  
  - 배포: `application-prod.yml`  (RDS 연동)  

## 💭 고민 지점과 리뷰 포인트
@NYoungLEE  
- `spring.profiles.active`를 `prod`로 설정하면 배포 환경에서 RDS와 함께 실행할 수 있어요.

```yaml
spring:
  profiles:
    active: dev
```

- 개발할 때는 `dev` 프로파일을 유지하면 h2로 안전하게 테스트할 수 있어요  
- `.env`에 추가된 환경변수들이 있어요! 저에게 요청해주시면 공유해드릴게요 !!


## 🔗 관련 이슈
Close #24 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * 개발 환경용 데이터베이스 설정 추가
  * 프로덕션 환경용 데이터베이스 설정 추가
  * 기본 설정 파일에서 데이터베이스 구성 제거 및 환경별 프로필 설정으로 분리

<!-- end of auto-generated comment: release notes by coderabbit.ai -->