### PR TITLE
refactor(calendar): 내 캘린더 조회 API 및 응답 DTO 개선

### DIFF
--- a/src/main/java/kr/santanrudolph/everyvent/domain/calendar/CalendarController.java
+++ b/src/main/java/kr/santanrudolph/everyvent/domain/calendar/CalendarController.java
@@ -88,19 +88,16 @@ public class CalendarController {
     return ResponseEntity.ok(response);
   }
 
-  @Operation(summary = "내 캘린더 목록 조회", description = "현재 로그인한 사용자가 생성한 특정 년/월 캘린더 목록을 조회합니다.")
+  @Operation(summary = "내 캘린더 목록 조회", description = "현재 로그인한 사용자가 생성한 모든 캘린더 목록을 조회합니다.")
   @ApiResponses({
       @ApiResponse(responseCode = "200", description = "조회 성공"),
       @ApiResponse(responseCode = "400", description = "INVALID_INPUT: 요청 형식 오류"),
       @ApiResponse(responseCode = "404", description = "NOT_FOUND: 사용자를 찾을 수 없음")
   })
   @GetMapping("/me")
-  public ResponseEntity<List<CalendarResponse>> getMyCalendars(
-      @RequestParam int year,
-      @RequestParam int month
-  ) {
+  public ResponseEntity<List<CalendarResponse>> getMyCalendars() {
     Long userId = AuthenticationUtil.getCurrentUserId();
-    List<CalendarResponse> responses = calendarService.getMyCalendars(userId, year, month);
+    List<CalendarResponse> responses = calendarService.getMyCalendars(userId);
     return ResponseEntity.ok(responses);
   }
 

--- a/src/main/java/kr/santanrudolph/everyvent/domain/calendar/CalendarRepository.java
+++ b/src/main/java/kr/santanrudolph/everyvent/domain/calendar/CalendarRepository.java
@@ -31,6 +31,16 @@ public interface CalendarRepository extends JpaRepository<Calendar, Long> {
   @Query("""
   SELECT c FROM OriginalCalendar c
   WHERE c.user.id = :userId
+    AND c.deletedAt IS NULL
+    AND NOT EXISTS (
+        SELECT 1 FROM OfficialCalendar o WHERE o.originalCalendar.id = c.id
+    )
+  """)
+  List<Calendar> findOriginalCalendarsByUserId(@Param("userId") Long userId);
+
+  @Query("""
+  SELECT c FROM OriginalCalendar c
+  WHERE c.user.id = :userId
     AND c.startDate = :startDate
     AND c.deletedAt IS NULL
     AND NOT EXISTS (

--- a/src/main/java/kr/santanrudolph/everyvent/domain/calendar/CalendarService.java
+++ b/src/main/java/kr/santanrudolph/everyvent/domain/calendar/CalendarService.java
@@ -104,14 +104,12 @@ public class CalendarService {
     return toCalendarResponse(calendar, isScrapable);
   }
 
-  public List<CalendarResponse> getMyCalendars(Long userId, int year, int month) {
+  public List<CalendarResponse> getMyCalendars(Long userId) {
 
     User user = getUserOrThrow(userId);
 
-    LocalDate date = LocalDate.of(year, month, 1);
-    log.info("조회 캘린더 기간 시작일: {}", date);
-
-    List<Calendar> calendars = calendarRepository.findOriginalCalendarsByUserIdInMonth(user.getId(), date);
+    // TODO: ScrapedCalendar 구현 시, ScrapedCalendar도 response에 추가
+    List<Calendar> calendars = calendarRepository.findOriginalCalendarsByUserId(user.getId());
 
     return toCalendarResponseList(calendars, user, user);
   }

--- a/src/main/java/kr/santanrudolph/everyvent/domain/calendar/dto/response/CalendarResponse.java
+++ b/src/main/java/kr/santanrudolph/everyvent/domain/calendar/dto/response/CalendarResponse.java
@@ -4,6 +4,7 @@ import kr.santanrudolph.everyvent.domain.calendar.entity.Calendar;
 import kr.santanrudolph.everyvent.domain.calendar.entity.DistributedCalendar;
 import kr.santanrudolph.everyvent.domain.calendar.entity.OfficialCalendar;
 import kr.santanrudolph.everyvent.domain.calendar.entity.OriginalCalendar;
+import kr.santanrudolph.everyvent.domain.calendar.enums.CalendarType;
 import kr.santanrudolph.everyvent.domain.calendar.enums.Category;
 import kr.santanrudolph.everyvent.domain.calendar.enums.Visibility;
 import kr.santanrudolph.everyvent.global.exception.ErrorCode;
@@ -16,6 +17,8 @@ import java.time.LocalDate;
 public abstract class CalendarResponse {
 
   private Long id;
+  private Long userId;
+  private CalendarType type;
   private String title;
   private String description;
   private LocalDate startDate;
@@ -26,6 +29,8 @@ public abstract class CalendarResponse {
   private Boolean isScrapable;
 
   protected CalendarResponse(Long id,
+                             Long userId,
+                             CalendarType type,
                              String title,
                              String description,
                              LocalDate startDate,
@@ -35,6 +40,8 @@ public abstract class CalendarResponse {
                              Category category,
                              Boolean isScrapable) {
       this.id = id;
+      this.userId = userId;
+      this.type = type;
       this.title = title;
       this.description = description;
       this.startDate = startDate;

--- a/src/main/java/kr/santanrudolph/everyvent/domain/calendar/dto/response/DistributedCalendarResponse.java
+++ b/src/main/java/kr/santanrudolph/everyvent/domain/calendar/dto/response/DistributedCalendarResponse.java
@@ -1,6 +1,7 @@
 package kr.santanrudolph.everyvent.domain.calendar.dto.response;
 
 import kr.santanrudolph.everyvent.domain.calendar.entity.DistributedCalendar;
+import kr.santanrudolph.everyvent.domain.calendar.enums.CalendarType;
 import kr.santanrudolph.everyvent.domain.calendar.enums.Category;
 import kr.santanrudolph.everyvent.domain.calendar.enums.Visibility;
 import lombok.Builder;
@@ -13,6 +14,8 @@ public class DistributedCalendarResponse extends CalendarResponse {
 
   @Builder
   private DistributedCalendarResponse(Long id,
+                                      Long userId,
+                                      CalendarType type,
                                       String title,
                                       String description,
                                       LocalDate startDate,
@@ -21,12 +24,15 @@ public class DistributedCalendarResponse extends CalendarResponse {
                                       String color,
                                       Category category,
                                       Boolean isScrapable) {
-    super(id, title, description, startDate, endDate, visibility, color, category, isScrapable);
+    super(id, userId, type, title, description, startDate, endDate, visibility, color, category, isScrapable);
   }
 
   public static DistributedCalendarResponse from(DistributedCalendar calendar) {
+
     return DistributedCalendarResponse.builder()
         .id(calendar.getId())
+        .userId(calendar.getUser().getId())
+        .type(CalendarType.DISTRIBUTED)
         .title(calendar.getTitle())
         .description(calendar.getDescription())
         .startDate(calendar.getStartDate())

--- a/src/main/java/kr/santanrudolph/everyvent/domain/calendar/dto/response/OfficialCalendarResponse.java
+++ b/src/main/java/kr/santanrudolph/everyvent/domain/calendar/dto/response/OfficialCalendarResponse.java
@@ -2,6 +2,7 @@ package kr.santanrudolph.everyvent.domain.calendar.dto.response;
 
 import kr.santanrudolph.everyvent.domain.calendar.entity.OfficialCalendar;
 import kr.santanrudolph.everyvent.domain.calendar.entity.OriginalCalendar;
+import kr.santanrudolph.everyvent.domain.calendar.enums.CalendarType;
 import kr.santanrudolph.everyvent.domain.calendar.enums.Category;
 import kr.santanrudolph.everyvent.domain.calendar.enums.Visibility;
 import lombok.Builder;
@@ -17,6 +18,8 @@ public class OfficialCalendarResponse extends CalendarResponse {
 
   @Builder
   private OfficialCalendarResponse(Long id,
+                                   Long userId,
+                                   CalendarType type,
                                    String title,
                                    String description,
                                    LocalDate startDate,
@@ -26,7 +29,7 @@ public class OfficialCalendarResponse extends CalendarResponse {
                                    Category category,
                                    Boolean isScrapable,
                                    Instant distributedAt) {
-    super(id, title, description, startDate, endDate, visibility, color, category, isScrapable);
+    super(id, userId, type, title, description, startDate, endDate, visibility, color, category, isScrapable);
     this.distributedAt = distributedAt;
   }
 
@@ -35,6 +38,8 @@ public class OfficialCalendarResponse extends CalendarResponse {
     OriginalCalendar original = calendar.getOriginalCalendar();
     return OfficialCalendarResponse.builder()
         .id(original.getId())
+        .userId(original.getUser().getId())
+        .type(CalendarType.OFFICIAL)
         .title(original.getTitle())
         .description(original.getDescription())
         .startDate(original.getStartDate())

--- a/src/main/java/kr/santanrudolph/everyvent/domain/calendar/dto/response/OriginalCalendarResponse.java
+++ b/src/main/java/kr/santanrudolph/everyvent/domain/calendar/dto/response/OriginalCalendarResponse.java
@@ -1,6 +1,7 @@
 package kr.santanrudolph.everyvent.domain.calendar.dto.response;
 
 import kr.santanrudolph.everyvent.domain.calendar.entity.OriginalCalendar;
+import kr.santanrudolph.everyvent.domain.calendar.enums.CalendarType;
 import kr.santanrudolph.everyvent.domain.calendar.enums.Category;
 import kr.santanrudolph.everyvent.domain.calendar.enums.Visibility;
 import lombok.Builder;
@@ -16,6 +17,8 @@ public class OriginalCalendarResponse extends CalendarResponse {
 
   @Builder
   private OriginalCalendarResponse(Long id,
+                                   Long userId,
+                                   CalendarType type,
                                    String title,
                                    String description,
                                    LocalDate startDate,
@@ -27,7 +30,7 @@ public class OriginalCalendarResponse extends CalendarResponse {
                                    LocalDate previewStartDate,
                                    LocalDate previewEndDate) {
 
-    super(id, title, description, startDate, endDate, visibility, color, category, isScrapable);
+    super(id, userId, type, title, description, startDate, endDate, visibility, color, category, isScrapable);
     this.previewStartDate = previewStartDate;
     this.previewEndDate = previewEndDate;
   }
@@ -35,6 +38,8 @@ public class OriginalCalendarResponse extends CalendarResponse {
   public static OriginalCalendarResponse from(OriginalCalendar calendar, boolean isScrapable) {
     return OriginalCalendarResponse.builder()
         .id(calendar.getId())
+        .userId(calendar.getUser().getId())
+        .type(CalendarType.ORIGINAL)
         .title(calendar.getTitle())
         .description(calendar.getDescription())
         .startDate(calendar.getStartDate())

--- a/src/main/java/kr/santanrudolph/everyvent/domain/calendar/enums/CalendarType.java
+++ b/src/main/java/kr/santanrudolph/everyvent/domain/calendar/enums/CalendarType.java
@@ -1,0 +1,8 @@
+package kr.santanrudolph.everyvent.domain.calendar.enums;
+
+public enum CalendarType {
+  ORIGINAL,
+  OFFICIAL,
+  DISTRIBUTED,
+  SCRAPED
+}


### PR DESCRIPTION
## 📝 무엇을 했나요?
1. CalendarType enum 추가
   - 캘린더 타입 구분을 위해 새 enum 정의(ORIGINAL, OFFICIAL, DISTRIBUTED, SCRAPED)

2. Response DTO(CalendarResponse) 수정
   - userId, type 필드 추가
   - from 메서드 및 생성자 로직 개선
 
3. 내 캘린더 목록 조회 API(getMyCalendars) 변경
   - 월별 조회에서 전체 나의 캘린더 목록 조회로 기능 확장
 
## 💭 고민 지점과 리뷰 포인트
- CalendarResponse DTO 변경 시 기존 API 호출/매핑 영향 여부
- CalendarType enum 추가로 기존 서비스 로직에서 필요한 처리가 누락된 곳이 없는지

## 🔗 관련 이슈
#5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 변경 사항

* **새로운 기능**
  * 캘린더 응답에 캘린더 유형(원본/공식/공유/스크랩) 정보 추가
  * 사용자별 캘린더 ID 정보 제공

* **버그 수정**
  * 내 캘린더 조회 시 특정 기간 필터 제거, 모든 캘린더를 한 번에 조회 가능하도록 개선

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->