### PR TITLE
feat(auth): OAuth 인증 코드 교환 방식으로 변경 및 프론트엔드 연동 준비

### DIFF
--- a/src/main/java/kr/santanrudolph/everyvent/auth/controller/AuthController.java
+++ b/src/main/java/kr/santanrudolph/everyvent/auth/controller/AuthController.java
@@ -7,6 +7,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import kr.santanrudolph.everyvent.auth.AuthenticationUtil;
+import kr.santanrudolph.everyvent.auth.dto.AuthCodeExchangeRequest;
 import kr.santanrudolph.everyvent.auth.dto.TokenRefreshRequest;
 import kr.santanrudolph.everyvent.auth.dto.TokenResponse;
 import kr.santanrudolph.everyvent.auth.security.JwtTokenProvider;
@@ -29,6 +30,21 @@ public class AuthController {
 
   private final AuthService authService;
   private final JwtTokenProvider jwtTokenProvider;
+
+  @Operation(
+      summary = "인증 코드로 토큰 교환",
+      description = "OAuth2 로그인 성공 후 발급된 일회성 인증 코드를 Access Token과 Refresh Token으로 교환합니다."
+  )
+  @ApiResponses({
+      @ApiResponse(responseCode = "200", description = "토큰 교환 성공"),
+      @ApiResponse(responseCode = "400", description = "INVALID_INPUT: 유효하지 않거나 만료된 인증 코드")
+  })
+  @PostMapping("/exchange")
+  public ResponseEntity<TokenResponse> exchangeAuthCode(
+      @Valid @RequestBody AuthCodeExchangeRequest request) {
+    TokenResponse response = authService.exchangeAuthCode(request.getCode());
+    return ResponseEntity.ok(response);
+  }
 
   @Operation(
       summary = "토큰 재발급",

--- a/src/main/java/kr/santanrudolph/everyvent/auth/dto/AuthCodeExchangeRequest.java
+++ b/src/main/java/kr/santanrudolph/everyvent/auth/dto/AuthCodeExchangeRequest.java
@@ -1,0 +1,12 @@
+package kr.santanrudolph.everyvent.auth.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+
+@Schema(description = "인증 코드 토큰 교환 요청")
+public record AuthCodeExchangeRequest(
+    @Schema(description = "일회성 인증 코드", example = "abc123-def456-ghi789")
+    @NotBlank(message = "인증 코드는 필수입니다.")
+    String code
+) {
+}

--- a/src/main/java/kr/santanrudolph/everyvent/auth/dto/AuthCodeExchangeRequest.java
+++ b/src/main/java/kr/santanrudolph/everyvent/auth/dto/AuthCodeExchangeRequest.java
@@ -9,4 +9,8 @@ public record AuthCodeExchangeRequest(
     @NotBlank(message = "인증 코드는 필수입니다.")
     String code
 ) {
+
+    public String getCode() {
+        return code;
+    }
 }

--- a/src/main/java/kr/santanrudolph/everyvent/auth/repository/RedisTokenRepository.java
+++ b/src/main/java/kr/santanrudolph/everyvent/auth/repository/RedisTokenRepository.java
@@ -16,14 +16,18 @@ import org.springframework.stereotype.Repository;
 public class RedisTokenRepository {
 
   private final RedisTemplate<String, String> redisTemplate;
+  private final long authCodeExpiration;
 
   // TODO: RedisKeyConstants 상수로 분리
   private static final String REFRESH_TOKEN_PREFIX = "refresh_token:";
   private static final String BLACKLIST_TOKEN_PREFIX = "blacklist_token:";
+  private static final String AUTH_CODE_PREFIX = "auth_code:";
 
   public RedisTokenRepository(
-      @Qualifier("tokenRedisTemplate") RedisTemplate<String, String> redisTemplate) {
+      @Qualifier("tokenRedisTemplate") RedisTemplate<String, String> redisTemplate,
+      @org.springframework.beans.factory.annotation.Value("${jwt.auth-code-expiration}") long authCodeExpiration) {
     this.redisTemplate = redisTemplate;
+    this.authCodeExpiration = authCodeExpiration;
   }
 
   public void saveRefreshToken(Long userId, String refreshToken, Instant expiresAt) {
@@ -80,6 +84,46 @@ public class RedisTokenRepository {
             Boolean.TRUE.equals(redisTemplate.hasKey(key)),
         "Blacklist를 조회할 수 없습니다."
     );
+  }
+
+  /**
+   * 일회성 인증 코드 저장 (OAuth2 로그인 성공 시 토큰 안전 전달용)
+   * @param authCode 일회성 인증 코드
+   * @param accessToken Access Token
+   * @param refreshToken Refresh Token
+   */
+  public void saveAuthCode(String authCode, String accessToken, String refreshToken) {
+    String key = AUTH_CODE_PREFIX + authCode;
+    String value = accessToken + ":" + refreshToken;
+
+    executeRedisOperation(() -> {
+      redisTemplate.opsForValue().set(key, value, authCodeExpiration, TimeUnit.SECONDS);
+      log.info("AuthCode saved - TTL: {}s", authCodeExpiration);
+      return null;
+    }, "인증 코드를 저장할 수 없습니다.");
+  }
+
+  /**
+   * 인증 코드로 토큰 조회 및 삭제 (1회용)
+   * @param authCode 일회성 인증 코드
+   * @return [accessToken, refreshToken] 배열 (존재하지 않으면 null)
+   */
+  public String[] getAndDeleteAuthCode(String authCode) {
+    String key = AUTH_CODE_PREFIX + authCode;
+
+    return executeRedisOperation(() -> {
+      String value = redisTemplate.opsForValue().get(key);
+      if (value == null) {
+        log.warn("AuthCode not found or expired: {}", authCode);
+        return null;
+      }
+
+      // 1회용이므로 즉시 삭제
+      redisTemplate.delete(key);
+      log.info("AuthCode used and deleted: {}", authCode);
+
+      return value.split(":");
+    }, "인증 코드를 조회할 수 없습니다.");
   }
 
   private <T> T executeRedisOperation(Supplier<T> operation, String errorMessage) {

--- a/src/main/java/kr/santanrudolph/everyvent/auth/security/OAuth2SuccessHandler.java
+++ b/src/main/java/kr/santanrudolph/everyvent/auth/security/OAuth2SuccessHandler.java
@@ -4,9 +4,11 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.time.Instant;
+import java.util.UUID;
 import kr.santanrudolph.everyvent.auth.repository.RedisTokenRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
 import org.springframework.stereotype.Component;
@@ -20,6 +22,9 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
   private final JwtTokenProvider jwtTokenProvider;
   private final RedisTokenRepository redisTokenRepository;
 
+  @Value("${frontend.url:http://localhost:3030}")
+  private String frontendUrl;
+
   @Override
   public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
       Authentication authentication) throws IOException {
@@ -28,6 +33,7 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
 
     log.info("OAuth2 Login Success - User ID: {}", userId);
 
+    // JWT 토큰 생성
     String accessToken = jwtTokenProvider.createAccessToken(userId);
     String refreshToken = jwtTokenProvider.createRefreshToken(userId);
     Instant refreshTokenExpiration = jwtTokenProvider.getExpirationDate(refreshToken).toInstant();
@@ -35,11 +41,14 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
     redisTokenRepository.saveRefreshToken(userId, refreshToken, refreshTokenExpiration);
     log.info("RefreshToken saved to Redis for User ID: {}", userId);
 
-    // 테스트용 콜백 엔드포인트로 리다이렉트 (토큰을 쿼리 파라미터로 전달하여, 로그인 시 프론트 없이도 토큰 확인 가능)
-    // TODO: 프론트 연동 시에는 삭제 필요
-    String targetUrl = UriComponentsBuilder.fromUriString("http://localhost:8080/oauth/callback")
-        .queryParam("accessToken", accessToken)
-        .queryParam("refreshToken", refreshToken)
+    // 일회성 인증 코드 생성 (보안 강화)
+    String authCode = UUID.randomUUID().toString();
+    redisTokenRepository.saveAuthCode(authCode, accessToken, refreshToken);
+    log.info("AuthCode generated for User ID: {}", userId);
+
+    // 프론트엔드로 인증 코드만 전달 (토큰은 URL에 노출되지 않음)
+    String targetUrl = UriComponentsBuilder.fromUriString(frontendUrl + "/oauth/callback")
+        .queryParam("code", authCode)
         .build().toUriString();
 
     log.info("Redirecting to: {}", targetUrl);

--- a/src/main/java/kr/santanrudolph/everyvent/auth/service/AuthService.java
+++ b/src/main/java/kr/santanrudolph/everyvent/auth/service/AuthService.java
@@ -70,6 +70,32 @@ public class AuthService {
         userId);
   }
 
+  /**
+   * 일회성 인증 코드를 토큰으로 교환 (OAuth2 로그인 콜백용)
+   * @param authCode 일회성 인증 코드
+   * @return TokenResponse (accessToken, refreshToken)
+   */
+  public TokenResponse exchangeAuthCode(String authCode) {
+    String[] tokens = redisTokenRepository.getAndDeleteAuthCode(authCode);
+
+    if (tokens == null || tokens.length != 2) {
+      log.warn("AuthCode not found or expired: {}", authCode);
+      throw new EveryventException(ErrorCode.INVALID_INPUT, "유효하지 않거나 만료된 인증 코드입니다.");
+    }
+
+    String accessToken = tokens[0];
+    String refreshToken = tokens[1];
+
+    log.info("AuthCode exchanged successfully");
+
+    return TokenResponse.builder()
+        .accessToken(accessToken)
+        .refreshToken(refreshToken)
+        .tokenType("Bearer")
+        .expiresIn(toSeconds(accessTokenExpiration))
+        .build();
+  }
+
   private long toSeconds(long milliseconds) {
     return milliseconds / 1000;
   }

--- a/src/main/java/kr/santanrudolph/everyvent/global/config/CorsConfig.java
+++ b/src/main/java/kr/santanrudolph/everyvent/global/config/CorsConfig.java
@@ -1,5 +1,6 @@
 package kr.santanrudolph.everyvent.global.config;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.cors.CorsConfiguration;
@@ -11,14 +12,19 @@ import java.util.Arrays;
 @Configuration
 public class CorsConfig {
 
+  @Value("${frontend.url}")
+  private String frontendUrl;
+
   @Bean
   public CorsConfigurationSource corsConfigurationSource() {
     CorsConfiguration configuration = new CorsConfiguration();
 
-    // 허용할 출처
+    // 허용할 출처 (로컬 개발 + 배포 환경)
     configuration.setAllowedOrigins(Arrays.asList(
         "http://localhost:3000",
-        "http://localhost:3001"
+        "http://localhost:3001",
+        "http://localhost:3030",
+        frontendUrl  // 환경별 프론트엔드 URL
     ));
 
     // 허용할 HTTP 메서드

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -24,6 +24,9 @@ spring:
         format_sql: true
         show_sql: true
 
+frontend:
+  url: http://localhost:3030  # 로컬 프론트엔드 URL
+
 logging:
   level:
     org.hibernate.SQL: debug

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -26,6 +26,9 @@ spring:
         show_sql: false
         default_batch_fetch_size: 100
 
+frontend:
+  url: http://localhost:3030  # 로컬 프론트엔드 URL
+
 logging:
   level:
     org.hibernate.SQL: info

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -31,4 +31,4 @@ jwt:
   secret: ${JWT_SECRET}
   access-token-expiration: 3600000
   refresh-token-expiration: 604800000
-  auth-code-expiration: 60  # 인증 코드 유효 시간 (초)
+  auth-code-expiration: 300  # 인증 코드 유효 시간 추후 시간 줄일 예정

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -31,3 +31,4 @@ jwt:
   secret: ${JWT_SECRET}
   access-token-expiration: 3600000
   refresh-token-expiration: 604800000
+  auth-code-expiration: 60  # 인증 코드 유효 시간 (초)


### PR DESCRIPTION
## 📝 무엇을 했나요?
OAuth 로그인 후 JWT 토큰을 URL에 직접 노출하지 않고, **일회성 인증 코드(one-time code)**를 통한 토큰 교환 방식으로 변경하여 보안을 강화했어요.

주요 변경 사항:
- 일회성 인증 코드 발급
- Redis에 저장, TTL ~~60초 설정~~
(현재 프론트 연동 편의를 위해 5분으로 변경)
- POST /api/auth/exchange 토큰 교환 API 추가
- JWT 토큰 URL 노출 방지 및 OAuth2 표준 방식 준수
- 프론트엔드 연동을 위한 CORS 설정 및 환경 설정 정리

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능
* OAuth2 인증 코드 교환 기능 추가: 일회용 인증 코드를 통한 보안 강화된 토큰 교환 메커니즘 구현
* 토큰 저장 및 관리 기능 확대: 일회용 코드의 저장, 조회, 삭제 기능 추가
* 설정 개선: 프론트엔드 URL 및 인증 코드 만료 시간 설정 추가

## 구성 변경
* CORS 정책 업데이트: 프론트엔드 URL 추가

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->