### PR TITLE
refactor(deploy): SSL 인증서 등록 및 Swagger 배포 서버 URL HTTPS로 변경

### DIFF
--- a/src/main/java/kr/santanrudolph/everyvent/global/config/CorsConfig.java
+++ b/src/main/java/kr/santanrudolph/everyvent/global/config/CorsConfig.java
@@ -21,9 +21,6 @@ public class CorsConfig {
 
     // 허용할 출처 (로컬 개발 + 배포 환경)
     configuration.setAllowedOrigins(Arrays.asList(
-        "http://localhost:3000",
-        "http://localhost:3001",
-        "http://localhost:3030",
         frontendUrl  // 환경별 프론트엔드 URL
     ));
 

--- a/src/main/java/kr/santanrudolph/everyvent/global/config/SwaggerConfig.java
+++ b/src/main/java/kr/santanrudolph/everyvent/global/config/SwaggerConfig.java
@@ -36,11 +36,11 @@ public class SwaggerConfig {
             .version("1.0.0"))
         .servers(List.of(
             new Server()
-                .url("http://localhost:8080")
-                .description("로컬 개발 서버"),
+                .url("https://api.everyvent.cloud")
+                .description("배포 서버"),
             new Server()
-                .url("http://52.79.177.171:8080")
-                .description("배포 서버")
+                .url("http://localhost:8080")
+                .description("로컬 개발 서버")
         ))
         .addSecurityItem(securityRequirement)
         .components(components);


### PR DESCRIPTION
## 📝 무엇을 했나요?
HTTPS 통신을 위해 백엔드 서버(EC2)에 **SSL 인증서**를 직접 발급·적용했어요.
이를 통해 `https://api.everyvent.cloud` 도메인에서 안전한 **HTTPS 요청**을 정상적으로 처리할 수 있어요.

또한, EC2 인스턴스에 **Nginx를 설치해 리버스 프록시**로 구성했어요.
Nginx가 **SSL을 종료(TLS Termination**)하고 내부의 Spring Boot 서버로 요청을 전달하도록 설정했기 때문에, 클라이언트는 항상 HTTPS로 통신해요.

- 흐름도

```markdown
[사용자 브라우저]
       |
       |   HTTPS (암호화)
       v
[Nginx]  ← SSL 인증서 설치됨
       |
       |   HTTP (암호화 안 됨, 내부망이므로 OK)
       v
[Spring Boot 서버]

```

변경사항에 따라 Swagger에서 사용하는 백엔드 API 기본 주소를 HTTPS 도메인으로 수정했어요!

## 💭 고민 지점과 리뷰 포인트
**프론트는 배포 후 `https://everyvent.server`를
백엔드는 `https://api.everyven.server`를 사용할 예정이에요.**

현재 `application-prod.yml`의 `frontend.url`이 `http://localhost:5173`로 설정되어 있는데, 프론트 배포 후 `https://everyvent.cloud`로 변경할 예정이에요

## 🔗 관련 이슈
Close #37

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리스 노트

* **구성 업데이트**
  * CORS 원본 설정이 환경 기반 구성으로 변경되었습니다.
  * API 문서에서 표시되는 기본 서버 설정이 프로덕션 환경으로 업데이트되었습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->