### PR TITLE
refactor: NoResourceFoundException를 별도 처리

### DIFF
--- a/src/main/java/kr/santanrudolph/everyvent/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/kr/santanrudolph/everyvent/global/exception/GlobalExceptionHandler.java
@@ -1,15 +1,18 @@
 package kr.santanrudolph.everyvent.global.exception;
 
 import jakarta.servlet.http.HttpServletRequest;
+
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.util.stream.Collectors;
+
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.servlet.resource.NoResourceFoundException;
 
 @Slf4j
 @RestControllerAdvice
@@ -56,6 +59,12 @@ public class GlobalExceptionHandler {
     return ResponseEntity
         .status(HttpStatus.BAD_REQUEST)
         .body(ErrorResponse.of(ErrorCode.INVALID_INPUT, detail));
+  }
+
+  @ExceptionHandler(NoResourceFoundException.class)
+  public ResponseEntity<Void> handleNoResourceFound(NoResourceFoundException e) {
+    log.debug("No static resource found: {}", e.getMessage());
+    return ResponseEntity.notFound().build();
   }
 
   @ExceptionHandler(Exception.class)


### PR DESCRIPTION
## 📝 무엇을 했나요?
NoResourceFoundException를 별도 처리하여 favicon 및 존재하지 않는 경로 요청 로그를 DEBUG로 변경했어요.
현재 서버를 실행시키면 다음과 같은 불필요한 NoResourceFoundException 에러 로그에 남아 가독성이 떨어져 별도의 핸들러를 만들었어요.
<img width="1027" height="362" alt="image" src="https://github.com/user-attachments/assets/6f5b7f78-4324-41d6-823d-05554e46dc4b" />
<img width="980" height="398" alt="image" src="https://github.com/user-attachments/assets/4a64ac78-1da9-4804-aedf-3270f2f1aad4" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 요청된 리소스를 찾을 수 없는 경우에 대한 에러 처리가 개선되었습니다. 이제 리소스가 존재하지 않는 상황에서 사용자가 더 적절한 오류 응답을 받게 됩니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->