### PR TITLE
fix: 카카오 OAuth redirect_uri HTTPS 인식 문제 해결

### DIFF
--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -1,3 +1,6 @@
+server:
+  forward-headers-strategy: framework
+
 spring:
   datasource:
     driver-class-name: org.postgresql.Driver


### PR DESCRIPTION
## 📝 무엇을 했나요?
- Spring Boot에서 forward headers 활성화 (server.forward-headers-strategy=framework)
- Nginx에서 X-Forwarded-Proto 설정 반영
- Spring Security가 HTTPS를 올바르게 인식하도록 수정


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **잡무**
  * 프로덕션 환경 설정을 최적화했습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->