### PR TITLE
fix(deploy): Docker 빌드 타임아웃 해결을 위해 GHCR 기반 배포로 ci/cd 개선

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,8 +30,11 @@ jobs:
       - name: Gradle 실행 권한 부여
         run: chmod +x gradlew
 
-      - name: 빌드 및 단위 테스트
-        run: ./gradlew clean build --tests '*Test' -DincludeTags=unit
+      - name: 클린 빌드 및 단위 테스트
+        run: |
+          ./gradlew clean
+          ./gradlew test -DincludeTags=unit
+          ./gradlew build -x test
 
       - name: 테스트 결과 리포트
         uses: EnricoMi/publish-unit-test-result-action@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,14 +2,15 @@ name: CI
 
 on:
   pull_request:
-    branches: [ develop, main ]
+    branches: [ develop ]
   push:
-    branches: [ develop, main ]
+    branches: [ develop ]
 
 permissions:
   contents: read
   checks: write
   pull-requests: write
+  packages: write
 
 jobs:
   build-and-test:
@@ -29,11 +30,8 @@ jobs:
       - name: Gradle 실행 권한 부여
         run: chmod +x gradlew
 
-      - name: 빌드
-        run: ./gradlew build -x test
-
-      - name: 단위 테스트 실행
-        run: ./gradlew test --tests '*Test' -DincludeTags=unit
+      - name: 빌드 및 단위 테스트
+        run: ./gradlew clean build --tests '*Test' -DincludeTags=unit
 
       - name: 테스트 결과 리포트
         uses: EnricoMi/publish-unit-test-result-action@v2
@@ -48,3 +46,34 @@ jobs:
       - name: 빌드 실패 알림
         if: failure()
         run: echo "❌ 빌드 또는 테스트가 실패했습니다."
+
+      - name: Docker 메타데이터 추출
+        id: meta
+        if: github.event_name == 'push'
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/hyeblee/everyvent-server
+          tags: |
+            type=raw,value=develop-latest
+            type=sha,prefix=develop-,format=short
+
+      - name: GHCR 로그인
+        if: github.event_name == 'push'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: hyeblee
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Docker 이미지 빌드 및 푸시
+        if: github.event_name == 'push'
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+      - name: 이미지 푸시 성공 알림
+        if: success() && github.event_name == 'push'
+        run: echo "🐳 Docker 이미지가 GHCR에 푸시되었습니다!"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,12 +22,11 @@ jobs:
           script: |
             cd /home/ec2-user/everyvent-server
 
-            # 최신 코드 가져오기
-            git pull origin develop || { echo "❌ Git pull failed"; exit 1; }
+            # GHCR에서 최신 이미지 pull
+            docker pull ghcr.io/hyeblee/everyvent-server:develop-latest || { echo "❌ Image pull failed"; exit 1; }
 
-            # Docker Compose로 재배포
+            # Docker Compose로 재시작
             docker-compose down || true
-            docker-compose build --no-cache || { echo "❌ Build failed"; exit 1; }
             docker-compose up -d || { echo "❌ Services failed to start"; exit 1; }
 
             # 서비스 안정화 대기 및 상태 확인

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,15 +11,13 @@ services:
     command: redis-server --appendonly yes
     restart: unless-stopped
     healthcheck:
-      test: ["CMD", "redis-cli", "ping"]
+      test: [ "CMD", "redis-cli", "ping" ]
       interval: 10s
       timeout: 3s
       retries: 3
 
   app:
-    build:
-      context: .
-      dockerfile: Dockerfile
+    image: ghcr.io/hyeblee/everyvent-server:develop-latest
     container_name: everyvent-app
     ports:
       - "8080:8080"


### PR DESCRIPTION
## 📝 무엇을 했나요?
GitHub Actions CI에서 Docker 이미지를 빌드하고 GHCR에 푸시하도록 CI/CD 파이프라인을 개선했어요.

### 주요 변경 사항
1. ci.yml
   - develop에 push 시, Docker 이미지 빌드 후 GHCR에 푸시
2. docker-compose.yml
   - build -> ghcr 이미지 사용으로 변경
3. deloy.yml
   - ec2내에서 직접 도커 이미지 빌드에서 ghcr 이미지 pull로 변경
## 🔗 관련 이슈
Close #41

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI/CD 파이프라인 정리: develop 기반 트리거로 단순화, 클린 빌드+단위테스트 통합, 테스트 결과 항상 보고
  * Docker 흐름 통합: 이미지 메타데이터 추출·로그인·빌드·푸시 및 푸시 성공 알림 추가
  * 배포 방식 전환: 코드 pull 대신 레지스트리 이미지 pull 후 컨테이너 재시작으로 배포 간소화
  * 컨테이너 설정 강화: 런타임 환경변수 추가 및 Redis 의존성 헬스체크 반영

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->