### PR TITLE
feat(user): 내 정보 조회에 닉네임 필요 여부 필드 추가

### DIFF
--- a/src/main/java/kr/santanrudolph/everyvent/domain/user/User.java
+++ b/src/main/java/kr/santanrudolph/everyvent/domain/user/User.java
@@ -4,7 +4,9 @@ import jakarta.persistence.*;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+
 import java.time.Instant;
+
 import kr.santanrudolph.everyvent.domain.user.enums.Role;
 import kr.santanrudolph.everyvent.domain.user.enums.SocialProvider;
 import kr.santanrudolph.everyvent.global.entity.BaseEntity;
@@ -53,7 +55,7 @@ public class User extends BaseEntity {
   private Instant deletedAt;
 
   public User(String socialId, SocialProvider socialProvider, String email, String nickname,
-      String introduction, Role role) {
+              String introduction, Role role) {
     this.socialId = socialId;
     this.socialProvider = socialProvider;
     this.email = email;
@@ -63,12 +65,12 @@ public class User extends BaseEntity {
   }
 
   public static User createFromOAuth(String socialId, SocialProvider provider, String email,
-      String nickname) {
+                                     String nickname) {
     return new User(socialId, provider, email, nickname, null, Role.USER);
   }
 
   public static User createAdmin(String socialId, SocialProvider provider, String email,
-      String nickname) {
+                                 String nickname) {
     return new User(socialId, provider, email, nickname, null, Role.ADMIN);
   }
 
@@ -91,4 +93,13 @@ public class User extends BaseEntity {
   public boolean isDeleted() {
     return this.deletedAt != null;
   }
+
+  public String getDefaultNickname() {
+    return this.socialProvider + "_" + this.socialId;
+  }
+
+  public boolean isNicknameRequired() {
+    return this.nickname.equals(getDefaultNickname());
+  }
+
 }

--- a/src/main/java/kr/santanrudolph/everyvent/domain/user/dto/response/UserResponse.java
+++ b/src/main/java/kr/santanrudolph/everyvent/domain/user/dto/response/UserResponse.java
@@ -10,17 +10,20 @@ public record UserResponse(
     String email,
     String introduction,
     String socialProvider,
-    String role
+    String role,
+    boolean isNicknameRequired
 ) {
 
   public static UserResponse from(User user) {
+
     return new UserResponse(
         user.getId(),
         user.getNickname(),
         user.getEmail(),
         user.getIntroduction(),
         user.getSocialProvider().name(),
-        user.getRole().name()
+        user.getRole().name(),
+        user.isNicknameRequired()
     );
   }
 }


### PR DESCRIPTION
## 📝 무엇을 했나요?
프론트에서 유저가 로그인하면 닉네임 설정 페이지로 이동시킬지 홈화면으로 이동시킬지 판단하기 위해 
내 정보 조회 API인 `/api/users/me` 의 응답값에 `isNicknameRequired` 필드를 추가했어요.

## 🔗 관련 이슈
Close #54

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새 기능

* **새 기능**
  * 사용자 닉네임 필수 설정 여부를 확인할 수 있는 기능이 추가되었습니다.
  * API 응답에 닉네임 설정 필요 여부 정보가 포함되도록 업데이트되었습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->