### PR TITLE
feat(calendar): 캘린더 공개 범위에 따른 조회 권한 로직 추가 및 수정 정책 변경

### DIFF
--- a/src/main/java/kr/santanrudolph/everyvent/domain/calendar/CalendarService.java
+++ b/src/main/java/kr/santanrudolph/everyvent/domain/calendar/CalendarService.java
@@ -299,14 +299,19 @@ public class CalendarService {
     }
   }
 
-  private boolean canView(Calendar calendar, User viewer, User targetUser) {
-    return switch (calendar.getVisibility()) {
-      case PUBLIC -> true;
-      case MUTUAL -> followService.isMutualFollow(viewer.getId(), targetUser.getId());
-      case FOLLOWER -> followService.isFollowing(viewer.getId(), targetUser.getId());
-      case PRIVATE -> viewer.getId().equals(targetUser.getId());
-    };
-  }
+    private boolean canView(Calendar calendar, User viewer, User targetUser) {
+
+      if (viewer.getId().equals(targetUser.getId())) {
+        return true;
+      }
+
+      return switch (calendar.getVisibility()) {
+        case PUBLIC -> true;
+        case MUTUAL -> followService.isMutualFollow(viewer.getId(), targetUser.getId());
+        case FOLLOWER -> followService.isFollowing(viewer.getId(), targetUser.getId());
+        case PRIVATE -> viewer.getId().equals(targetUser.getId());
+      };
+    }
 
   // 생성/업데이트 관련
   private OriginalCalendar buildCalendar(User user, OriginalCalendarRequest request) {

--- a/src/main/java/kr/santanrudolph/everyvent/domain/calendar/CalendarService.java
+++ b/src/main/java/kr/santanrudolph/everyvent/domain/calendar/CalendarService.java
@@ -94,7 +94,7 @@ public class CalendarService {
   public CalendarResponse getCalendar(Long calendarId, Long userId) {
 
     User viewer = getUserOrThrow(userId);
-    Calendar calendar =   getActiveCalendarOrThrow(calendarId);
+    Calendar calendar = getActiveCalendarOrThrow(calendarId);
 
     if (!canView(calendar, viewer, calendar.getUser())) {
       throw new EveryventException(ErrorCode.FORBIDDEN, "해당 캘린더를 조회할 권한이 없습니다.");

--- a/src/main/java/kr/santanrudolph/everyvent/domain/calendar/CalendarService.java
+++ b/src/main/java/kr/santanrudolph/everyvent/domain/calendar/CalendarService.java
@@ -295,7 +295,7 @@ public class CalendarService {
     YearMonth calendarMonth = YearMonth.from(endDate.atZone(koreaZone));
 
     if(!now.isBefore(calendarMonth)) {
-      throw new EveryventException(ErrorCode.INVALID_INPUT, "캘린더 시작월 이후에는 수정할 수 없습니다.");
+      throw new EveryventException(ErrorCode.INVALID_INPUT, "캘린더 해당 월부터는 수정할 수 없습니다.");
     }
   }
 

--- a/src/main/java/kr/santanrudolph/everyvent/domain/calendar/CalendarService.java
+++ b/src/main/java/kr/santanrudolph/everyvent/domain/calendar/CalendarService.java
@@ -309,7 +309,7 @@ public class CalendarService {
         case PUBLIC -> true;
         case MUTUAL -> followService.isMutualFollow(viewer.getId(), targetUser.getId());
         case FOLLOWER -> followService.isFollowing(viewer.getId(), targetUser.getId());
-        case PRIVATE -> viewer.getId().equals(targetUser.getId());
+        case PRIVATE -> false;
       };
     }
 

--- a/src/main/java/kr/santanrudolph/everyvent/domain/calendar/CalendarService.java
+++ b/src/main/java/kr/santanrudolph/everyvent/domain/calendar/CalendarService.java
@@ -294,7 +294,7 @@ public class CalendarService {
     YearMonth now = YearMonth.now(koreaZone);
     YearMonth calendarMonth = YearMonth.from(endDate.atZone(koreaZone));
 
-    if(!now.isBefore(calendarMonth)) {
+    if (!now.isBefore(calendarMonth)) {
       throw new EveryventException(ErrorCode.INVALID_INPUT, "캘린더 해당 월부터는 수정할 수 없습니다.");
     }
   }

--- a/src/main/java/kr/santanrudolph/everyvent/domain/calendar/CalendarService.java
+++ b/src/main/java/kr/santanrudolph/everyvent/domain/calendar/CalendarService.java
@@ -100,7 +100,7 @@ public class CalendarService {
       throw new EveryventException(ErrorCode.FORBIDDEN, "해당 캘린더를 조회할 권한이 없습니다.");
     }
 
-    boolean isScrapable = calendar.isScrapable() && !calendar.getUser().getId().equals(viewer.getId());
+    boolean isScrapable = calendar.isScrapable() && !isCalendarOwner(viewer, calendar);
     return toCalendarResponse(calendar, isScrapable);
   }
 
@@ -169,7 +169,7 @@ public class CalendarService {
     }
 
     User user = getUserOrThrow(userId);
-    if (!Objects.equals(calendar.getUser().getId(), user.getId())) {
+    if (!isCalendarOwner(user, calendar)) {
       throw new EveryventException(ErrorCode.FORBIDDEN, "해당 캘린더 수정 권한이 없습니다.");
     }
 
@@ -204,7 +204,7 @@ public class CalendarService {
       throw new EveryventException(ErrorCode.FORBIDDEN, "공식 캘린더 원본은 일반 삭제 API에서 삭제할 수 없습니다.");
     }
 
-    if (!Objects.equals(calendar.getUser().getId(), user.getId()) && user.getRole() != Role.ADMIN) {
+    if (!isCalendarOwner(user, calendar) && user.getRole() != Role.ADMIN) {
       throw new EveryventException(ErrorCode.FORBIDDEN, "해당 캘린더를 삭제할 권한이 없습니다.");
     }
 
@@ -299,19 +299,49 @@ public class CalendarService {
     }
   }
 
-    private boolean canView(Calendar calendar, User viewer, User targetUser) {
+  private void validateMonthlyCalendarLimit(Long userId, OriginalCalendarRequest request) {
+    long userMonthlyCalendarCount = calendarRepository
+            .countByUserIdInMonth(userId, request.getStartDate(), request.getEndDate());
 
-      if (viewer.getId().equals(targetUser.getId())) {
-        return true;
-      }
-
-      return switch (calendar.getVisibility()) {
-        case PUBLIC -> true;
-        case MUTUAL -> followService.isMutualFollow(viewer.getId(), targetUser.getId());
-        case FOLLOWER -> followService.isFollowing(viewer.getId(), targetUser.getId());
-        case PRIVATE -> false;
-      };
+    if (userMonthlyCalendarCount >= 3) {
+      throw new EveryventException(ErrorCode.INVALID_INPUT, "캘린더는 최대 3개까지 생성할 수 있습니다.");
     }
+  }
+
+  private void validateDateRange(Instant startDate, Instant endDate) {
+    if (startDate.isAfter(endDate)) {
+      throw new EveryventException(ErrorCode.INVALID_INPUT, "미리보기 기간의 시작일은 종료일보다 앞서야 합니다.");
+    }
+  }
+
+  private void validateWithinCalendarPeriod(Instant startDate, Instant endDate, Instant start, Instant end) {
+    if (start.isBefore(startDate) || end.isAfter(endDate)) {
+      throw new EveryventException(ErrorCode.INVALID_INPUT,
+              "미리보기 기간은 캘린더 기간 안에 포함되어야 합니다.");
+    }
+  }
+
+  private boolean isOwner(User viewer, User targetUser) {
+    return viewer.getId().equals(targetUser.getId());
+  }
+
+  private boolean isCalendarOwner(User user, Calendar calendar) {
+    return Objects.equals(calendar.getUser().getId(), user.getId());
+  }
+
+  private boolean canView(Calendar calendar, User viewer, User targetUser) {
+
+    if (isOwner(viewer, targetUser)) {
+      return true;
+    }
+
+    return switch (calendar.getVisibility()) {
+      case PUBLIC -> true;
+      case MUTUAL -> followService.isMutualFollow(viewer.getId(), targetUser.getId());
+      case FOLLOWER -> followService.isFollowing(viewer.getId(), targetUser.getId());
+      case PRIVATE -> false;
+    };
+  }
 
   // 생성/업데이트 관련
   private OriginalCalendar buildCalendar(User user, OriginalCalendarRequest request) {
@@ -372,29 +402,6 @@ public class CalendarService {
     originalCalendar.updateCategory(request.getCategory());
   }
 
-  // 검증 관련
-  private void validateMonthlyCalendarLimit(Long userId, OriginalCalendarRequest request) {
-    long userMonthlyCalendarCount = calendarRepository
-            .countByUserIdInMonth(userId, request.getStartDate(), request.getEndDate());
-
-    if (userMonthlyCalendarCount >= 3) {
-      throw new EveryventException(ErrorCode.INVALID_INPUT, "캘린더는 최대 3개까지 생성할 수 있습니다.");
-    }
-  }
-
-  private void validateDateRange(Instant startDate, Instant endDate) {
-    if (startDate.isAfter(endDate)) {
-      throw new EveryventException(ErrorCode.INVALID_INPUT, "미리보기 기간의 시작일은 종료일보다 앞서야 합니다.");
-    }
-  }
-
-  private void validateWithinCalendarPeriod(Instant startDate, Instant endDate, Instant start, Instant end) {
-    if (start.isBefore(startDate) || end.isAfter(endDate)) {
-      throw new EveryventException(ErrorCode.INVALID_INPUT,
-              "미리보기 기간은 캘린더 기간 안에 포함되어야 합니다.");
-    }
-  }
-
   // DTO 변환
   private CalendarResponse toCalendarResponse(Calendar calendar, boolean isScrapable) {
 
@@ -408,7 +415,7 @@ public class CalendarService {
             .filter(calendar -> canView(calendar, viewer, targetUser))
             .sorted(Comparator.comparingLong(Calendar::getId))
             .map(calendar -> {
-              boolean isScrapable = calendar.isScrapable() && !calendar.getUser().getId().equals(viewer.getId());
+              boolean isScrapable = calendar.isScrapable() && !isCalendarOwner(viewer, calendar);
               return toCalendarResponse(calendar, isScrapable);
             })
             .toList();

--- a/src/main/java/kr/santanrudolph/everyvent/domain/calendar/CalendarService.java
+++ b/src/main/java/kr/santanrudolph/everyvent/domain/calendar/CalendarService.java
@@ -94,7 +94,7 @@ public class CalendarService {
   public CalendarResponse getCalendar(Long calendarId, Long userId) {
 
     User viewer = getUserOrThrow(userId);
-    Calendar calendar = getActiveCalendarOrThrow(calendarId);
+    Calendar calendar =   getActiveCalendarOrThrow(calendarId);
 
     if (!canView(calendar, viewer, calendar.getUser())) {
       throw new EveryventException(ErrorCode.FORBIDDEN, "해당 캘린더를 조회할 권한이 없습니다.");
@@ -278,7 +278,6 @@ public class CalendarService {
   }
 
   private void validateDistribution(OfficialCalendar officialCalendar) {
-
     Instant endDate = officialCalendar.getOriginalCalendar().getEndDate();
     ZoneId koreaZone = ZoneId.of("Asia/Seoul");
     YearMonth now = YearMonth.now(koreaZone);
@@ -289,12 +288,15 @@ public class CalendarService {
     }
   }
 
-  private boolean isEditableAfterStartMonth(Calendar calendar) {
+  private void validateEditCalendar(Calendar calendar) {
     Instant endDate = calendar.getEndDate();
     ZoneId koreaZone = ZoneId.of("Asia/Seoul");
     YearMonth now = YearMonth.now(koreaZone);
     YearMonth calendarMonth = YearMonth.from(endDate.atZone(koreaZone));
-    return !calendarMonth.isAfter(now);
+
+    if(!now.isBefore(calendarMonth)) {
+      throw new EveryventException(ErrorCode.INVALID_INPUT, "캘린더 시작월 이후에는 수정할 수 없습니다.");
+    }
   }
 
   private boolean canView(Calendar calendar, User viewer, User targetUser) {
@@ -337,17 +339,15 @@ public class CalendarService {
                                              OriginalCalendarRequest request,
                                              Instant previewStartDate,
                                              Instant previewEndDate) {
-    if (isEditableAfterStartMonth(calendar)) {
-      updatePartialOriginalCalendar(calendar, request);
-    } else {
-      updateAllOriginalCalendar(calendar, request, previewStartDate, previewEndDate);
-    }
+
+    validateEditCalendar(calendar);
+    updateOriginalCalendar(calendar, request, previewStartDate, previewEndDate);
   }
 
-  private void updateAllOriginalCalendar(OriginalCalendar originalCalendar,
-                                         OriginalCalendarRequest request,
-                                         Instant previewStartDate,
-                                         Instant previewEndDate) {
+  private void updateOriginalCalendar(OriginalCalendar originalCalendar,
+                                      OriginalCalendarRequest request,
+                                      Instant previewStartDate,
+                                      Instant previewEndDate) {
 
 
     Instant startDate = request.getStartDate();
@@ -362,15 +362,6 @@ public class CalendarService {
     originalCalendar.updateTitle(request.getTitle());
     originalCalendar.updateDescription(request.getDescription());
     originalCalendar.updatePeriod(startDate, endDate);
-    originalCalendar.updateVisibility(request.getVisibility());
-    originalCalendar.updateColor(request.getColor());
-    originalCalendar.updateCategory(request.getCategory());
-  }
-
-  private void updatePartialOriginalCalendar(OriginalCalendar originalCalendar,
-                                             OriginalCalendarRequest request) {
-    originalCalendar.updateTitle(request.getTitle());
-    originalCalendar.updateDescription(request.getDescription());
     originalCalendar.updateVisibility(request.getVisibility());
     originalCalendar.updateColor(request.getColor());
     originalCalendar.updateCategory(request.getCategory());
@@ -403,7 +394,7 @@ public class CalendarService {
   private CalendarResponse toCalendarResponse(Calendar calendar, boolean isScrapable) {
 
     OfficialCalendar official = officialCalendarRepository.findByOriginalCalendarId(calendar.getId())
-                            .orElse(null);
+            .orElse(null);
     return CalendarResponse.from(calendar, official, isScrapable);
   }
 

--- a/src/main/java/kr/santanrudolph/everyvent/domain/calendar/CalendarService.java
+++ b/src/main/java/kr/santanrudolph/everyvent/domain/calendar/CalendarService.java
@@ -9,6 +9,7 @@ import kr.santanrudolph.everyvent.domain.calendar.entity.Calendar;
 import kr.santanrudolph.everyvent.domain.calendar.entity.DistributedCalendar;
 import kr.santanrudolph.everyvent.domain.calendar.entity.OfficialCalendar;
 import kr.santanrudolph.everyvent.domain.calendar.entity.OriginalCalendar;
+import kr.santanrudolph.everyvent.domain.follow.FollowService;
 import kr.santanrudolph.everyvent.domain.user.enums.Role;
 import kr.santanrudolph.everyvent.domain.user.User;
 import kr.santanrudolph.everyvent.domain.user.UserRepository;
@@ -34,6 +35,7 @@ public class CalendarService {
   private final CalendarRepository calendarRepository;
   private final OfficialCalendarRepository officialCalendarRepository;
   private final UserRepository userRepository;
+  private final FollowService followService;
 
   @Transactional
   public OriginalCalendarResponse createCalendar(Long userId, OriginalCalendarRequest request) {
@@ -298,8 +300,9 @@ public class CalendarService {
   private boolean canView(Calendar calendar, User viewer, User targetUser) {
     return switch (calendar.getVisibility()) {
       case PUBLIC -> true;
+      case MUTUAL -> followService.isMutualFollow(viewer.getId(), targetUser.getId());
+      case FOLLOWER -> followService.isFollowing(viewer.getId(), targetUser.getId());
       case PRIVATE -> viewer.getId().equals(targetUser.getId());
-      default -> false;
     };
   }
 


### PR DESCRIPTION
## 📝 무엇을 했나요?
1. 공개 범위에 따른 조회 권한 로직 추가
팔로워 조회 메서드 구현 이후 공개 범위(FOLLOWER, MUTUAL)에 따른 조회 권한 로직 추가했습니다.
```
      case MUTUAL -> followService.isMutualFollow(viewer.getId(), targetUser.getId());
      case FOLLOWER -> followService.isFollowing(viewer.getId(), targetUser.getId());
```
2. 캘린더 수정 정책 변경
**1) 수정 전**
캘린더 해당 월 이전에는 모든 필드 수정 가능, 해당 월부터는 일부 필드 수정 가능(캘린더 기간, 미리보기 기간 불가)
**2) 수정 후**
캘린더 해당 월 이전에는 모든 필드 수정 가능, 해당 월부터는 모든 필드 수정 불가

## 💭 고민 지점과 리뷰 포인트
1. 공개 범위 조회 권한 로직
FOLLOWER와 MUTUAL 케이스에서 followService 호출이 적절하게 처리되는지
2. 캘린더 수정 정책
캘린더 해당 월부터 모든 필드 수정 불가로 바꾼 로직이 서비스 흐름에 잘 반영되었는지

## 🔗 관련 이슈
#5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **기능 개선**
  * 팔로우 관계 기반 달력 가시성 규칙 추가(소유자·공개·상호팔로우·팔로워 기준 적용)
  * 편집 가능성 검증 로직 강화 및 편집 흐름에 통합
  * 달력 업데이트 처리 경로 단일화로 일관성 향상
  * 소유권 검사 방식 통일 및 스크랩 가능성 계산 개선
  * 내부 응답 포맷 정리(외부 API 동작 불변)

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->