### PR TITLE
feat(task): Task CRUD 및 상태 관리 기능 구현

### DIFF
--- a/src/main/java/kr/santanrudolph/everyvent/domain/task/Task.java
+++ b/src/main/java/kr/santanrudolph/everyvent/domain/task/Task.java
@@ -9,6 +9,8 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.time.Instant;
+
 @Entity
 @Table(
         name = "tasks",
@@ -43,6 +45,8 @@ public class Task extends BaseEntity {
   @Column(nullable = false)
   private boolean isCompleted = false;
 
+  private Instant deletedAt;
+
   private Task(Calendar calendar, String name, int day) {
     if (calendar == null) {
       throw new EveryventException(ErrorCode.INVALID_INPUT, "캘린더는 필수입니다.");
@@ -57,6 +61,10 @@ public class Task extends BaseEntity {
 
   public static Task create(Calendar calendar, String name, int day) {
     return new Task(calendar, name, day);
+  }
+
+  public void softDelete() {
+    this.deletedAt = Instant.now();
   }
 
   // 필드 업데이트 메서드

--- a/src/main/java/kr/santanrudolph/everyvent/domain/task/Task.java
+++ b/src/main/java/kr/santanrudolph/everyvent/domain/task/Task.java
@@ -13,12 +13,12 @@ import lombok.NoArgsConstructor;
 @Table(
         name = "tasks",
         indexes = {
-                @Index(name = "idx_calendar_day", columnList = "calendar_id, day")
+                @Index(name = "idx_calendar_day", columnList = "calendar_id, day_of_month")
         },
         uniqueConstraints = {
                 @UniqueConstraint(
                         name = "uk_task_calendar_day_name",
-                        columnNames = {"calendar_id", "day", "name"}
+                        columnNames = {"calendar_id", "day_of_month", "name"}
                 )
         }
 )
@@ -37,7 +37,7 @@ public class Task extends BaseEntity {
   @Column(nullable = false, length = 30)
   private String name;
 
-  @Column(nullable = false)
+  @Column(name = "day_of_month", nullable = false)
   private int day;
 
   @Column(nullable = false)

--- a/src/main/java/kr/santanrudolph/everyvent/domain/task/TaskController.java
+++ b/src/main/java/kr/santanrudolph/everyvent/domain/task/TaskController.java
@@ -25,14 +25,14 @@ public class TaskController {
 
   @Operation(summary = "태스크 생성", description = "로그인한 사용자가 지정한 기간 동안 태스크를 생성합니다.")
   @ApiResponses({
-          @ApiResponse(responseCode = "201", description = "태스크 생성 성공"),
-          @ApiResponse(responseCode = "400", description = "INVALID_INPUT: 잘못된 날짜 범위 또는 요청 값 오류"),
-          @ApiResponse(responseCode = "403", description = "FORBIDDEN: 캘린더 접근 권한 없음"),
-          @ApiResponse(responseCode = "404", description = "NOT_FOUND: 캘린더 또는 사용자 없음")
+      @ApiResponse(responseCode = "201", description = "태스크 생성 성공"),
+      @ApiResponse(responseCode = "400", description = "INVALID_INPUT: 잘못된 요청 값 또는 날짜 범위 오류"),
+      @ApiResponse(responseCode = "403", description = "FORBIDDEN: 권한 없음 또는 생성 불가한 일자"),
+      @ApiResponse(responseCode = "404", description = "NOT_FOUND: 사용자 또는 캘린더를 찾을 수 없음 또는 삭제된 캘린더")
   })
   @PostMapping
   public ResponseEntity<TaskResponses> createTask(
-          @Valid @RequestBody TaskCreateRequest request
+      @Valid @RequestBody TaskCreateRequest request
   ) {
     Long userId = AuthenticationUtil.getCurrentUserId();
     TaskResponses response = taskService.createTask(userId, request);
@@ -41,14 +41,14 @@ public class TaskController {
 
   @Operation(summary = "공식 캘린더 태스크 생성", description = "관리자가 공식 캘린더에 지정한 기간 동안 태스크를 생성합니다.")
   @ApiResponses({
-          @ApiResponse(responseCode = "201", description = "태스크 생성 성공"),
-          @ApiResponse(responseCode = "400", description = "INVALID_INPUT: 잘못된 날짜 범위 또는 요청 값 오류"),
-          @ApiResponse(responseCode = "403", description = "FORBIDDEN: 공식 캘린더 접근 권한 없음"),
-          @ApiResponse(responseCode = "404", description = "NOT_FOUND: 캘린더 또는 사용자 없음")
+      @ApiResponse(responseCode = "201", description = "태스크 생성 성공"),
+      @ApiResponse(responseCode = "400", description = "INVALID_INPUT: 잘못된 요청 값 또는 날짜 범위 오류"),
+      @ApiResponse(responseCode = "403", description = "FORBIDDEN: 관리자 권한 없음 또는 생성 불가한 일자"),
+      @ApiResponse(responseCode = "404", description = "NOT_FOUND: 사용자/캘린더를 찾을 수 없음 또는 삭제된 공식 캘린더")
   })
   @PostMapping("/official")
   public ResponseEntity<TaskResponses> createOfficialTask(
-          @Valid @RequestBody TaskCreateRequest request
+      @Valid @RequestBody TaskCreateRequest request
   ) {
     Long userId = AuthenticationUtil.getCurrentUserId();
     TaskResponses response = taskService.createOfficialTask(userId, request);
@@ -57,9 +57,10 @@ public class TaskController {
 
   @Operation(summary = "태스크 조회", description = "로그인한 사용자가 소유한 일반 태스크를 조회합니다.")
   @ApiResponses({
-          @ApiResponse(responseCode = "200", description = "태스크 조회 성공"),
-          @ApiResponse(responseCode = "403", description = "FORBIDDEN: 접근 권한 없음"),
-          @ApiResponse(responseCode = "404", description = "NOT_FOUND: 태스크 또는 사용자를 찾을 수 없음")
+      @ApiResponse(responseCode = "200", description = "태스크 조회 성공"),
+      @ApiResponse(responseCode = "400", description = "INVALID_INPUT: 공식 태스크는 조회할 수 없음"),
+      @ApiResponse(responseCode = "403", description = "FORBIDDEN: 접근 권한 없음"),
+      @ApiResponse(responseCode = "404", description = "NOT_FOUND: 사용자 또는 태스크를 찾을 수 없음")
   })
   @GetMapping("/{taskId}")
   public ResponseEntity<TaskResponse> getTask(@PathVariable Long taskId) {
@@ -70,9 +71,10 @@ public class TaskController {
 
   @Operation(summary = "공식 캘린더 태스크 조회", description = "관리자가 공식 캘린더 태스크를 조회합니다.")
   @ApiResponses({
-          @ApiResponse(responseCode = "200", description = "태스크 조회 성공"),
-          @ApiResponse(responseCode = "403", description = "FORBIDDEN: 접근 권한 없음"),
-          @ApiResponse(responseCode = "404", description = "NOT_FOUND: 태스크 또는 사용자를 찾을 수 없음")
+      @ApiResponse(responseCode = "200", description = "태스크 조회 성공"),
+      @ApiResponse(responseCode = "400", description = "INVALID_INPUT: 일반 태스크는 조회할 수 없음"),
+      @ApiResponse(responseCode = "403", description = "FORBIDDEN: 접근 권한 없음"),
+      @ApiResponse(responseCode = "404", description = "NOT_FOUND: 사용자/태스크를 찾을 수 없음 또는 삭제된 공식 캘린더")
   })
   @GetMapping("/official/{taskId}")
   public ResponseEntity<TaskResponse> getOfficialTask(@PathVariable Long taskId) {
@@ -83,14 +85,15 @@ public class TaskController {
 
   @Operation(summary = "태스크 수정", description = "로그인한 사용자가 소유한 태스크 이름 또는 날짜를 수정합니다.")
   @ApiResponses({
-          @ApiResponse(responseCode = "200", description = "태스크 수정 성공"),
-          @ApiResponse(responseCode = "403", description = "FORBIDDEN: 접근 권한 없음"),
-          @ApiResponse(responseCode = "404", description = "NOT_FOUND: 태스크 또는 사용자를 찾을 수 없음")
+      @ApiResponse(responseCode = "200", description = "태스크 수정 성공"),
+      @ApiResponse(responseCode = "400", description = "INVALID_INPUT: 공식 태스크는 수정할 수 없음"),
+      @ApiResponse(responseCode = "403", description = "FORBIDDEN: 접근 권한 없음 또는 수정 불가한 일자"),
+      @ApiResponse(responseCode = "404", description = "NOT_FOUND: 사용자 또는 태스크를 찾을 수 없음")
   })
   @PutMapping("/{taskId}")
   public ResponseEntity<TaskResponse> updateTaskDetails(
-          @PathVariable Long taskId,
-          @Valid @RequestBody TaskUpdateCommand command
+      @PathVariable Long taskId,
+      @Valid @RequestBody TaskUpdateCommand command
   ) {
     Long userId = AuthenticationUtil.getCurrentUserId();
     TaskResponse response = taskService.updateTaskDetails(userId, taskId, command);
@@ -99,14 +102,15 @@ public class TaskController {
 
   @Operation(summary = "공식 캘린더 태스크 수정", description = "관리자가 공식 캘린더 태스크 이름 또는 날짜를 수정합니다.")
   @ApiResponses({
-          @ApiResponse(responseCode = "200", description = "태스크 수정 성공"),
-          @ApiResponse(responseCode = "403", description = "FORBIDDEN: 접근 권한 없음"),
-          @ApiResponse(responseCode = "404", description = "NOT_FOUND: 태스크 또는 사용자를 찾을 수 없음")
+      @ApiResponse(responseCode = "200", description = "태스크 수정 성공"),
+      @ApiResponse(responseCode = "400", description = "INVALID_INPUT: 일반 태스크는 수정할 수 없음"),
+      @ApiResponse(responseCode = "403", description = "FORBIDDEN: 접근 권한 없음 또는 수정 불가한 일자"),
+      @ApiResponse(responseCode = "404", description = "NOT_FOUND: 사용자/태스크를 찾을 수 없음 또는 삭제된 공식 캘린더")
   })
   @PutMapping("/official/{taskId}")
   public ResponseEntity<TaskResponse> updateOfficialTaskDetails(
-          @PathVariable Long taskId,
-          @Valid @RequestBody TaskUpdateCommand command
+      @PathVariable Long taskId,
+      @Valid @RequestBody TaskUpdateCommand command
   ) {
     Long userId = AuthenticationUtil.getCurrentUserId();
     TaskResponse response = taskService.updateOfficialTaskDetails(userId, taskId, command);
@@ -115,14 +119,14 @@ public class TaskController {
 
   @Operation(summary = "태스크 완료 상태 변경", description = "로그인한 사용자가 소유한 태스크의 완료 여부를 변경합니다.")
   @ApiResponses({
-          @ApiResponse(responseCode = "200", description = "태스크의 완료 상태 수정 성공"),
-          @ApiResponse(responseCode = "403", description = "FORBIDDEN: 접근 권한 없음"),
-          @ApiResponse(responseCode = "404", description = "NOT_FOUND: 태스크 또는 사용자를 찾을 수 없음")
+      @ApiResponse(responseCode = "200", description = "태스크의 완료 상태 수정 성공"),
+      @ApiResponse(responseCode = "403", description = "FORBIDDEN: 접근 권한 없음"),
+      @ApiResponse(responseCode = "404", description = "NOT_FOUND: 사용자 또는 태스크를 찾을 수 없음")
   })
   @PatchMapping("/completion/{taskId}")
   public ResponseEntity<TaskResponse> updateTaskCompletion(
-          @PathVariable Long taskId,
-          @RequestParam boolean isCompleted
+      @PathVariable Long taskId,
+      @RequestParam boolean isCompleted
   ) {
     Long userId = AuthenticationUtil.getCurrentUserId();
     TaskResponse response = taskService.updateTaskCompletion(userId, taskId, isCompleted);
@@ -131,13 +135,14 @@ public class TaskController {
 
   @Operation(summary = "태스크 삭제", description = "로그인한 사용자가 소유한 태스크를 삭제합니다.")
   @ApiResponses({
-          @ApiResponse(responseCode = "204", description = "태스크 삭제 성공"),
-          @ApiResponse(responseCode = "403", description = "FORBIDDEN: 접근 권한 없음"),
-          @ApiResponse(responseCode = "404", description = "NOT_FOUND: 태스크 또는 사용자를 찾을 수 없음")
+      @ApiResponse(responseCode = "204", description = "태스크 삭제 성공"),
+      @ApiResponse(responseCode = "400", description = "INVALID_INPUT: 공식 태스크는 삭제할 수 없음"),
+      @ApiResponse(responseCode = "403", description = "FORBIDDEN: 접근 권한 없음 또는 삭제 불가한 일자"),
+      @ApiResponse(responseCode = "404", description = "NOT_FOUND: 사용자 또는 태스크를 찾을 수 없음")
   })
   @DeleteMapping("/{taskId}")
   public ResponseEntity<Void> deleteTask(
-          @PathVariable Long taskId
+      @PathVariable Long taskId
   ) {
     Long userId = AuthenticationUtil.getCurrentUserId();
     taskService.deleteTask(userId, taskId);
@@ -146,14 +151,13 @@ public class TaskController {
 
   @Operation(summary = "공식 태스크 삭제", description = "관리자가 공식 캘린더 태스크를 삭제합니다.")
   @ApiResponses({
-          @ApiResponse(responseCode = "204", description = "태스크 삭제 성공"),
-          @ApiResponse(responseCode = "403", description = "FORBIDDEN: 접근 권한 없음"),
-          @ApiResponse(responseCode = "404", description = "NOT_FOUND: 태스크 또는 사용자를 찾을 수 없음")
+      @ApiResponse(responseCode = "204", description = "태스크 삭제 성공"),
+      @ApiResponse(responseCode = "400", description = "INVALID_INPUT: 일반 태스크는 삭제할 수 없음"),
+      @ApiResponse(responseCode = "403", description = "FORBIDDEN: 접근 권한 없음"),
+      @ApiResponse(responseCode = "404", description = "NOT_FOUND: 사용자 또는 태스크를 찾을 수 없음")
   })
   @DeleteMapping("/official/{taskId}")
-  public ResponseEntity<Void> deleteOfficialTask(
-          @PathVariable Long taskId
-  ) {
+  public ResponseEntity<Void> deleteOfficialTask(@PathVariable Long taskId) {
     Long userId = AuthenticationUtil.getCurrentUserId();
     taskService.deleteOfficialTask(userId, taskId);
     return ResponseEntity.noContent().build();

--- a/src/main/java/kr/santanrudolph/everyvent/domain/task/TaskController.java
+++ b/src/main/java/kr/santanrudolph/everyvent/domain/task/TaskController.java
@@ -1,0 +1,161 @@
+package kr.santanrudolph.everyvent.domain.task;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import kr.santanrudolph.everyvent.auth.AuthenticationUtil;
+import kr.santanrudolph.everyvent.domain.task.command.TaskUpdateCommand;
+import kr.santanrudolph.everyvent.domain.task.dto.request.TaskCreateRequest;
+import kr.santanrudolph.everyvent.domain.task.dto.response.TaskResponse;
+import kr.santanrudolph.everyvent.domain.task.dto.response.TaskResponses;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "태스크", description = "태스크 관련 API")
+@RestController
+@RequestMapping("/api/tasks")
+@RequiredArgsConstructor
+public class TaskController {
+
+  private final TaskService taskService;
+
+  @Operation(summary = "태스크 생성", description = "로그인한 사용자가 지정한 기간 동안 태스크를 생성합니다.")
+  @ApiResponses({
+          @ApiResponse(responseCode = "201", description = "태스크 생성 성공"),
+          @ApiResponse(responseCode = "400", description = "INVALID_INPUT: 잘못된 날짜 범위 또는 요청 값 오류"),
+          @ApiResponse(responseCode = "403", description = "FORBIDDEN: 캘린더 접근 권한 없음"),
+          @ApiResponse(responseCode = "404", description = "NOT_FOUND: 캘린더 또는 사용자 없음")
+  })
+  @PostMapping
+  public ResponseEntity<TaskResponses> createTask(
+          @Valid @RequestBody TaskCreateRequest request
+  ) {
+    Long userId = AuthenticationUtil.getCurrentUserId();
+    TaskResponses response = taskService.createTask(userId, request);
+    return ResponseEntity.status(HttpStatus.CREATED).body(response);
+  }
+
+  @Operation(summary = "공식 캘린더 태스크 생성", description = "관리자가 공식 캘린더에 지정한 기간 동안 태스크를 생성합니다.")
+  @ApiResponses({
+          @ApiResponse(responseCode = "201", description = "태스크 생성 성공"),
+          @ApiResponse(responseCode = "400", description = "INVALID_INPUT: 잘못된 날짜 범위 또는 요청 값 오류"),
+          @ApiResponse(responseCode = "403", description = "FORBIDDEN: 공식 캘린더 접근 권한 없음"),
+          @ApiResponse(responseCode = "404", description = "NOT_FOUND: 캘린더 또는 사용자 없음")
+  })
+  @PostMapping("/official")
+  public ResponseEntity<TaskResponses> createOfficialTask(
+          @Valid @RequestBody TaskCreateRequest request
+  ) {
+    Long userId = AuthenticationUtil.getCurrentUserId();
+    TaskResponses response = taskService.createOfficialTask(userId, request);
+    return ResponseEntity.status(HttpStatus.CREATED).body(response);
+  }
+
+  @Operation(summary = "태스크 조회", description = "로그인한 사용자가 소유한 일반 태스크를 조회합니다.")
+  @ApiResponses({
+          @ApiResponse(responseCode = "200", description = "태스크 조회 성공"),
+          @ApiResponse(responseCode = "403", description = "FORBIDDEN: 접근 권한 없음"),
+          @ApiResponse(responseCode = "404", description = "NOT_FOUND: 태스크 또는 사용자를 찾을 수 없음")
+  })
+  @GetMapping("/{taskId}")
+  public ResponseEntity<TaskResponse> getTask(@PathVariable Long taskId) {
+    Long userId = AuthenticationUtil.getCurrentUserId();
+    TaskResponse response = taskService.getTask(userId, taskId);
+    return ResponseEntity.ok(response);
+  }
+
+  @Operation(summary = "공식 캘린더 태스크 조회", description = "관리자가 공식 캘린더 태스크를 조회합니다.")
+  @ApiResponses({
+          @ApiResponse(responseCode = "200", description = "태스크 조회 성공"),
+          @ApiResponse(responseCode = "403", description = "FORBIDDEN: 접근 권한 없음"),
+          @ApiResponse(responseCode = "404", description = "NOT_FOUND: 태스크 또는 사용자를 찾을 수 없음")
+  })
+  @GetMapping("/official/{taskId}")
+  public ResponseEntity<TaskResponse> getOfficialTask(@PathVariable Long taskId) {
+    Long userId = AuthenticationUtil.getCurrentUserId();
+    TaskResponse response = taskService.getOfficialTask(userId, taskId);
+    return ResponseEntity.ok(response);
+  }
+
+  @Operation(summary = "태스크 수정", description = "로그인한 사용자가 소유한 태스크 이름 또는 날짜를 수정합니다.")
+  @ApiResponses({
+          @ApiResponse(responseCode = "200", description = "태스크 수정 성공"),
+          @ApiResponse(responseCode = "403", description = "FORBIDDEN: 접근 권한 없음"),
+          @ApiResponse(responseCode = "404", description = "NOT_FOUND: 태스크 또는 사용자를 찾을 수 없음")
+  })
+  @PutMapping("/{taskId}")
+  public ResponseEntity<TaskResponse> updateTaskDetails(
+          @PathVariable Long taskId,
+          @RequestBody TaskUpdateCommand command
+  ) {
+    Long userId = AuthenticationUtil.getCurrentUserId();
+    TaskResponse response = taskService.updateTaskDetails(userId, taskId, command);
+    return ResponseEntity.ok(response);
+  }
+
+  @Operation(summary = "공식 캘린더 태스크 수정", description = "관리자가 공식 캘린더 태스크 이름 또는 날짜를 수정합니다.")
+  @ApiResponses({
+          @ApiResponse(responseCode = "200", description = "태스크 수정 성공"),
+          @ApiResponse(responseCode = "403", description = "FORBIDDEN: 접근 권한 없음"),
+          @ApiResponse(responseCode = "404", description = "NOT_FOUND: 태스크 또는 사용자를 찾을 수 없음")
+  })
+  @PutMapping("/official/{taskId}")
+  public ResponseEntity<TaskResponse> updateOfficialTaskDetails(
+          @PathVariable Long taskId,
+          @RequestBody TaskUpdateCommand command
+  ) {
+    Long userId = AuthenticationUtil.getCurrentUserId();
+    TaskResponse response = taskService.updateOfficialTaskDetails(userId, taskId, command);
+    return ResponseEntity.ok(response);
+  }
+
+  @Operation(summary = "태스크 완료 상태 변경", description = "로그인한 사용자가 소유한 태스크의 완료 여부를 변경합니다.")
+  @ApiResponses({
+          @ApiResponse(responseCode = "200", description = "태스크의 완료 상태 수정 성공"),
+          @ApiResponse(responseCode = "403", description = "FORBIDDEN: 접근 권한 없음"),
+          @ApiResponse(responseCode = "404", description = "NOT_FOUND: 태스크 또는 사용자를 찾을 수 없음")
+  })
+  @PatchMapping("/completion/{taskId}")
+  public ResponseEntity<TaskResponse> updateTaskCompletion(
+          @PathVariable Long taskId,
+          @RequestParam boolean isCompleted
+  ) {
+    Long userId = AuthenticationUtil.getCurrentUserId();
+    TaskResponse response = taskService.updateTaskCompletion(userId, taskId, isCompleted);
+    return ResponseEntity.ok(response);
+  }
+
+  @Operation(summary = "태스크 삭제", description = "로그인한 사용자가 소유한 태스크를 삭제합니다.")
+  @ApiResponses({
+          @ApiResponse(responseCode = "204", description = "태스크 삭제 성공"),
+          @ApiResponse(responseCode = "403", description = "FORBIDDEN: 접근 권한 없음"),
+          @ApiResponse(responseCode = "404", description = "NOT_FOUND: 태스크 또는 사용자를 찾을 수 없음")
+  })
+  @DeleteMapping("/{taskId}")
+  public ResponseEntity<Void> deleteTask(
+          @PathVariable Long taskId
+  ) {
+    Long userId = AuthenticationUtil.getCurrentUserId();
+    taskService.deleteTask(userId, taskId);
+    return ResponseEntity.noContent().build();
+  }
+
+  @Operation(summary = "공식 태스크 삭제", description = "관리자가 공식 캘린더 태스크를 삭제합니다.")
+  @ApiResponses({
+          @ApiResponse(responseCode = "204", description = "태스크 삭제 성공"),
+          @ApiResponse(responseCode = "403", description = "FORBIDDEN: 접근 권한 없음"),
+          @ApiResponse(responseCode = "404", description = "NOT_FOUND: 태스크 또는 사용자를 찾을 수 없음")
+  })
+  @DeleteMapping("/official/{taskId}")
+  public ResponseEntity<Void> deleteOfficialTask(
+          @PathVariable Long taskId
+  ) {
+    Long userId = AuthenticationUtil.getCurrentUserId();
+    taskService.deleteOfficialTask(userId, taskId);
+    return ResponseEntity.noContent().build();
+  }
+}

--- a/src/main/java/kr/santanrudolph/everyvent/domain/task/TaskController.java
+++ b/src/main/java/kr/santanrudolph/everyvent/domain/task/TaskController.java
@@ -90,7 +90,7 @@ public class TaskController {
   @PutMapping("/{taskId}")
   public ResponseEntity<TaskResponse> updateTaskDetails(
           @PathVariable Long taskId,
-          @RequestBody TaskUpdateCommand command
+          @Valid @RequestBody TaskUpdateCommand command
   ) {
     Long userId = AuthenticationUtil.getCurrentUserId();
     TaskResponse response = taskService.updateTaskDetails(userId, taskId, command);
@@ -106,7 +106,7 @@ public class TaskController {
   @PutMapping("/official/{taskId}")
   public ResponseEntity<TaskResponse> updateOfficialTaskDetails(
           @PathVariable Long taskId,
-          @RequestBody TaskUpdateCommand command
+          @Valid @RequestBody TaskUpdateCommand command
   ) {
     Long userId = AuthenticationUtil.getCurrentUserId();
     TaskResponse response = taskService.updateOfficialTaskDetails(userId, taskId, command);

--- a/src/main/java/kr/santanrudolph/everyvent/domain/task/TaskRepository.java
+++ b/src/main/java/kr/santanrudolph/everyvent/domain/task/TaskRepository.java
@@ -1,0 +1,42 @@
+package kr.santanrudolph.everyvent.domain.task;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface TaskRepository extends JpaRepository<Task, Long> {
+  Optional<Task> findByIdAndDeletedAtIsNull(Long taskId);
+
+  List<Task> findByCalendarIdAndDeletedAtIsNull(Long id);
+
+  @Query("SELECT t FROM Task t WHERE t.calendar.id = :calendarId AND t.deletedAt IS NULL")
+  List<Task> findByCalendarId(
+      @Param("calendarId") Long calendarId);
+
+  @Query("""
+    SELECT t
+    FROM Task t
+    WHERE t.calendar.id = :calendarId
+      AND t.day = :day
+      AND t.deletedAt IS NULL
+  """)
+  List<Task> findByCalendarIdAndDay(
+      @Param("calendarId") Long calendarId,
+      @Param("day") int day);
+
+  @Query("""
+    SELECT COUNT(t)
+    FROM Task t
+    WHERE t.calendar.id = :calendarId
+      AND t.day = :day
+      AND t.deletedAt IS NULL
+  """)
+  int countByCalendarIdAndDay(
+      @Param("calendarId") Long calendarId,
+      @Param("day") int day);
+}

--- a/src/main/java/kr/santanrudolph/everyvent/domain/task/TaskRepository.java
+++ b/src/main/java/kr/santanrudolph/everyvent/domain/task/TaskRepository.java
@@ -12,11 +12,7 @@ import java.util.Optional;
 public interface TaskRepository extends JpaRepository<Task, Long> {
   Optional<Task> findByIdAndDeletedAtIsNull(Long taskId);
 
-  List<Task> findByCalendarIdAndDeletedAtIsNull(Long id);
-
-  @Query("SELECT t FROM Task t WHERE t.calendar.id = :calendarId AND t.deletedAt IS NULL")
-  List<Task> findByCalendarId(
-      @Param("calendarId") Long calendarId);
+  List<Task> findByCalendarIdAndDeletedAtIsNull(Long calendarId);
 
   @Query("""
     SELECT t

--- a/src/main/java/kr/santanrudolph/everyvent/domain/task/TaskRepository.java
+++ b/src/main/java/kr/santanrudolph/everyvent/domain/task/TaskRepository.java
@@ -30,13 +30,17 @@ public interface TaskRepository extends JpaRepository<Task, Long> {
       @Param("day") int day);
 
   @Query("""
-    SELECT COUNT(t)
+    SELECT t.day
     FROM Task t
     WHERE t.calendar.id = :calendarId
-      AND t.day = :day
+      AND t.day BETWEEN :start AND :end
       AND t.deletedAt IS NULL
-  """)
-  int countByCalendarIdAndDay(
-      @Param("calendarId") Long calendarId,
-      @Param("day") int day);
+    GROUP BY t.day
+    HAVING COUNT(t) >= 3
+    """)
+  List<Integer> findDaysWithLimitExceeded(
+          @Param("calendarId") Long calendarId,
+          @Param("start") int start,
+          @Param("end") int end
+  );
 }

--- a/src/main/java/kr/santanrudolph/everyvent/domain/task/TaskService.java
+++ b/src/main/java/kr/santanrudolph/everyvent/domain/task/TaskService.java
@@ -35,7 +35,7 @@ public class TaskService {
   public TaskResponses createTask(Long userId, TaskCreateRequest request) {
     Calendar calendar = getActiveCalendarOrThrow(request.calendarId());
     if (isOfficialCalendar(calendar)) {
-      throw new EveryventException(ErrorCode.FORBIDDEN, "공식 캘린더 태스크는 일반 생성 API에서 생성할 수 없습니다.");
+      throw new EveryventException(ErrorCode.INVALID_INPUT, "공식 캘린더 태스크는 일반 생성 API에서 생성할 수 없습니다.");
     }
 
     if (isPastOrSameStartMonth(calendar)) {
@@ -57,10 +57,10 @@ public class TaskService {
   public TaskResponses createOfficialTask(Long userId, TaskCreateRequest request) {
     Calendar calendar = getActiveCalendarOrThrow(request.calendarId());
     if (!isOfficialCalendar(calendar)) {
-      throw new EveryventException(ErrorCode.FORBIDDEN, "일반 캘린더 태스크는 공식 생성 API에서 생성할 수 없습니다.");
+      throw new EveryventException(ErrorCode.INVALID_INPUT, "일반 캘린더 태스크는 공식 생성 API에서 생성할 수 없습니다.");
     }
     if (isDeletedOfficialCalendar(calendar)) {
-      throw new EveryventException(ErrorCode.FORBIDDEN, "삭제된 공식 캘린더에는 접근할 수 없습니다.");
+      throw new EveryventException(ErrorCode.NOT_FOUND, "삭제된 공식 캘린더에는 접근할 수 없습니다.");
     }
 
     if (isPastStartMonth(calendar)) {
@@ -84,7 +84,7 @@ public class TaskService {
 
     Calendar calendar = task.getCalendar();
     if (isOfficialCalendar(calendar)) {
-      throw new EveryventException(ErrorCode.FORBIDDEN, "공식 캘린더 태스크는 일반 조회 API에서 조회할 수 없습니다.");
+      throw new EveryventException(ErrorCode.INVALID_INPUT, "공식 캘린더 태스크는 일반 조회 API에서 조회할 수 없습니다.");
     }
 
     User user = getUserOrThrow(userId);
@@ -98,10 +98,10 @@ public class TaskService {
 
     Calendar calendar = task.getCalendar();
     if (!isOfficialCalendar(calendar)) {
-      throw new EveryventException(ErrorCode.FORBIDDEN, "일반 캘린더 태스크는 공식 조회 API에서 조회할 수 없습니다.");
+      throw new EveryventException(ErrorCode.INVALID_INPUT, "일반 캘린더 태스크는 공식 조회 API에서 조회할 수 없습니다.");
     }
     if (isDeletedOfficialCalendar(calendar)) {
-      throw new EveryventException(ErrorCode.FORBIDDEN, "삭제된 공식 캘린더에는 접근할 수 없습니다.");
+      throw new EveryventException(ErrorCode.NOT_FOUND, "삭제된 공식 캘린더에는 접근할 수 없습니다.");
     }
 
     User user = getUserOrThrow(userId);
@@ -115,7 +115,7 @@ public class TaskService {
     Task task = getTaskOrThrow(taskId);
 
     if (isOfficialCalendar(task.getCalendar())) {
-      throw new EveryventException(ErrorCode.FORBIDDEN, "공식 캘린더 태스크는 일반 수정 API에서 수정할 수 없습니다.");
+      throw new EveryventException(ErrorCode.INVALID_INPUT, "공식 캘린더 태스크는 일반 수정 API에서 수정할 수 없습니다.");
     }
 
     if (isPastOrSameStartMonth(task.getCalendar())) {
@@ -136,10 +136,10 @@ public class TaskService {
 
     Calendar calendar = task.getCalendar();
     if (!isOfficialCalendar(calendar)) {
-      throw new EveryventException(ErrorCode.FORBIDDEN, "일반 캘린더 태스크는 공식 수정 API에서 수정할 수 없습니다.");
+      throw new EveryventException(ErrorCode.INVALID_INPUT, "일반 캘린더 태스크는 공식 수정 API에서 수정할 수 없습니다.");
     }
     if (isDeletedOfficialCalendar(calendar)) {
-      throw new EveryventException(ErrorCode.FORBIDDEN, "삭제된 공식 캘린더에는 접근할 수 없습니다.");
+      throw new EveryventException(ErrorCode.NOT_FOUND, "삭제된 공식 캘린더에는 접근할 수 없습니다.");
     }
 
     if (isPastStartMonth(task.getCalendar())) {
@@ -176,7 +176,7 @@ public class TaskService {
 
     Calendar calendar = task.getCalendar();
     if (isOfficialCalendar(calendar)) {
-      throw new EveryventException(ErrorCode.FORBIDDEN, "공식 캘린더 태스크는 일반 삭제 API에서 삭제할 수 없습니다.");
+      throw new EveryventException(ErrorCode.INVALID_INPUT, "공식 캘린더 태스크는 일반 삭제 API에서 삭제할 수 없습니다.");
     }
 
     if (isPastOrSameStartMonth(task.getCalendar())) {
@@ -195,10 +195,10 @@ public class TaskService {
 
     Calendar calendar = task.getCalendar();
     if (!isOfficialCalendar(calendar)) {
-      throw new EveryventException(ErrorCode.FORBIDDEN, "일반 캘린더 태스크는 공식 삭제 API에서 삭제할 수 없습니다.");
+      throw new EveryventException(ErrorCode.INVALID_INPUT, "일반 캘린더 태스크는 공식 삭제 API에서 삭제할 수 없습니다.");
     }
     if (isDeletedOfficialCalendar(calendar)) {
-      throw new EveryventException(ErrorCode.FORBIDDEN, "삭제된 공식 캘린더에는 접근할 수 없습니다.");
+      throw new EveryventException(ErrorCode.NOT_FOUND, "삭제된 공식 캘린더에는 접근할 수 없습니다.");
     }
 
     User user = getUserOrThrow(userId);
@@ -219,7 +219,7 @@ public class TaskService {
             .orElseThrow(() -> new EveryventException(ErrorCode.NOT_FOUND, "해당 캘린더를 찾을 수 없습니다."));
 
     if (calendar.getDeletedAt() != null) {
-      throw new EveryventException(ErrorCode.FORBIDDEN, "이미 삭제된 캘린더입니다.");
+      throw new EveryventException(ErrorCode.NOT_FOUND, "이미 삭제된 캘린더입니다.");
     }
 
     return calendar;

--- a/src/main/java/kr/santanrudolph/everyvent/domain/task/TaskService.java
+++ b/src/main/java/kr/santanrudolph/everyvent/domain/task/TaskService.java
@@ -247,12 +247,9 @@ public class TaskService {
     int start = startDate.getDayOfMonth();
     int end = endDate.getDayOfMonth();
 
-    for (int day = start; day <= end; day++) {
-      int count = taskRepository.countByCalendarIdAndDay(calendar.getId(), day);
-
-      if (count >= 3) {
-        throw new EveryventException(ErrorCode.FORBIDDEN, "태스크는 각 일자에 최대 3개까지 생성할 수 있습니다.");
-      }
+    List<Integer> exceededDays = taskRepository.findDaysWithLimitExceeded(calendar.getId(), start, end);
+    if (!exceededDays.isEmpty()) {
+      throw new EveryventException(ErrorCode.FORBIDDEN, "태스크는 각 일자에 최대 3개까지 생성할 수 있습니다.");
     }
   }
 

--- a/src/main/java/kr/santanrudolph/everyvent/domain/task/TaskService.java
+++ b/src/main/java/kr/santanrudolph/everyvent/domain/task/TaskService.java
@@ -35,7 +35,7 @@ public class TaskService {
   public TaskResponses createTask(Long userId, TaskCreateRequest request) {
     Calendar calendar = getActiveCalendarOrThrow(request.calendarId());
     if (isOfficialCalendar(calendar)) {
-      throw new EveryventException(ErrorCode.NOT_FOUND, "공식 캘린더 태스크는 일반 생성 API에서 생성할 수 없습니다.");
+      throw new EveryventException(ErrorCode.FORBIDDEN, "공식 캘린더 태스크는 일반 생성 API에서 생성할 수 없습니다.");
     }
 
     if (isPastOrSameStartMonth(calendar)) {
@@ -57,7 +57,7 @@ public class TaskService {
   public TaskResponses createOfficialTask(Long userId, TaskCreateRequest request) {
     Calendar calendar = getActiveCalendarOrThrow(request.calendarId());
     if (!isOfficialCalendar(calendar)) {
-      throw new EveryventException(ErrorCode.NOT_FOUND, "일반 캘린더 태스크는 공식 생성 API에서 생성할 수 없습니다.");
+      throw new EveryventException(ErrorCode.FORBIDDEN, "일반 캘린더 태스크는 공식 생성 API에서 생성할 수 없습니다.");
     }
     if (isDeletedOfficialCalendar(calendar)) {
       throw new EveryventException(ErrorCode.FORBIDDEN, "삭제된 공식 캘린더에는 접근할 수 없습니다.");

--- a/src/main/java/kr/santanrudolph/everyvent/domain/task/TaskService.java
+++ b/src/main/java/kr/santanrudolph/everyvent/domain/task/TaskService.java
@@ -1,0 +1,309 @@
+package kr.santanrudolph.everyvent.domain.task;
+
+import kr.santanrudolph.everyvent.domain.calendar.CalendarRepository;
+import kr.santanrudolph.everyvent.domain.calendar.OfficialCalendarRepository;
+import kr.santanrudolph.everyvent.domain.calendar.entity.Calendar;
+import kr.santanrudolph.everyvent.domain.calendar.entity.OfficialCalendar;
+import kr.santanrudolph.everyvent.domain.task.command.TaskUpdateCommand;
+import kr.santanrudolph.everyvent.domain.task.dto.request.TaskCreateRequest;
+import kr.santanrudolph.everyvent.domain.task.dto.response.TaskResponse;
+import kr.santanrudolph.everyvent.domain.task.dto.response.TaskResponses;
+import kr.santanrudolph.everyvent.domain.user.User;
+import kr.santanrudolph.everyvent.domain.user.UserRepository;
+import kr.santanrudolph.everyvent.domain.user.enums.Role;
+import kr.santanrudolph.everyvent.global.exception.ErrorCode;
+import kr.santanrudolph.everyvent.global.exception.EveryventException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.YearMonth;
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class TaskService {
+
+  private final TaskRepository taskRepository;
+  private final CalendarRepository calendarRepository;
+  private final OfficialCalendarRepository officialCalendarRepository;
+  private final UserRepository userRepository;
+
+  @Transactional
+  public TaskResponses createTask(Long userId, TaskCreateRequest request) {
+    Calendar calendar = getActiveCalendarOrThrow(request.calendarId());
+
+    if (isPastOrSameStartMonth(calendar)) {
+      throw new EveryventException(ErrorCode.FORBIDDEN, "해당 캘린더의 월이 시작되면 일반 태스크는 생성할 수 없습니다.");
+    }
+
+    User user = getUserOrThrow(userId);
+    validateOwnerPermission(calendar, user);
+
+    validateDailyTaskLimit(calendar, request.startDate(), request.endDate());
+
+    List<Task> tasks = createTaskEntities(calendar, request);
+    taskRepository.saveAll(tasks);
+
+    return TaskResponses.from(tasks);
+  }
+
+  @Transactional
+  public TaskResponses createOfficialTask(Long userId, TaskCreateRequest request) {
+    Calendar calendar = getActiveCalendarOrThrow(request.calendarId());
+    if (!isOfficialCalendar(calendar)) {
+      throw new EveryventException(ErrorCode.NOT_FOUND, "해당 캘린더는 공식 캘린더가 아닙니다.");
+    }
+
+    if (isPastStartMonth(calendar)) {
+      throw new EveryventException(ErrorCode.FORBIDDEN, "해당 캘린더의 월까지만 공식 태스크를 생성할 수 있습니다.");
+    }
+
+    User user = getUserOrThrow(userId);
+    validateAdminPermission(user);
+
+    validateDailyTaskLimit(calendar, request.startDate(), request.endDate());
+
+    List<Task> tasks = createTaskEntities(calendar, request);
+
+    taskRepository.saveAll(tasks);
+
+    return TaskResponses.from(tasks);
+  }
+
+  public TaskResponse getTask(Long userId, Long taskId) {
+    Task task = getTaskOrThrow(taskId);
+
+    Calendar calendar = task.getCalendar();
+    if (isOfficialCalendar(calendar)) {
+      throw new EveryventException(ErrorCode.FORBIDDEN, "공식 캘린더 태스크는 일반 조회 API에서 조회할 수 없습니다.");
+    }
+
+    User user = getUserOrThrow(userId);
+    validateOwnerPermission(calendar, user);
+
+    return TaskResponse.from(task);
+  }
+
+  public TaskResponse getOfficialTask(Long userId, Long taskId) {
+    Task task = getTaskOrThrow(taskId);
+
+    if (!isOfficialCalendar(task.getCalendar())) {
+      throw new EveryventException(ErrorCode.FORBIDDEN, "일반 캘린더 태스크는 공식 조회 API에서 조회할 수 없습니다.");
+    }
+
+    User user = getUserOrThrow(userId);
+    validateAdminPermission(user);
+
+    return TaskResponse.from(task);
+  }
+
+  @Transactional
+  public TaskResponse updateTaskDetails(Long userId, Long taskId, TaskUpdateCommand command) {
+    Task task = getTaskOrThrow(taskId);
+
+    if (isOfficialCalendar(task.getCalendar())) {
+      throw new EveryventException(ErrorCode.FORBIDDEN, "공식 캘린더 태스크는 일반 수정 API에서 수정할 수 없습니다.");
+    }
+
+    if (isPastOrSameStartMonth(task.getCalendar())) {
+      throw new EveryventException(ErrorCode.FORBIDDEN, "해당 캘린더의 월이 시작되면 일반 태스크는 수정할 수 없습니다.");
+    }
+
+    User user = getUserOrThrow(userId);
+    validateOwnerPermission(task.getCalendar(), user);
+
+    updateTaskFields(task, command);
+
+    return TaskResponse.from(task);
+  }
+
+  @Transactional
+  public TaskResponse updateOfficialTaskDetails(Long userId, Long taskId, TaskUpdateCommand command) {
+    Task task = getTaskOrThrow(taskId);
+
+    if (!isOfficialCalendar(task.getCalendar())) {
+      throw new EveryventException(ErrorCode.FORBIDDEN, "일반 캘린더 태스크는 공식 수정 API에서 수정할 수 없습니다.");
+    }
+
+    if (isPastStartMonth(task.getCalendar())) {
+      throw new EveryventException(ErrorCode.FORBIDDEN, "해당 캘린더의 월까지만 공식 태스크를 수정할 수 있습니다.");
+    }
+
+    User user = getUserOrThrow(userId);
+    validateAdminPermission(user);
+
+    updateTaskFields(task, command);
+
+    return TaskResponse.from(task);
+  }
+
+  @Transactional
+  public TaskResponse updateTaskCompletion(Long userId, Long taskId, boolean isCompleted) {
+    Task task = getTaskOrThrow(taskId);
+
+    User user = getUserOrThrow(userId);
+    validateOwnerPermission(task.getCalendar(), user);
+
+    if (isCompleted) {
+      task.markCompleted();
+    } else {
+      task.unmarkCompleted();
+    }
+
+    return TaskResponse.from(task);
+  }
+
+  @Transactional
+  public void deleteTask(Long userId, Long taskId) {
+    Task task = getTaskOrThrow(taskId);
+
+    Calendar calendar = task.getCalendar();
+    if (isOfficialCalendar(calendar)) {
+      throw new EveryventException(ErrorCode.FORBIDDEN, "공식 캘린더 태스크는 일반 삭제 API에서 삭제할 수 없습니다.");
+    }
+
+    if (isPastOrSameStartMonth(task.getCalendar())) {
+      throw new EveryventException(ErrorCode.FORBIDDEN, "해당 캘린더의 월이 시작되면 일반 태스크는 삭제할 수 없습니다.");
+    }
+
+    User user = getUserOrThrow(userId);
+    validateOwnerPermission(calendar, user);
+
+    task.softDelete();
+  }
+
+  @Transactional
+  public void deleteOfficialTask(Long userId, Long taskId) {
+    Task task = getTaskOrThrow(taskId);
+
+    if (!isOfficialCalendar(task.getCalendar())) {
+      throw new EveryventException(ErrorCode.FORBIDDEN, "일반 캘린더 태스크는 공식 삭제 API에서 삭제할 수 없습니다.");
+    }
+
+    User user = getUserOrThrow(userId);
+    validateAdminPermission(user);
+
+    task.softDelete();
+  }
+
+  // ==================== Private Helper Methods ====================
+  // 엔티티/객체 관련
+  private User getUserOrThrow(Long userId) {
+    return userRepository.findByIdAndDeletedAtIsNull(userId)
+            .orElseThrow(() -> new EveryventException(ErrorCode.NOT_FOUND, "해당 사용자를 찾을 수 없습니다."));
+  }
+
+  private Calendar getActiveCalendarOrThrow(Long calendarId) {
+    Calendar calendar = calendarRepository.findById(calendarId)
+            .orElseThrow(() -> new EveryventException(ErrorCode.NOT_FOUND, "해당 캘린더를 찾을 수 없습니다."));
+
+    if (calendar.getDeletedAt() != null) {
+      throw new EveryventException(ErrorCode.FORBIDDEN, "이미 삭제된 캘린더입니다.");
+    }
+
+    return calendar;
+  }
+
+  private Task getTaskOrThrow(Long taskId) {
+    return taskRepository.findByIdAndDeletedAtIsNull(taskId)
+            .orElseThrow(() -> new EveryventException(ErrorCode.NOT_FOUND, "태스크를 찾을 수 없습니다."));
+  }
+
+  // 권한/검증 관련
+  private void validateOwnerPermission(Calendar calendar, User user) {
+    if (!calendar.getUser().equals(user)) {
+      throw new EveryventException(ErrorCode.FORBIDDEN, "해당 캘린더에 접근할 권한이 없습니다.");
+    }
+  }
+
+  private void validateAdminPermission(User user) {
+    if (user.getRole() != Role.ADMIN) {
+      throw new EveryventException(ErrorCode.FORBIDDEN, "공식 캘린더에 접근할 권한이 없습니다.");
+    }
+  }
+
+  private void validateTaskDateRange(Calendar calendar, LocalDate start, LocalDate end) {
+    if (end.isBefore(start)) {
+      throw new EveryventException(ErrorCode.INVALID_INPUT, "종료일은 시작일과 같거나 이후의 날짜여야 합니다.");
+    }
+
+    LocalDate calendarStart = calendar.getStartDate();
+    LocalDate calendarEnd = calendar.getEndDate();
+
+    if (start.isBefore(calendarStart) || start.isAfter(calendarEnd)) {
+      throw new EveryventException(ErrorCode.INVALID_INPUT, "태스크 시작일은 캘린더 기간 안에 있어야 합니다.");
+    }
+    if (end.isBefore(calendarStart) || end.isAfter(calendarEnd)) {
+      throw new EveryventException(ErrorCode.INVALID_INPUT, "태스크 종료일은 캘린더 기간 안에 있어야 합니다.");
+    }
+  }
+
+  private void validateDailyTaskLimit(Calendar calendar, LocalDate startDate, LocalDate endDate) {
+
+    int start = startDate.getDayOfMonth();
+    int end = endDate.getDayOfMonth();
+
+    for (int day = start; day <= end; day++) {
+      int count = taskRepository.countByCalendarIdAndDay(calendar.getId(), day);
+
+      if (count >= 3) {
+        throw new EveryventException(ErrorCode.FORBIDDEN, "태스크는 각 일자에 최대 3개까지 생성할 수 있습니다.");
+      }
+    }
+  }
+
+  private boolean isOfficialCalendar(Calendar calendar) {
+    OfficialCalendar officialCalendar = officialCalendarRepository
+            .findByOriginalCalendarId(calendar.getId())
+            .orElse(null);
+
+    if (officialCalendar != null && officialCalendar.getDeletedAt() != null) {
+      throw new EveryventException(ErrorCode.FORBIDDEN, "삭제된 원본 캘린더엔 더 이상 접근할 수 없습니다.");
+    }
+
+    return officialCalendar != null;
+  }
+
+  private boolean isPastOrSameStartMonth(Calendar calendar) {
+    YearMonth now = YearMonth.now();
+    YearMonth startMonth = YearMonth.from(calendar.getStartDate());
+    return !now.isBefore(startMonth);
+  }
+
+  private boolean isPastStartMonth(Calendar calendar) {
+    YearMonth now = YearMonth.now();
+    YearMonth startMonth = YearMonth.from(calendar.getStartDate());
+    return now.isAfter(startMonth);
+  }
+
+  // 생성/업데이트 관련
+  private List<Task> createTaskEntities(Calendar calendar, TaskCreateRequest request) {
+    LocalDate start = request.startDate();
+    LocalDate end = request.endDate();
+    validateTaskDateRange(calendar, start, end);
+
+    List<Task> tasks = new ArrayList<>();
+
+    for (LocalDate date = start; !date.isAfter(end); date = date.plusDays(1)) {
+      int day = date.getDayOfMonth();
+      Task task = Task.create(calendar, request.name(), day);
+      tasks.add(task);
+    }
+
+    return tasks;
+  }
+
+  private void updateTaskFields(Task task, TaskUpdateCommand command) {
+    if (command.name() != null && !command.name().isBlank()) {
+      task.updateName(command.name());
+    }
+    if (command.day() != null) {
+      task.updateDay(command.day());
+    }
+  }
+
+}

--- a/src/main/java/kr/santanrudolph/everyvent/domain/task/TaskService.java
+++ b/src/main/java/kr/santanrudolph/everyvent/domain/task/TaskService.java
@@ -57,7 +57,10 @@ public class TaskService {
   public TaskResponses createOfficialTask(Long userId, TaskCreateRequest request) {
     Calendar calendar = getActiveCalendarOrThrow(request.calendarId());
     if (!isOfficialCalendar(calendar)) {
-      throw new EveryventException(ErrorCode.NOT_FOUND, "해당 캘린더는 공식 캘린더가 아니거나 삭제된 캘린더입니다.");
+      throw new EveryventException(ErrorCode.NOT_FOUND, "일반 캘린더 태스크는 공식 생성 API에서 생성할 수 없습니다.");
+    }
+    if (isDeletedOfficialCalendar(calendar)) {
+      throw new EveryventException(ErrorCode.FORBIDDEN, "삭제된 공식 캘린더에는 접근할 수 없습니다.");
     }
 
     if (isPastStartMonth(calendar)) {
@@ -93,8 +96,12 @@ public class TaskService {
   public TaskResponse getOfficialTask(Long userId, Long taskId) {
     Task task = getTaskOrThrow(taskId);
 
-    if (!isOfficialCalendar(task.getCalendar())) {
+    Calendar calendar = task.getCalendar();
+    if (!isOfficialCalendar(calendar)) {
       throw new EveryventException(ErrorCode.FORBIDDEN, "일반 캘린더 태스크는 공식 조회 API에서 조회할 수 없습니다.");
+    }
+    if (isDeletedOfficialCalendar(calendar)) {
+      throw new EveryventException(ErrorCode.FORBIDDEN, "삭제된 공식 캘린더에는 접근할 수 없습니다.");
     }
 
     User user = getUserOrThrow(userId);
@@ -127,8 +134,12 @@ public class TaskService {
   public TaskResponse updateOfficialTaskDetails(Long userId, Long taskId, TaskUpdateCommand command) {
     Task task = getTaskOrThrow(taskId);
 
-    if (!isOfficialCalendar(task.getCalendar())) {
+    Calendar calendar = task.getCalendar();
+    if (!isOfficialCalendar(calendar)) {
       throw new EveryventException(ErrorCode.FORBIDDEN, "일반 캘린더 태스크는 공식 수정 API에서 수정할 수 없습니다.");
+    }
+    if (isDeletedOfficialCalendar(calendar)) {
+      throw new EveryventException(ErrorCode.FORBIDDEN, "삭제된 공식 캘린더에는 접근할 수 없습니다.");
     }
 
     if (isPastStartMonth(task.getCalendar())) {
@@ -182,8 +193,12 @@ public class TaskService {
   public void deleteOfficialTask(Long userId, Long taskId) {
     Task task = getTaskOrThrow(taskId);
 
-    if (!isOfficialCalendar(task.getCalendar())) {
+    Calendar calendar = task.getCalendar();
+    if (!isOfficialCalendar(calendar)) {
       throw new EveryventException(ErrorCode.FORBIDDEN, "일반 캘린더 태스크는 공식 삭제 API에서 삭제할 수 없습니다.");
+    }
+    if (isDeletedOfficialCalendar(calendar)) {
+      throw new EveryventException(ErrorCode.FORBIDDEN, "삭제된 공식 캘린더에는 접근할 수 없습니다.");
     }
 
     User user = getUserOrThrow(userId);
@@ -258,7 +273,13 @@ public class TaskService {
   private boolean isOfficialCalendar(Calendar calendar) {
     return officialCalendarRepository
             .findByOriginalCalendarId(calendar.getId())
-            .map(oc -> oc.getDeletedAt() == null)
+            .isPresent();
+  }
+
+  private boolean isDeletedOfficialCalendar(Calendar calendar) {
+    return officialCalendarRepository
+            .findByOriginalCalendarId(calendar.getId())
+            .map(oc -> oc.getDeletedAt() != null)
             .orElse(false);
   }
 

--- a/src/main/java/kr/santanrudolph/everyvent/domain/task/TaskService.java
+++ b/src/main/java/kr/santanrudolph/everyvent/domain/task/TaskService.java
@@ -316,7 +316,7 @@ public class TaskService {
     if (command.name() != null && !command.name().isBlank()) {
       task.updateName(command.name());
     }
-    if (command.day() != null) {
+    if (command.day() != null && !command.day().equals(task.getDay())) {
       YearMonth yearMonth = YearMonth.from(task.getCalendar().getStartDate());
       LocalDate changedDate = yearMonth.atDay(command.day());
       validateDailyTaskLimit(task.getCalendar(), changedDate, changedDate);

--- a/src/main/java/kr/santanrudolph/everyvent/domain/task/TaskService.java
+++ b/src/main/java/kr/santanrudolph/everyvent/domain/task/TaskService.java
@@ -55,7 +55,7 @@ public class TaskService {
   public TaskResponses createOfficialTask(Long userId, TaskCreateRequest request) {
     Calendar calendar = getActiveCalendarOrThrow(request.calendarId());
     if (!isOfficialCalendar(calendar)) {
-      throw new EveryventException(ErrorCode.NOT_FOUND, "해당 캘린더는 공식 캘린더가 아닙니다.");
+      throw new EveryventException(ErrorCode.NOT_FOUND, "해당 캘린더는 공식 캘린더가 아니거나 삭제된 캘린더입니다.");
     }
 
     if (isPastStartMonth(calendar)) {
@@ -254,15 +254,10 @@ public class TaskService {
   }
 
   private boolean isOfficialCalendar(Calendar calendar) {
-    OfficialCalendar officialCalendar = officialCalendarRepository
+    return officialCalendarRepository
             .findByOriginalCalendarId(calendar.getId())
-            .orElse(null);
-
-    if (officialCalendar != null && officialCalendar.getDeletedAt() != null) {
-      throw new EveryventException(ErrorCode.FORBIDDEN, "삭제된 원본 캘린더엔 더 이상 접근할 수 없습니다.");
-    }
-
-    return officialCalendar != null;
+            .map(oc -> oc.getDeletedAt() == null)
+            .orElse(false);
   }
 
   private boolean isPastOrSameStartMonth(Calendar calendar) {

--- a/src/main/java/kr/santanrudolph/everyvent/domain/task/TaskService.java
+++ b/src/main/java/kr/santanrudolph/everyvent/domain/task/TaskService.java
@@ -34,6 +34,9 @@ public class TaskService {
   @Transactional
   public TaskResponses createTask(Long userId, TaskCreateRequest request) {
     Calendar calendar = getActiveCalendarOrThrow(request.calendarId());
+    if (isOfficialCalendar(calendar)) {
+      throw new EveryventException(ErrorCode.NOT_FOUND, "공식 캘린더 태스크는 일반 생성 API에서 생성할 수 없습니다.");
+    }
 
     if (isPastOrSameStartMonth(calendar)) {
       throw new EveryventException(ErrorCode.FORBIDDEN, "해당 캘린더의 월이 시작되면 일반 태스크는 생성할 수 없습니다.");

--- a/src/main/java/kr/santanrudolph/everyvent/domain/task/TaskService.java
+++ b/src/main/java/kr/santanrudolph/everyvent/domain/task/TaskService.java
@@ -3,7 +3,6 @@ package kr.santanrudolph.everyvent.domain.task;
 import kr.santanrudolph.everyvent.domain.calendar.CalendarRepository;
 import kr.santanrudolph.everyvent.domain.calendar.OfficialCalendarRepository;
 import kr.santanrudolph.everyvent.domain.calendar.entity.Calendar;
-import kr.santanrudolph.everyvent.domain.calendar.entity.OfficialCalendar;
 import kr.santanrudolph.everyvent.domain.task.command.TaskUpdateCommand;
 import kr.santanrudolph.everyvent.domain.task.dto.request.TaskCreateRequest;
 import kr.santanrudolph.everyvent.domain.task.dto.response.TaskResponse;
@@ -294,6 +293,9 @@ public class TaskService {
       task.updateName(command.name());
     }
     if (command.day() != null) {
+      YearMonth yearMonth = YearMonth.from(task.getCalendar().getStartDate());
+      LocalDate changedDate = yearMonth.atDay(command.day());
+      validateDailyTaskLimit(task.getCalendar(), changedDate, changedDate);
       task.updateDay(command.day());
     }
   }

--- a/src/main/java/kr/santanrudolph/everyvent/domain/task/command/TaskUpdateCommand.java
+++ b/src/main/java/kr/santanrudolph/everyvent/domain/task/command/TaskUpdateCommand.java
@@ -1,0 +1,6 @@
+package kr.santanrudolph.everyvent.domain.task.command;
+
+public record TaskUpdateCommand(
+    String name,
+    Integer day
+) {}

--- a/src/main/java/kr/santanrudolph/everyvent/domain/task/dto/request/TaskCreateRequest.java
+++ b/src/main/java/kr/santanrudolph/everyvent/domain/task/dto/request/TaskCreateRequest.java
@@ -1,0 +1,20 @@
+package kr.santanrudolph.everyvent.domain.task.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+import java.time.LocalDate;
+
+public record TaskCreateRequest(
+        @NotNull
+        Long calendarId,
+
+        @NotBlank
+        String name,
+
+        @NotNull
+        LocalDate startDate,
+
+        @NotNull
+        LocalDate endDate
+) {}

--- a/src/main/java/kr/santanrudolph/everyvent/domain/task/dto/response/TaskResponse.java
+++ b/src/main/java/kr/santanrudolph/everyvent/domain/task/dto/response/TaskResponse.java
@@ -1,0 +1,21 @@
+package kr.santanrudolph.everyvent.domain.task.dto.response;
+
+import kr.santanrudolph.everyvent.domain.task.Task;
+
+public record TaskResponse(
+        Long id,
+        Long calendarId,
+        String name,
+        int day,
+        boolean isCompleted
+) {
+  public static TaskResponse from(Task task) {
+    return new TaskResponse(
+            task.getId(),
+            task.getCalendar().getId(),
+            task.getName(),
+            task.getDay(),
+            task.isCompleted()
+    );
+  }
+}

--- a/src/main/java/kr/santanrudolph/everyvent/domain/task/dto/response/TaskResponses.java
+++ b/src/main/java/kr/santanrudolph/everyvent/domain/task/dto/response/TaskResponses.java
@@ -1,0 +1,18 @@
+package kr.santanrudolph.everyvent.domain.task.dto.response;
+
+import kr.santanrudolph.everyvent.domain.task.Task;
+
+import java.util.List;
+
+public record TaskResponses(
+    List<TaskResponse> tasks
+) {
+
+  public static TaskResponses from(List<Task> entities) {
+    List<TaskResponse> responses = entities.stream()
+        .map(TaskResponse::from)
+        .toList();
+
+    return new TaskResponses(responses);
+  }
+}


### PR DESCRIPTION
## 📝 무엇을 했나요?
이번 PR에서는 Task 관련 기능 전반을 구현하고, JPA 매핑 문제와 soft delete 기능까지 포함했습니다. 주요 변경 사항은 다음과 같습니다.

**1. 컬럼 매핑 오류 수정**
- day 필드가 예약어로 인식되지 않아 day_of_month로 컬럼명 변경

**2. Soft Delete 기능 추가**
- Task 엔티티에 deletedAt 필드 추가
- 삭제 대신 soft delete 처리하는 softDelete() 메서드 구현

**3. Task 생성/수정/조회용 DTO 및 Command**
- Task 생성 요청을 처리하는 TaskCreateRequest DTO 추가
- Task 수정 요청을 처리하는 TaskUpdateCommand 추가
- Task 응답용 TaskResponse, TaskResponses DTO 추가

**4. 캘린더 내 태스크 배포 로직 구현**
- 사용자 및 공식 캘린더 기준으로 태스크 배포 로직을 Service/Repository 레이어에 구현
- 배포된 태스크를 조회, 저장, 상태 관리 가능

**5. Task 관련 REST API 엔드포인트 구현**
- Task 생성, 수정, 삭제, 조회 등 주요 엔드포인트 추가
- Controller에서 Request/Response DTO를 이용해 클라이언트 요청 처리

## 💭 고민 지점과 리뷰 포인트
1. Soft Delete 구현 : deletedAt 값이 잘 설정되고 조회 시 soft deleted 데이터가 필터링되는지
2. 컬럼명 변경(day → day_of_month)으로 이제 문제없이 JPA 매핑이 되는지
3. DTO/Command 구조가 적절한지
4. REST API 경로 및 HTTP 메서드가 적절한지

## 🔗 관련 이슈
#19 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 작업 관리 REST API 추가: 생성·조회·수정·삭제·완료 토글(일반/공식 캘린더 구분)
  * 작업 생성 시 요청·응답 포맷 도입(단건·일괄 응답 지원)
  * 특정 기간 내 일별 한도 초과일 조회 기능 추가

* **Bug Fixes / Improvements**
  * 소프트 삭제 도입(삭제된 작업은 보존하되 조회에서 제외)
  * 날짜 필드 매핑 개선(일자 컬럼명 명시) 및 권한·유효성 검사 강화

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->