### PR TITLE
refactor(follow): UserBasicResponse에 introduction 추가로 인한 로직 코드 수정

### DIFF
--- a/src/main/java/kr/santanrudolph/everyvent/domain/follow/FollowController.java
+++ b/src/main/java/kr/santanrudolph/everyvent/domain/follow/FollowController.java
@@ -66,7 +66,7 @@ public class FollowController {
 
   @Operation(
       summary = "특정 사용자의 팔로워 목록 조회",
-      description = "특정 사용자를 팔로우하는 Follow 관계 Id와 사용자 목록을 조회합니다."
+      description = "특정 사용자를 팔로우하는 사용자들의 Follow 관계 id와 목록을 조회합니다."
   )
   @ApiResponses({
       @ApiResponse(responseCode = "200", description = "팔로워 목록 조회 성공"),
@@ -85,7 +85,7 @@ public class FollowController {
 
   @Operation(
       summary = "특정 사용자의 팔로잉 목록 조회",
-      description = "특정 사용자가 팔로우하는 Follow 관계 Id와 사용자 목록을 조회합니다."
+      description = "특정 사용자가 팔로우하는 사용자들의 Follow 관계 id와 목록을 조회합니다."
   )
   @ApiResponses({
       @ApiResponse(responseCode = "200", description = "팔로잉 목록 조회 성공"),

--- a/src/main/java/kr/santanrudolph/everyvent/domain/follow/FollowController.java
+++ b/src/main/java/kr/santanrudolph/everyvent/domain/follow/FollowController.java
@@ -22,6 +22,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
 import java.util.List;
 
 @Tag(name = "팔로우", description = "팔로우 관련 API")
@@ -65,7 +66,7 @@ public class FollowController {
 
   @Operation(
       summary = "특정 사용자의 팔로워 목록 조회",
-      description = "특정 사용자를 팔로우하는 사용자 목록을 조회합니다."
+      description = "특정 사용자를 팔로우하는 Follow 관계 Id와 사용자 목록을 조회합니다."
   )
   @ApiResponses({
       @ApiResponse(responseCode = "200", description = "팔로워 목록 조회 성공"),
@@ -84,7 +85,7 @@ public class FollowController {
 
   @Operation(
       summary = "특정 사용자의 팔로잉 목록 조회",
-      description = "특정 사용자가 팔로우하는 사용자 목록을 조회합니다."
+      description = "특정 사용자가 팔로우하는 Follow 관계 Id와 사용자 목록을 조회합니다."
   )
   @ApiResponses({
       @ApiResponse(responseCode = "200", description = "팔로잉 목록 조회 성공"),

--- a/src/main/java/kr/santanrudolph/everyvent/domain/follow/FollowRepository.java
+++ b/src/main/java/kr/santanrudolph/everyvent/domain/follow/FollowRepository.java
@@ -1,8 +1,11 @@
 package kr.santanrudolph.everyvent.domain.follow;
 
 import java.util.List;
+
 import kr.santanrudolph.everyvent.domain.follow.dto.FollowResponse;
+
 import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -15,17 +18,17 @@ public interface FollowRepository extends JpaRepository<Follow, Long> {
   boolean existsByFollowerIdAndTargetId(Long followerId, Long targetId);
 
   @Query("SELECT COUNT(f) FROM Follow f " +
-         "WHERE f.target.id = :targetId " +
-         "AND f.follower.deletedAt IS NULL ")
+      "WHERE f.target.id = :targetId " +
+      "AND f.follower.deletedAt IS NULL ")
   int countActiveFollowersByTargetId(@Param("targetId") Long targetId);
 
   @Query("SELECT COUNT(f) FROM Follow f " +
-         "WHERE f.follower.id = :followerId " +
-         "AND f.target.deletedAt IS NULL")
+      "WHERE f.follower.id = :followerId " +
+      "AND f.target.deletedAt IS NULL")
   int countActiveFollowingsByFollowerId(@Param("followerId") Long followerId);
 
   @Query(
-      "SELECT new kr.santanrudolph.everyvent.domain.follow.dto.FollowResponse(f.id, u.id, u.nickname) "
+      "SELECT new kr.santanrudolph.everyvent.domain.follow.dto.FollowResponse(f.id, new kr.santanrudolph.everyvent.domain.user.dto.response.UserBasicResponse(u.id, u.nickname, u.introduction)) "
           +
           "FROM Follow f " +
           "JOIN f.follower u " +
@@ -33,7 +36,7 @@ public interface FollowRepository extends JpaRepository<Follow, Long> {
   List<FollowResponse> findActiveFollowersByTargetId(@Param("targetId") Long targetId);
 
   @Query(
-      "SELECT new kr.santanrudolph.everyvent.domain.follow.dto.FollowResponse(f.id, u.id, u.nickname) "
+      "SELECT new kr.santanrudolph.everyvent.domain.follow.dto.FollowResponse(f.id, new kr.santanrudolph.everyvent.domain.user.dto.response.UserBasicResponse(u.id, u.nickname, u.introduction)) "
           +
           "FROM Follow f " +
           "JOIN f.target u " +
@@ -45,7 +48,7 @@ public interface FollowRepository extends JpaRepository<Follow, Long> {
   @Modifying
   @Query("DELETE FROM Follow f WHERE f.follower.id = :followerId AND f.target.id = :targetId")
   int deleteByFollowerIdAndTargetId(@Param("followerId") Long followerId,
-      @Param("targetId") Long targetId);
+                                    @Param("targetId") Long targetId);
 
   @Modifying
   @Query("DELETE FROM Follow f WHERE f.follower.id = :userId OR f.target.id = :userId")

--- a/src/main/java/kr/santanrudolph/everyvent/domain/follow/FollowRepository.java
+++ b/src/main/java/kr/santanrudolph/everyvent/domain/follow/FollowRepository.java
@@ -1,11 +1,9 @@
 package kr.santanrudolph.everyvent.domain.follow;
 
 import java.util.List;
-
-import kr.santanrudolph.everyvent.domain.follow.dto.FollowResponse;
-
 import java.util.Optional;
 
+import kr.santanrudolph.everyvent.domain.follow.dto.FollowResponse;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -28,7 +26,7 @@ public interface FollowRepository extends JpaRepository<Follow, Long> {
   int countActiveFollowingsByFollowerId(@Param("followerId") Long followerId);
 
   @Query(
-      "SELECT new kr.santanrudolph.everyvent.domain.follow.dto.FollowResponse(f.id, new kr.santanrudolph.everyvent.domain.user.dto.response.UserBasicResponse(u.id, u.nickname, u.introduction)) "
+      "SELECT new kr.santanrudolph.everyvent.domain.follow.dto.FollowResponse(f.id, u.id, u.nickname, u.introduction) "
           +
           "FROM Follow f " +
           "JOIN f.follower u " +
@@ -36,7 +34,7 @@ public interface FollowRepository extends JpaRepository<Follow, Long> {
   List<FollowResponse> findActiveFollowersByTargetId(@Param("targetId") Long targetId);
 
   @Query(
-      "SELECT new kr.santanrudolph.everyvent.domain.follow.dto.FollowResponse(f.id, new kr.santanrudolph.everyvent.domain.user.dto.response.UserBasicResponse(u.id, u.nickname, u.introduction)) "
+      "SELECT new kr.santanrudolph.everyvent.domain.follow.dto.FollowResponse(f.id, u.id, u.nickname, u.introduction) "
           +
           "FROM Follow f " +
           "JOIN f.target u " +

--- a/src/main/java/kr/santanrudolph/everyvent/domain/follow/dto/FollowResponse.java
+++ b/src/main/java/kr/santanrudolph/everyvent/domain/follow/dto/FollowResponse.java
@@ -6,4 +6,8 @@ public record FollowResponse(
     Long id,
     UserBasicResponse user
 ) {
+
+  public FollowResponse(Long id, Long userId, String userNickname, String userIntroduction) {
+    this(id, new UserBasicResponse(userId, userNickname, userIntroduction));
+  }
 }

--- a/src/main/java/kr/santanrudolph/everyvent/domain/follow/dto/FollowResponse.java
+++ b/src/main/java/kr/santanrudolph/everyvent/domain/follow/dto/FollowResponse.java
@@ -6,8 +6,4 @@ public record FollowResponse(
     Long id,
     UserBasicResponse user
 ) {
-
-  public FollowResponse(Long id, Long userId, String userNickname) {
-    this(id, new UserBasicResponse(userId, userNickname));
-  }
 }

--- a/src/main/java/kr/santanrudolph/everyvent/domain/user/dto/response/UserBasicResponse.java
+++ b/src/main/java/kr/santanrudolph/everyvent/domain/user/dto/response/UserBasicResponse.java
@@ -6,13 +6,15 @@ import kr.santanrudolph.everyvent.domain.user.User;
 public record UserBasicResponse(
 
     Long id,
-    String nickname
+    String nickname,
+    String introduction
 ) {
 
   public static UserBasicResponse from(User user) {
     return new UserBasicResponse(
         user.getId(),
-        user.getNickname()
+        user.getNickname(),
+        user.getIntroduction()
     );
   }
 }

--- a/src/test/java/kr/santanrudolph/everyvent/domain/follow/FollowRepositoryTest.java
+++ b/src/test/java/kr/santanrudolph/everyvent/domain/follow/FollowRepositoryTest.java
@@ -67,7 +67,7 @@ class FollowRepositoryTest {
   @DisplayName("팔로워 목록 조회 테스트")
   class FindFollowersTest {
 
-    @DisplayName("follow_id, follower_id, follower_nickname 목록을 조회한다.")
+    @DisplayName("follow_id, follower_id, follower_nickname, follower_introduction 목록을 조회한다.")
     @Test
     void findFollowers_Success() {
       // given
@@ -84,10 +84,10 @@ class FollowRepositoryTest {
 
       // then
       assertThat(result).hasSize(2)
-          .extracting("id", "user.id", "user.nickname")
+          .extracting("id", "user.id", "user.nickname", "user.introduction")
           .containsExactlyInAnyOrder(
-              tuple(follow1.getId(), follower1.getId(), "follower1"),
-              tuple(follow2.getId(), follower2.getId(), "follower2"));
+              tuple(follow1.getId(), follower1.getId(), "follower1", null),
+              tuple(follow2.getId(), follower2.getId(), "follower2", null));
     }
 
     @DisplayName("팔로워가 없으면 빈 리스트를 반환한다.")
@@ -121,8 +121,8 @@ class FollowRepositoryTest {
 
       // then
       assertThat(result).hasSize(1)
-          .extracting("id", "user.id", "user.nickname")
-          .containsExactly(tuple(follow1.getId(), activeUser.getId(), activeUser.getNickname()));
+          .extracting("id", "user.id", "user.nickname", "user.introduction")
+          .containsExactly(tuple(follow1.getId(), activeUser.getId(), activeUser.getNickname(), null));
 
     }
 
@@ -149,10 +149,10 @@ class FollowRepositoryTest {
 
       // then
       assertThat(result).hasSize(2)
-          .extracting("id", "user.id", "user.nickname")
+          .extracting("id", "user.id", "user.nickname", "user.introduction")
           .containsExactlyInAnyOrder(
-              tuple(follow1.getId(), target1.getId(), target1.getNickname()),
-              tuple(follow2.getId(), target2.getId(), target2.getNickname()));
+              tuple(follow1.getId(), target1.getId(), target1.getNickname(), null),
+              tuple(follow2.getId(), target2.getId(), target2.getNickname(), null));
     }
 
     @DisplayName("팔로잉 하는 사람이 없으면 빈 리스트를 반환한다.")
@@ -186,8 +186,8 @@ class FollowRepositoryTest {
 
       // then
       assertThat(result).hasSize(1)
-          .extracting("id", "user.id", "user.nickname")
-          .containsExactly(tuple(follow1.getId(), target1.getId(), target1.getNickname()));
+          .extracting("id", "user.id", "user.nickname", "user.introduction")
+          .containsExactly(tuple(follow1.getId(), target1.getId(), target1.getNickname(), null));
     }
 
   }

--- a/src/test/java/kr/santanrudolph/everyvent/domain/follow/FollowServiceTest.java
+++ b/src/test/java/kr/santanrudolph/everyvent/domain/follow/FollowServiceTest.java
@@ -228,8 +228,8 @@ class FollowServiceTest {
       target = createUser(TARGET_ID, "target");
 
       List<FollowResponse> expectedFollowers = List.of(
-          new FollowResponse(FOLLOW_ID, FOLLOWER_ID, "follower1"),
-          new FollowResponse(FOLLOW_ID2, FOLLOWER_ID2, "follower2")
+          new FollowResponse(FOLLOW_ID, new kr.santanrudolph.everyvent.domain.user.dto.response.UserBasicResponse(FOLLOWER_ID, "follower1", "introduction1")),
+          new FollowResponse(FOLLOW_ID2, new kr.santanrudolph.everyvent.domain.user.dto.response.UserBasicResponse(FOLLOWER_ID2, "follower2", "introduction2"))
       );
 
       given(userRepository.findByIdAndDeletedAtIsNull(TARGET_ID)).willReturn(Optional.of(target));
@@ -242,10 +242,10 @@ class FollowServiceTest {
       // then
       assertThat(result)
           .hasSize(2)
-          .extracting("id", "user.id", "user.nickname")
+          .extracting("id", "user.id", "user.nickname", "user.introduction")
           .containsExactly(
-              tuple(FOLLOW_ID, FOLLOWER_ID, "follower1"),
-              tuple(FOLLOW_ID2, FOLLOWER_ID2, "follower2"));
+              tuple(FOLLOW_ID, FOLLOWER_ID, "follower1", "introduction1"),
+              tuple(FOLLOW_ID2, FOLLOWER_ID2, "follower2", "introduction2"));
       then(userRepository).should(times(1)).findByIdAndDeletedAtIsNull(TARGET_ID);
       then(followRepository).should(times(1)).findActiveFollowersByTargetId(TARGET_ID);
     }
@@ -299,8 +299,8 @@ class FollowServiceTest {
       follower = createUser(FOLLOWER_ID, "follower");
 
       List<FollowResponse> expectedFollowings = List.of(
-          new FollowResponse(FOLLOW_ID, TARGET_ID, "target1"),
-          new FollowResponse(FOLLOW_ID2, TARGET_ID2, "target2")
+          new FollowResponse(FOLLOW_ID, new kr.santanrudolph.everyvent.domain.user.dto.response.UserBasicResponse(TARGET_ID, "target1", "introduction1")),
+          new FollowResponse(FOLLOW_ID2, new kr.santanrudolph.everyvent.domain.user.dto.response.UserBasicResponse(TARGET_ID2, "target2", "introduction2"))
       );
 
       given(userRepository.findByIdAndDeletedAtIsNull(FOLLOWER_ID)).willReturn(
@@ -314,10 +314,10 @@ class FollowServiceTest {
       // then
       assertThat(result)
           .hasSize(2)
-          .extracting("id", "user.id", "user.nickname")
+          .extracting("id", "user.id", "user.nickname", "user.introduction")
           .containsExactly(
-              tuple(FOLLOW_ID, TARGET_ID, "target1"),
-              tuple(FOLLOW_ID2, TARGET_ID2, "target2"));
+              tuple(FOLLOW_ID, TARGET_ID, "target1", "introduction1"),
+              tuple(FOLLOW_ID2, TARGET_ID2, "target2", "introduction2"));
       then(userRepository).should(times(1)).findByIdAndDeletedAtIsNull(FOLLOWER_ID);
       then(followRepository).should(times(1)).findActiveFollowingsByFollowerId(FOLLOWER_ID);
     }


### PR DESCRIPTION
## 📝 무엇을 했나요?
팔로워/팔로우 목록 조회 시, 이름 뿐만 아니라 소개글도 반환하도록 소개글 필드를 추가했어요.
## 🔗 관련 이슈
Close #56 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **Documentation**
  * 팔로워/팔로잉 조회 API 설명을 보다 구체적으로 업데이트했습니다.

* **Refactor**
  * 팔로워/팔로잉 조회 응답에 사용자 소개(introduction) 필드가 추가되어 반환 내용이 확장되었습니다.

* **Tests**
  * 확장된 응답 구조를 반영하도록 관련 단위 테스트와 검증을 업데이트했습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->