### PR TITLE
fix: develop 브랜치 push 후 CI보다 deploy가 먼저 끝나는 문제 수정

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,13 +1,17 @@
 name: Deploy to Test Server
 
 on:
-  push:
+  workflow_run:
+    workflows: [ "CI" ]
+    types:
+      - completed
     branches: [ develop ]
   workflow_dispatch:  # 수동 실행 가능
 
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
 
     steps:
       - name: 코드 체크아웃


### PR DESCRIPTION
## 📝 무엇을 했나요?
`develop`브랜치에 push 할 때 CI와 Deploy가 동시에 실행되면서,
이미지가 빌드되기 전에 Deploy가 먼저 수행되는 문제가 발생하고 있었어요.

이번 PR에서는 `deploy.yml`에 workflow_run 트리거를 develop push에서 CI 완료로 변경하여
CI가 성공적으로 완료된 이후에만 Deploy가 실행되도록 동작 방식을 개선했어요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * 배포 프로세스가 개선되어 자동화된 검사가 성공적으로 완료된 후에만 배포가 진행되도록 수정되었습니다. 이로 인해 더욱 안정적인 배포를 제공합니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->