### PR TITLE
fix(swagger): swagger 설정에 배포 서버 URL 추가로 CORS 에러 해결

### DIFF
--- a/src/main/java/kr/santanrudolph/everyvent/global/config/SwaggerConfig.java
+++ b/src/main/java/kr/santanrudolph/everyvent/global/config/SwaggerConfig.java
@@ -37,7 +37,10 @@ public class SwaggerConfig {
         .servers(List.of(
             new Server()
                 .url("http://localhost:8080")
-                .description("로컬 개발 서버")
+                .description("로컬 개발 서버"),
+            new Server()
+                .url("http://43.201.101.45:8080")
+                .description("배포 서버")
         ))
         .addSecurityItem(securityRequirement)
         .components(components);


### PR DESCRIPTION
## 📝 무엇을 했나요?

프론트 테스트용 배포 버전2에서, 토큰 교환 API호출 시 다음과 같은 **CORS 에러**가 발생하는 문제를 발견했어요.
<img width="853" height="743" alt="image" src="https://github.com/user-attachments/assets/ba8fdaca-0210-490e-bc1d-5307bee70c1c" />

**원인**
- `SwaggerConfig`에 localhost만 등록되어 있어, 배포 환경의 Swagger UI가 배포 서버로 요청을 보낼 수 없었어요.
(localhost로 요청 보내고 있었음)
- 처음에는 CORS 문제니까, 호출하고 있는 배포 서버 URL을 등록해야 한다고 잘못 판단했어요.
하지만 다시 생각해보니 실제로 배포 서버 간 요청은 동일 네트워크 내에서 이루어지므로 CORS가 필요하지 않았어요.
따라서 해당 PR의 변경 사항은 불필요하여 되돌렸습니다.
(참고: https://github.com/SANTA-N-RUDOLPH/everyvent-server/pull/35)

**해결**
- 배포 서버 URL을 Swagger 서버 목록에 추가하여, Swagger UI에서 배포 서버를 선택할 수 있도록 했어요.

## 💭 고민 지점과 리뷰 포인트
<!-- 예상되는 리팩터링 지점이 있다면 추가로 작성해 주세요.-->
@NYoungLEE 동의해주신대루 빠른 프론트 연동 및 에러 해결을 위해 긴급 머지 하겠습니다! 🙏

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리스 노트

* **설정 개선**
  * API 문서에서 배포 서버를 선택할 수 있도록 업데이트되었습니다. 기존 로컬 환경과 함께 배포 환경에서의 API 테스트가 가능합니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->