### PR TITLE
fix: 프론트엔드 로컬 포트 3030 -> 5173으로 변경

### DIFF
--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -25,7 +25,7 @@ spring:
         show_sql: true
 
 frontend:
-  url: http://localhost:3030  # 로컬 프론트엔드 URL
+  url: http://localhost:5173  # 로컬 프론트엔드 URL
 
 logging:
   level:

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -27,7 +27,7 @@ spring:
         default_batch_fetch_size: 100
 
 frontend:
-  url: http://localhost:3030  # 로컬 프론트엔드 URL
+  url: http://localhost:5173  # 로컬 프론트엔드 URL
 
 logging:
   level:


### PR DESCRIPTION
## 📝 무엇을 했나요?
프론트엔드 로컬 서버 포트가 예상했던 3030이 아니라 5173으로 설정되어 있는 것을 확인했습니다.
이로 인해 CORS 설정과 실제 요청 출처가 일치하지 않아 요청이 차단되는 문제가 있었고,
프론트 포트에 맞춰 CORS 설정을 수정하여 정상적으로 요청이 처리되도록 문제를 해결했습니다!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리즈 노트

* **Chores**
  * 프론트엔드 연결 설정을 업데이트했습니다 (개발 및 프로덕션 환경).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->