### PR TITLE
fix(deploy): Docker Compose에서 항상 최신 이미지 pull하도록 설정

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,7 @@ services:
 
   app:
     image: ghcr.io/santa-n-rudolph/everyvent-server:develop-latest
+    pull_policy: always
     container_name: everyvent-app
     ports:
       - "8080:8080"


### PR DESCRIPTION
GHCR에 새 이미지로 push는 정상적으로 되지만,
배포단계에서 최신이미지가 아닌 옛날 이미지를 사용하여 배포되는 문제를 해결했어요.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 변경 사항

* **기타(Chores)**
  * 배포 안정성 향상을 위해 Docker 이미지 풀 정책이 업데이트되었습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->