### PR TITLE
feat(calendar): 캘린더 기능 개선 및 월간/일별 조회 API 추가

### DIFF
--- a/src/main/java/kr/santanrudolph/everyvent/auth/AuthenticationUtil.java
+++ b/src/main/java/kr/santanrudolph/everyvent/auth/AuthenticationUtil.java
@@ -37,6 +37,29 @@ public class AuthenticationUtil {
     }
   }
 
+  public static Long getCurrentUserIdOrNull() {
+    Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+    if (authentication == null || !authentication.isAuthenticated()) {
+      return null;
+    }
+
+    Object principal = authentication.getPrincipal();
+    if (principal == null || ANONYMOUS_USER.equals(principal)) {
+      return null;
+    }
+
+    try {
+      return (Long) principal;
+    } catch (ClassCastException e) {
+      throw new EveryventException(
+          ErrorCode.INTERNAL_SERVER_ERROR,
+          "인증 정보의 Principal이 예상 타입(Long)이 아닙니다. 현재 타입: "
+              + authentication.getPrincipal().getClass().getSimpleName()
+      );
+    }
+  }
+
   public static boolean isAuthenticated() {
     Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
 

--- a/src/main/java/kr/santanrudolph/everyvent/domain/calendar/CalendarController.java
+++ b/src/main/java/kr/santanrudolph/everyvent/domain/calendar/CalendarController.java
@@ -7,14 +7,12 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import kr.santanrudolph.everyvent.auth.AuthenticationUtil;
 import kr.santanrudolph.everyvent.domain.calendar.dto.request.OriginalCalendarRequest;
-import kr.santanrudolph.everyvent.domain.calendar.dto.response.CalendarResponse;
-import kr.santanrudolph.everyvent.domain.calendar.dto.response.DistributedCalendarResponse;
-import kr.santanrudolph.everyvent.domain.calendar.dto.response.OfficialCalendarResponse;
-import kr.santanrudolph.everyvent.domain.calendar.dto.response.OriginalCalendarResponse;
+import kr.santanrudolph.everyvent.domain.calendar.dto.response.*;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.time.LocalDate;
 import java.util.List;
 
 @Tag(name = "캘린더", description = "캘린더 관련 API")
@@ -136,7 +134,81 @@ public class CalendarController {
     return ResponseEntity.ok(responses);
   }
 
-  @Operation(summary = "공식 캘린더 목록 조회 (관리자용)", description = "관리자가 특정 년/월의 공식 캘린더 목록을 조회합니다.")
+  @Operation(
+      summary = "모든 캘린더 월간 통계 조회",
+      description = """
+       특정 사용자가 가진 모든 캘린더의 월간 태스크 통계 정보(태스크 개수 및 완료 여부)를 조회합니다.
+       로그인하지 않아도 데이터를 확인할 수 있습니다.
+       """
+  )
+  @ApiResponses({
+      @ApiResponse(responseCode = "200", description = "조회 성공"),
+      @ApiResponse(responseCode = "403", description = "FORBIDDEN: 조회 권한 없음"),
+      @ApiResponse(responseCode = "404", description = "NOT_FOUND: 사용자를 찾을 수 없음")
+  })
+  @GetMapping("/stats/monthly/user/{targetId}")
+  public ResponseEntity<List<MonthlyCalendarStatsResponse>> getAllMonthlyStats(
+      @PathVariable Long targetId,
+      @RequestParam int year,
+      @RequestParam int month
+  ) {
+    Long viewerId = AuthenticationUtil.getCurrentUserIdOrNull();
+    List<MonthlyCalendarStatsResponse> responses = calendarService.getAllMonthlyStats(viewerId, targetId, year, month);
+    return ResponseEntity.ok(responses);
+  }
+
+  @Operation(summary = "단일 캘린더 월간 통계 조회", description = "특정 캘린더의 월간 태스크 통계 정보(태스크 개수)를 조회합니다.")
+  @ApiResponses({
+      @ApiResponse(responseCode = "200", description = "조회 성공"),
+      @ApiResponse(responseCode = "403", description = "FORBIDDEN: 조회 권한 없음"),
+      @ApiResponse(responseCode = "404", description = "NOT_FOUND: 사용자/캘린더를 찾을 수 없음")
+  })
+  @GetMapping("/stats/monthly/calendar/{calendarId}")
+  public ResponseEntity<MonthlyCalendarResponse> getMonthlyStats(
+      @PathVariable Long calendarId
+  ) {
+    Long viewerId = AuthenticationUtil.getCurrentUserId();
+    MonthlyCalendarResponse response = calendarService.getMonthlyStats(viewerId, calendarId);
+    return ResponseEntity.ok(response);
+  }
+
+  @Operation(summary = "모든 캘린더 특정 날짜 태스크 조회",
+      description = """
+       특정 사용자가 가진 모든 캘린더에서 지정한 날짜의 태스크를 조회합니다.
+       로그인하지 않아도 데이터를 확인할 수 있습니다.
+       """
+  )
+  @ApiResponses({
+      @ApiResponse(responseCode = "200", description = "조회 성공"),
+      @ApiResponse(responseCode = "403", description = "FORBIDDEN: 조회 권한 없음"),
+      @ApiResponse(responseCode = "404", description = "NOT_FOUND: 사용자를 찾을 수 없음")
+  })
+  @GetMapping("/tasks/daily/user/{targetId}")
+  public ResponseEntity<List<DailyTasksOfCalendarResponse>> getDailyTasksOfAllCalendars(
+      @PathVariable Long targetId,
+      @RequestParam LocalDate date
+  ) {
+    Long viewerId = AuthenticationUtil.getCurrentUserIdOrNull();
+    List<DailyTasksOfCalendarResponse> responses = calendarService.getDailyTasksOfAllCalendars(viewerId, targetId, date);
+    return ResponseEntity.ok(responses);
+  }
+
+  @Operation(summary = "단일 캘린더 특정 날짜 태스크 조회", description = "특정 캘린더에서 지정한 날짜의 태스크를 조회합니다.")
+  @ApiResponses({
+      @ApiResponse(responseCode = "200", description = "조회 성공"),
+      @ApiResponse(responseCode = "403", description = "FORBIDDEN: 조회 권한 없음"),
+      @ApiResponse(responseCode = "404", description = "NOT_FOUND: 사용자/캘린더를 찾을 수 없음")
+  })
+  @GetMapping("/tasks/daily/calendar/{calendarId}")
+  public ResponseEntity<DailyTasksOfCalendarResponse> getDailyTasksOfCalendar(
+      @PathVariable Long calendarId,
+      @RequestParam LocalDate date
+  ) {
+    Long viewerId = AuthenticationUtil.getCurrentUserId();
+    DailyTasksOfCalendarResponse response = calendarService.getDailyTasksOfCalendar(viewerId, calendarId, date);
+    return ResponseEntity.ok(response);
+  }
+
   @Operation(summary = "공식 캘린더 목록 조회 (관리자용)", description = "관리자가 생성한 모든 공식 캘린더 목록을 조회합니다.")
   @ApiResponses({
       @ApiResponse(responseCode = "200", description = "조회 성공"),
@@ -149,6 +221,39 @@ public class CalendarController {
     Long adminId = AuthenticationUtil.getCurrentUserId();
     List<CalendarResponse> responses = calendarService.getOfficialCalendars(adminId);
     return ResponseEntity.ok(responses);
+  }
+
+  @Operation(summary = "공식 캘린더 월간 통계 조회 (관리자용)",
+      description = "관리자가 등록한 특정 공식 캘린더의 월간 태스크 통계 정보(태스크 개수)를 조회합니다.")
+  @ApiResponses({
+      @ApiResponse(responseCode = "200", description = "조회 성공"),
+      @ApiResponse(responseCode = "403", description = "FORBIDDEN: 관리자만 조회 가능"),
+      @ApiResponse(responseCode = "404", description = "NOT_FOUND: 사용자를 찾을 수 없음")
+  })
+  @GetMapping("/official/stats/monthly/{calendarId}")
+  public ResponseEntity<MonthlyCalendarResponse> getOfficialMonthlyStats(
+      @PathVariable Long calendarId
+  ) {
+    Long adminId = AuthenticationUtil.getCurrentUserId();
+    MonthlyCalendarResponse response = calendarService.getOfficialMonthlyStats(adminId, calendarId);
+    return ResponseEntity.ok(response);
+  }
+
+  @Operation(summary = "공식 캘린더 특정 날짜 태스크 조회 (관리자용)",
+      description = "관리자가 등록한 특정 공식 캘린더에서 지정한 날짜의 태스크를 조회합니다.")
+  @ApiResponses({
+      @ApiResponse(responseCode = "200", description = "조회 성공"),
+      @ApiResponse(responseCode = "403", description = "FORBIDDEN: 관리자만 조회 가능"),
+      @ApiResponse(responseCode = "404", description = "NOT_FOUND: 사용자/캘린더를 찾을 수 없음")
+  })
+  @GetMapping("/official/tasks/daily/{calendarId}")
+  public ResponseEntity<DailyTasksOfCalendarResponse> getOfficialDailyTasksOfCalendar(
+      @PathVariable Long calendarId,
+      @RequestParam LocalDate date
+  ) {
+    Long adminId = AuthenticationUtil.getCurrentUserId();
+    DailyTasksOfCalendarResponse response = calendarService.getOfficialDailyTasksOfCalendar(adminId, calendarId, date);
+    return ResponseEntity.ok(response);
   }
 
   @Operation(summary = "원본 캘린더 수정", description = "로그인한 사용자가 생성한 원본 캘린더를 수정합니다.")

--- a/src/main/java/kr/santanrudolph/everyvent/domain/calendar/CalendarController.java
+++ b/src/main/java/kr/santanrudolph/everyvent/domain/calendar/CalendarController.java
@@ -56,7 +56,7 @@ public class CalendarController {
     return ResponseEntity.ok(response);
   }
 
-  @Operation(summary = "공식 캘린더 배포", description = "관리자가 생성한 공식 캘린더를 모든 일반 사용자에게 배포합니다.")
+  @Operation(summary = "공식 캘린더 배포 (관리자용)", description = "관리자가 생성한 공식 캘린더를 모든 일반 사용자에게 배포합니다.")
   @ApiResponses({
       @ApiResponse(responseCode = "200", description = "공식 캘린더 배포 성공"),
       @ApiResponse(responseCode = "400", description = "INVALID_INPUT: 캘린더 배포 가능 기간 제한"),

--- a/src/main/java/kr/santanrudolph/everyvent/domain/calendar/CalendarController.java
+++ b/src/main/java/kr/santanrudolph/everyvent/domain/calendar/CalendarController.java
@@ -137,6 +137,7 @@ public class CalendarController {
   }
 
   @Operation(summary = "공식 캘린더 목록 조회 (관리자용)", description = "관리자가 특정 년/월의 공식 캘린더 목록을 조회합니다.")
+  @Operation(summary = "공식 캘린더 목록 조회 (관리자용)", description = "관리자가 생성한 모든 공식 캘린더 목록을 조회합니다.")
   @ApiResponses({
       @ApiResponse(responseCode = "200", description = "조회 성공"),
       @ApiResponse(responseCode = "400", description = "INVALID_INPUT: 요청 형식 오류"),
@@ -144,12 +145,9 @@ public class CalendarController {
       @ApiResponse(responseCode = "404", description = "NOT_FOUND: 사용자를 찾을 수 없음")
   })
   @GetMapping("/official")
-  public ResponseEntity<List<CalendarResponse>> getOfficialCalendars(
-      @RequestParam int year,
-      @RequestParam int month
-  ) {
+  public ResponseEntity<List<CalendarResponse>> getOfficialCalendars() {
     Long adminId = AuthenticationUtil.getCurrentUserId();
-    List<CalendarResponse> responses = calendarService.getOfficialCalendars(year, month, adminId);
+    List<CalendarResponse> responses = calendarService.getOfficialCalendars(adminId);
     return ResponseEntity.ok(responses);
   }
 

--- a/src/main/java/kr/santanrudolph/everyvent/domain/calendar/CalendarRepository.java
+++ b/src/main/java/kr/santanrudolph/everyvent/domain/calendar/CalendarRepository.java
@@ -29,6 +29,20 @@ public interface CalendarRepository extends JpaRepository<Calendar, Long> {
       @Param("startDate") LocalDate startDate);
 
   @Query("""
+    SELECT c FROM Calendar c
+    WHERE c.user.id = :userId
+      AND c.startDate = :startDate
+      AND c.deletedAt IS NULL
+      AND c.id NOT IN (
+        SELECT oc.id FROM OriginalCalendar oc
+        JOIN OfficialCalendar ofc ON ofc.originalCalendar.id = oc.id
+      )
+  """)
+  List<Calendar> findCalendarsByUserIdInMonth(
+      @Param("userId") Long userId,
+      @Param("startDate") LocalDate startDate);
+
+  @Query("""
   SELECT c FROM OriginalCalendar c
   WHERE c.user.id = :userId
     AND c.deletedAt IS NULL

--- a/src/main/java/kr/santanrudolph/everyvent/domain/calendar/CalendarService.java
+++ b/src/main/java/kr/santanrudolph/everyvent/domain/calendar/CalendarService.java
@@ -357,11 +357,11 @@ public class CalendarService {
         request.getDescription(),
         startDate,
         endDate,
+        previewStartDate,
+        previewEndDate,
         request.getVisibility(),
         request.getColor(),
-        request.getCategory(),
-        previewStartDate,
-        previewEndDate
+        request.getCategory()
     );
   }
 

--- a/src/main/java/kr/santanrudolph/everyvent/domain/calendar/CalendarService.java
+++ b/src/main/java/kr/santanrudolph/everyvent/domain/calendar/CalendarService.java
@@ -148,15 +148,7 @@ public class CalendarService {
     List<Calendar> calendars = calendarRepository.findCalendarsByUserIdInMonth(targetId, date);
 
     return calendars.stream()
-        .filter(calendar -> {
-          // 비회원: PUBLIC 캘린더만 접근 가능
-          if (viewer == null) {
-            return calendar.getVisibility() == Visibility.PUBLIC;
-          }
-
-          // 회원: 권한 확인
-          return canView(calendar, viewer, targetUser);
-        })
+        .filter(calendar -> canView(calendar, viewer, targetUser))
         .map(calendar -> toMonthlyAllCalendarStatsResponse(calendar, viewer))
         .toList();
   }
@@ -184,15 +176,7 @@ public class CalendarService {
     List<Calendar> calendars = calendarRepository.findCalendarsByUserIdInMonth(targetId, startDate);
 
     return calendars.stream()
-        .filter(calendar -> {
-          // 비회원: PUBLIC 캘린더만 접근 가능
-          if (viewer == null) {
-            return calendar.getVisibility() == Visibility.PUBLIC;
-          }
-
-          // 회원: 권한 확인
-          return canView(calendar, viewer, targetUser);
-        })
+        .filter(calendar -> canView(calendar, viewer, targetUser))
         .map(calendar -> toDailyTasksOfCalendarResponse(calendar, date, viewer, true))
         .toList();
   }
@@ -476,6 +460,10 @@ public class CalendarService {
   }
 
   private boolean canView(Calendar calendar, User viewer, User targetUser) {
+    // 비회원: PUBLIC 캘린더만 허용
+    if (viewer == null) {
+      return calendar.getVisibility() == Visibility.PUBLIC;
+    }
 
     if (isOwner(viewer, targetUser)) {
       return true;

--- a/src/main/java/kr/santanrudolph/everyvent/domain/calendar/CalendarService.java
+++ b/src/main/java/kr/santanrudolph/everyvent/domain/calendar/CalendarService.java
@@ -246,7 +246,7 @@ public class CalendarService {
         .orElseThrow(() -> new EveryventException(ErrorCode.NOT_FOUND, "해당 캘린더를 찾을 수 없습니다."));
 
     if (calendar.getDeletedAt() != null) {
-      throw new EveryventException(ErrorCode.FORBIDDEN, "이미 삭제된 캘린더입니다.");
+      throw new EveryventException(ErrorCode.NOT_FOUND, "이미 삭제된 캘린더입니다.");
     }
 
     return calendar;

--- a/src/main/java/kr/santanrudolph/everyvent/domain/calendar/CalendarService.java
+++ b/src/main/java/kr/santanrudolph/everyvent/domain/calendar/CalendarService.java
@@ -1,17 +1,17 @@
 package kr.santanrudolph.everyvent.domain.calendar;
 
 import kr.santanrudolph.everyvent.domain.calendar.dto.request.OriginalCalendarRequest;
-import kr.santanrudolph.everyvent.domain.calendar.dto.response.CalendarResponse;
-import kr.santanrudolph.everyvent.domain.calendar.dto.response.DistributedCalendarResponse;
-import kr.santanrudolph.everyvent.domain.calendar.dto.response.OfficialCalendarResponse;
-import kr.santanrudolph.everyvent.domain.calendar.dto.response.OriginalCalendarResponse;
+import kr.santanrudolph.everyvent.domain.calendar.dto.response.*;
 import kr.santanrudolph.everyvent.domain.calendar.entity.Calendar;
 import kr.santanrudolph.everyvent.domain.calendar.entity.DistributedCalendar;
 import kr.santanrudolph.everyvent.domain.calendar.entity.OfficialCalendar;
 import kr.santanrudolph.everyvent.domain.calendar.entity.OriginalCalendar;
+import kr.santanrudolph.everyvent.domain.calendar.enums.CalendarType;
+import kr.santanrudolph.everyvent.domain.calendar.enums.Visibility;
 import kr.santanrudolph.everyvent.domain.follow.FollowService;
 import kr.santanrudolph.everyvent.domain.task.Task;
 import kr.santanrudolph.everyvent.domain.task.TaskRepository;
+import kr.santanrudolph.everyvent.domain.task.dto.response.TaskResponse;
 import kr.santanrudolph.everyvent.domain.user.enums.Role;
 import kr.santanrudolph.everyvent.domain.user.User;
 import kr.santanrudolph.everyvent.domain.user.UserRepository;
@@ -139,7 +139,77 @@ public class CalendarService {
     return toCalendarResponseList(new ArrayList<>(distributedCalendars), viewer, targetUser);
   }
 
-  public List<CalendarResponse> getOfficialCalendars(int year, int month, Long adminId) {
+  public List<MonthlyCalendarStatsResponse> getAllMonthlyStats(Long userId, Long targetId, int year, int month) {
+
+    User viewer = userId != null ? getUserOrThrow(userId) : null;
+    User targetUser = getUserOrThrow(targetId);
+
+    LocalDate date = LocalDate.of(year, month, 1);
+    List<Calendar> calendars = calendarRepository.findCalendarsByUserIdInMonth(targetId, date);
+
+    return calendars.stream()
+        .filter(calendar -> {
+          // 비회원: PUBLIC 캘린더만 접근 가능
+          if (viewer == null) {
+            return calendar.getVisibility() == Visibility.PUBLIC;
+          }
+
+          // 회원: 권한 확인
+          return canView(calendar, viewer, targetUser);
+        })
+        .map(calendar -> toMonthlyAllCalendarStatsResponse(calendar, viewer))
+        .toList();
+  }
+
+  public MonthlyCalendarResponse getMonthlyStats(Long userId, Long calendarId) {
+
+    User viewer = getUserOrThrow(userId);
+
+    Calendar calendar = getActiveCalendarOrThrow(calendarId);
+
+    if (!canView(calendar, viewer, calendar.getUser())) {
+      throw new EveryventException(ErrorCode.FORBIDDEN, "해당 캘린더를 조회할 권한이 없습니다.");
+    }
+
+    return toMonthlyCalendarStatsResponse(calendar, viewer, true);
+  }
+
+  public List<DailyTasksOfCalendarResponse> getDailyTasksOfAllCalendars(Long userId, Long targetId, LocalDate date) {
+
+    User viewer = userId != null ? getUserOrThrow(userId) : null;
+    User targetUser = getUserOrThrow(targetId);
+
+    LocalDate startDate = LocalDate.of(date.getYear(), date.getMonth(), 1);
+
+    List<Calendar> calendars = calendarRepository.findCalendarsByUserIdInMonth(targetId, startDate);
+
+    return calendars.stream()
+        .filter(calendar -> {
+          // 비회원: PUBLIC 캘린더만 접근 가능
+          if (viewer == null) {
+            return calendar.getVisibility() == Visibility.PUBLIC;
+          }
+
+          // 회원: 권한 확인
+          return canView(calendar, viewer, targetUser);
+        })
+        .map(calendar -> toDailyTasksOfCalendarResponse(calendar, date, viewer, true))
+        .toList();
+  }
+
+  public DailyTasksOfCalendarResponse getDailyTasksOfCalendar(Long userId, Long calendarId, LocalDate date) {
+
+    User viewer = getUserOrThrow(userId);
+
+    Calendar calendar = getActiveCalendarOrThrow(calendarId);
+
+    if (!canView(calendar, viewer, calendar.getUser())) {
+      throw new EveryventException(ErrorCode.FORBIDDEN, "해당 캘린더를 조회할 권한이 없습니다.");
+    }
+
+    return toDailyTasksOfCalendarResponse(calendar, date, viewer, true);
+  }
+
   public List<CalendarResponse> getOfficialCalendars(Long adminId) {
 
     User admin = getUserOrThrow(adminId);
@@ -151,6 +221,26 @@ public class CalendarService {
         .collect(Collectors.toList());
 
     return toCalendarResponseList(officialCalendars, admin, admin);
+  }
+
+  public MonthlyCalendarResponse getOfficialMonthlyStats(Long adminId, Long calendarId) {
+
+    User admin = getUserOrThrow(adminId);
+
+    OfficialCalendar officialCalendar = getOfficialCalendarOrThrow(calendarId, adminId);
+    Calendar calendar = officialCalendar.getOriginalCalendar();
+
+    return toMonthlyCalendarStatsResponse(calendar, admin, false);
+  }
+
+  public DailyTasksOfCalendarResponse getOfficialDailyTasksOfCalendar(Long adminId, Long calendarId, LocalDate date) {
+
+    User admin = getUserOrThrow(adminId);
+
+    OfficialCalendar officialCalendar = getOfficialCalendarOrThrow(calendarId, adminId);
+    Calendar calendar = officialCalendar.getOriginalCalendar();
+
+    return toDailyTasksOfCalendarResponse(calendar, date, admin, false);
   }
 
   @Transactional
@@ -190,7 +280,7 @@ public class CalendarService {
     return toCalendarResponse(calendar, false);
   }
 
-  // TODO: 추후 ScrapCalendar 구현 시, updateScrapedCalendar 추가
+  // TODO: 추후 ScrapedCalendar 구현 시, updateScrapedCalendar 추가
 
   @Transactional
   public void deleteOriginalCalendar(Long userId, Long calendarId) {
@@ -304,7 +394,7 @@ public class CalendarService {
 
   private void validateMonthlyCalendarLimit(Long userId, OriginalCalendarRequest request) {
     long userMonthlyCalendarCount = calendarRepository
-            .countByUserIdInMonth(userId, request.getStartDate());
+        .countByUserIdInMonth(userId, request.getStartDate());
 
     if (userMonthlyCalendarCount >= 3) {
       throw new EveryventException(ErrorCode.INVALID_INPUT, "캘린더는 최대 3개까지 생성할 수 있습니다.");
@@ -327,11 +417,61 @@ public class CalendarService {
     }
   }
 
+  private List<Task> filterTasksByCalendarMonth(Calendar calendar, List<Task> tasks, User viewer) {
+
+    LocalDate now = LocalDate.now();
+    YearMonth calendarMonth = YearMonth.from(calendar.getStartDate());
+    YearMonth nowMonth = YearMonth.from(now);
+
+    boolean isOwner = isCalendarOwner(viewer, calendar);
+
+    // 1) 현재 달 → 오늘 날짜까지만 공개
+    if (calendarMonth.equals(nowMonth)) {
+      int today = now.getDayOfMonth();
+      return tasks.stream()
+          .filter(task -> task.getDay() <= today)
+          .toList();
+    }
+
+    // 2) 과거 달 → 전체 공개
+    if (calendarMonth.isBefore(nowMonth)) {
+      return tasks;
+    }
+
+    // 3) 미래 달
+    // 3-1) 자신의 캘린더 → 전체 공개
+    if (isOwner) {
+      return tasks;
+    }
+
+    // 3-2) 다른 사용자의 캘린더 → preview 기간만 공개
+    LocalDate previewStartTemp = null;
+    LocalDate previewEndTemp = null;
+
+    if (calendar instanceof OriginalCalendar originalCalendar) {
+      previewStartTemp = originalCalendar.getPreviewStartDate();
+      previewEndTemp = originalCalendar.getPreviewEndDate();
+    }
+
+    final LocalDate previewStart = previewStartTemp;
+    final LocalDate previewEnd = previewEndTemp;
+
+    return tasks.stream()
+        .filter(task -> {
+          LocalDate taskDate = calendar.getStartDate().withDayOfMonth(task.getDay());
+          return !taskDate.isBefore(previewStart) && !taskDate.isAfter(previewEnd);
+        })
+        .toList();
+  }
+
   private boolean isOwner(User viewer, User targetUser) {
     return viewer.getId().equals(targetUser.getId());
   }
 
   private boolean isCalendarOwner(User user, Calendar calendar) {
+    if(user == null){
+      return false;
+    }
     return Objects.equals(calendar.getUser().getId(), user.getId());
   }
 
@@ -347,6 +487,18 @@ public class CalendarService {
       case FOLLOWER -> followService.isFollowing(viewer.getId(), targetUser.getId());
       case PRIVATE -> false;
     };
+  }
+
+  private CalendarType determineCalendarType(Calendar calendar) {
+    if (calendar instanceof OriginalCalendar) {
+      OfficialCalendar official = officialCalendarRepository.findByOriginalCalendarId(calendar.getId())
+          .orElse(null);
+      return (official != null) ? CalendarType.OFFICIAL : CalendarType.ORIGINAL;
+    } else if (calendar instanceof DistributedCalendar) {
+      return CalendarType.DISTRIBUTED;
+    } else {
+      return CalendarType.SCRAPED;
+    }
   }
 
   // 생성/업데이트 관련
@@ -420,6 +572,23 @@ public class CalendarService {
     originalCalendar.updateCategory(request.getCategory());
   }
 
+  private Map<Integer, DailyTaskStats> aggregateDailyTaskStats(List<Task> tasks) {
+    return tasks.stream()
+        .collect(Collectors.groupingBy(
+            Task::getDay,
+            TreeMap::new,
+            Collectors.collectingAndThen(
+                Collectors.toList(),
+                list -> {
+                  int total = list.size();
+                  int completed = (int) list.stream().filter(Task::isCompleted).count();
+                  int pending = total - completed;
+                  return new DailyTaskStats(total, completed, pending);
+                }
+            )
+        ));
+  }
+
   // DTO 변환
   private CalendarResponse toCalendarResponse(Calendar calendar, boolean isScrapable) {
 
@@ -440,6 +609,65 @@ public class CalendarService {
           return toCalendarResponse(calendar, isScrapable);
         })
         .toList();
+  }
+
+  private MonthlyCalendarStatsResponse toMonthlyAllCalendarStatsResponse(Calendar calendar, User viewer) {
+
+    List<Task> tasks = taskRepository.findByCalendarIdAndDeletedAtIsNull(calendar.getId());
+    tasks = filterTasksByCalendarMonth(calendar, tasks, viewer);
+    Map<Integer, DailyTaskStats> dayStatus = aggregateDailyTaskStats(tasks);
+
+    CalendarType type = determineCalendarType(calendar);
+
+    boolean isScrapable = type == CalendarType.ORIGINAL
+        && calendar.isScrapable()
+        && !isCalendarOwner(viewer, calendar);
+
+    return MonthlyCalendarStatsResponse.from(calendar, type, isScrapable, dayStatus);
+  }
+
+  private MonthlyCalendarResponse toMonthlyCalendarStatsResponse(Calendar calendar, User viewer, boolean filtering) {
+
+    List<Task> tasks = taskRepository.findByCalendarIdAndDeletedAtIsNull(calendar.getId());
+    if (filtering) {
+      tasks = filterTasksByCalendarMonth(calendar, tasks, viewer);
+    }
+    Map<Integer, Integer> dayTaskCount = tasks.stream()
+        .collect(Collectors.groupingBy(
+            Task::getDay,
+            TreeMap::new,
+            Collectors.collectingAndThen(Collectors.toList(), List::size)
+        ));
+
+    CalendarType type = determineCalendarType(calendar);
+
+    boolean isScrapable = type == CalendarType.ORIGINAL
+        && calendar.isScrapable()
+        && !isCalendarOwner(viewer, calendar);
+
+    return MonthlyCalendarResponse.from(calendar, type, isScrapable, dayTaskCount);
+  }
+
+  private DailyTasksOfCalendarResponse toDailyTasksOfCalendarResponse(Calendar calendar,
+                                                                      LocalDate date,
+                                                                      User viewer,
+                                                                      boolean filtering) {
+
+    List<Task> tasks = taskRepository.findByCalendarIdAndDay(calendar.getId(), date.getDayOfMonth());
+    if (filtering) {
+      tasks = filterTasksByCalendarMonth(calendar, tasks, viewer);
+    }
+    List<TaskResponse> taskResponses = tasks.stream()
+        .map(TaskResponse::from)
+        .toList();
+
+    CalendarType type = determineCalendarType(calendar);
+
+    boolean isScrapable = type == CalendarType.ORIGINAL
+        && calendar.isScrapable()
+        && !isCalendarOwner(viewer, calendar);
+
+    return DailyTasksOfCalendarResponse.from(calendar, type, date, isScrapable, taskResponses);
   }
 
 }

--- a/src/main/java/kr/santanrudolph/everyvent/domain/calendar/CalendarService.java
+++ b/src/main/java/kr/santanrudolph/everyvent/domain/calendar/CalendarService.java
@@ -207,8 +207,13 @@ public class CalendarService {
       throw new EveryventException(ErrorCode.FORBIDDEN, "해당 캘린더를 삭제할 권한이 없습니다.");
     }
 
+    List<Task> tasks = taskRepository.findByCalendarIdAndDeletedAtIsNull(calendar.getId());
+
     calendar.softDelete();
+    tasks.forEach(Task::softDelete);
+
     calendarRepository.save(calendar);
+    taskRepository.saveAll(tasks);
   }
 
   @Transactional
@@ -217,11 +222,15 @@ public class CalendarService {
     OfficialCalendar official = getOfficialCalendarOrThrow(calendarId, adminId);
     OriginalCalendar calendar = official.getOriginalCalendar();
 
+    List<Task> tasks = taskRepository.findByCalendarIdAndDeletedAtIsNull(calendar.getId());
+
     calendar.softDelete();
     official.softDelete();
+    tasks.forEach(Task::softDelete);
 
     calendarRepository.save(calendar);
     officialCalendarRepository.save(official);
+    taskRepository.saveAll(tasks);
   }
 
   // ==================== Private Helper Methods ====================

--- a/src/main/java/kr/santanrudolph/everyvent/domain/calendar/CalendarService.java
+++ b/src/main/java/kr/santanrudolph/everyvent/domain/calendar/CalendarService.java
@@ -140,12 +140,12 @@ public class CalendarService {
   }
 
   public List<CalendarResponse> getOfficialCalendars(int year, int month, Long adminId) {
+  public List<CalendarResponse> getOfficialCalendars(Long adminId) {
 
     User admin = getUserOrThrow(adminId);
     validateAdminRole(admin);
 
-    LocalDate date = LocalDate.of(year, month, 1);
-    List<OfficialCalendar> officialEntities = officialCalendarRepository.findAllByPeriod(date);
+    List<OfficialCalendar> officialEntities = officialCalendarRepository.findAllOfficialCalendars();
     List<Calendar> officialCalendars = officialEntities.stream()
         .map(OfficialCalendar::getOriginalCalendar)
         .collect(Collectors.toList());

--- a/src/main/java/kr/santanrudolph/everyvent/domain/calendar/CalendarService.java
+++ b/src/main/java/kr/santanrudolph/everyvent/domain/calendar/CalendarService.java
@@ -431,7 +431,10 @@ public class CalendarService {
   private List<CalendarResponse> toCalendarResponseList(List<Calendar> calendars, User viewer, User targetUser) {
     return calendars.stream()
         .filter(calendar -> canView(calendar, viewer, targetUser))
-        .sorted(Comparator.comparingLong(Calendar::getId))
+        .sorted(
+            Comparator.comparing(Calendar::getStartDate)
+                .thenComparingLong(Calendar::getId)
+        )
         .map(calendar -> {
           boolean isScrapable = calendar.isScrapable() && !isCalendarOwner(viewer, calendar);
           return toCalendarResponse(calendar, isScrapable);

--- a/src/main/java/kr/santanrudolph/everyvent/domain/calendar/CalendarService.java
+++ b/src/main/java/kr/santanrudolph/everyvent/domain/calendar/CalendarService.java
@@ -401,53 +401,6 @@ public class CalendarService {
     }
   }
 
-  private List<Task> filterTasksByCalendarMonth(Calendar calendar, List<Task> tasks, User viewer) {
-
-    LocalDate now = LocalDate.now();
-    YearMonth calendarMonth = YearMonth.from(calendar.getStartDate());
-    YearMonth nowMonth = YearMonth.from(now);
-
-    boolean isOwner = isCalendarOwner(viewer, calendar);
-
-    // 1) 현재 달 → 오늘 날짜까지만 공개
-    if (calendarMonth.equals(nowMonth)) {
-      int today = now.getDayOfMonth();
-      return tasks.stream()
-          .filter(task -> task.getDay() <= today)
-          .toList();
-    }
-
-    // 2) 과거 달 → 전체 공개
-    if (calendarMonth.isBefore(nowMonth)) {
-      return tasks;
-    }
-
-    // 3) 미래 달
-    // 3-1) 자신의 캘린더 → 전체 공개
-    if (isOwner) {
-      return tasks;
-    }
-
-    // 3-2) 다른 사용자의 캘린더 → preview 기간만 공개
-    LocalDate previewStartTemp = null;
-    LocalDate previewEndTemp = null;
-
-    if (calendar instanceof OriginalCalendar originalCalendar) {
-      previewStartTemp = originalCalendar.getPreviewStartDate();
-      previewEndTemp = originalCalendar.getPreviewEndDate();
-    }
-
-    final LocalDate previewStart = previewStartTemp;
-    final LocalDate previewEnd = previewEndTemp;
-
-    return tasks.stream()
-        .filter(task -> {
-          LocalDate taskDate = calendar.getStartDate().withDayOfMonth(task.getDay());
-          return !taskDate.isBefore(previewStart) && !taskDate.isAfter(previewEnd);
-        })
-        .toList();
-  }
-
   private boolean isOwner(User viewer, User targetUser) {
     return viewer.getId().equals(targetUser.getId());
   }
@@ -477,6 +430,45 @@ public class CalendarService {
     };
   }
 
+  private boolean canViewDate(Calendar calendar, LocalDate date, User viewer) {
+
+    LocalDate now = LocalDate.now();
+    YearMonth calendarMonth = YearMonth.from(calendar.getStartDate());
+    YearMonth nowMonth = YearMonth.from(now);
+
+    boolean isOwner = isCalendarOwner(viewer, calendar);
+
+    // 1) 현재 달 → 오늘 날짜까지만 공개
+    if (calendarMonth.equals(nowMonth)) {
+      return date.getDayOfMonth() <= now.getDayOfMonth();
+    }
+
+    // 2) 과거 달 → 전체 공개
+    if (calendarMonth.isBefore(nowMonth)) {
+      return true;
+    }
+
+    // 3) 미래 달
+    // 3-1) 자신의 캘린더 → 전체 공개
+    if (isOwner) {
+      return true;
+    }
+
+    // 3-2) 다른 사용자의 캘린더 → preview 기간만 공개
+    if (calendar instanceof OriginalCalendar originalCalendar) {
+      LocalDate previewStart = originalCalendar.getPreviewStartDate();
+      LocalDate previewEnd = originalCalendar.getPreviewEndDate();
+
+      if (previewStart == null || previewEnd == null) {
+        return false;
+      }
+
+      return !date.isBefore(previewStart) && !date.isAfter(previewEnd);
+    }
+
+    return false;
+  }
+
   private CalendarType determineCalendarType(Calendar calendar) {
     if (calendar instanceof OriginalCalendar) {
       OfficialCalendar official = officialCalendarRepository.findByOriginalCalendarId(calendar.getId())
@@ -487,6 +479,15 @@ public class CalendarService {
     } else {
       return CalendarType.SCRAPED;
     }
+  }
+
+  private List<Task> filterMonthlyTasks(Calendar calendar, List<Task> tasks, User viewer) {
+    return tasks.stream()
+        .filter(task -> {
+          LocalDate taskDate = calendar.getStartDate().withDayOfMonth(task.getDay());
+          return canViewDate(calendar, taskDate, viewer);
+        })
+        .toList();
   }
 
   // 생성/업데이트 관련
@@ -602,7 +603,7 @@ public class CalendarService {
   private MonthlyCalendarStatsResponse toMonthlyAllCalendarStatsResponse(Calendar calendar, User viewer) {
 
     List<Task> tasks = taskRepository.findByCalendarIdAndDeletedAtIsNull(calendar.getId());
-    tasks = filterTasksByCalendarMonth(calendar, tasks, viewer);
+    tasks = filterMonthlyTasks(calendar, tasks, viewer);
     Map<Integer, DailyTaskStats> dayStatus = aggregateDailyTaskStats(tasks);
 
     CalendarType type = determineCalendarType(calendar);
@@ -618,7 +619,7 @@ public class CalendarService {
 
     List<Task> tasks = taskRepository.findByCalendarIdAndDeletedAtIsNull(calendar.getId());
     if (filtering) {
-      tasks = filterTasksByCalendarMonth(calendar, tasks, viewer);
+      tasks = filterMonthlyTasks(calendar, tasks, viewer);
     }
     Map<Integer, Integer> dayTaskCount = tasks.stream()
         .collect(Collectors.groupingBy(
@@ -642,8 +643,8 @@ public class CalendarService {
                                                                       boolean filtering) {
 
     List<Task> tasks = taskRepository.findByCalendarIdAndDay(calendar.getId(), date.getDayOfMonth());
-    if (filtering) {
-      tasks = filterTasksByCalendarMonth(calendar, tasks, viewer);
+    if (filtering && !canViewDate(calendar, date, viewer)) {
+      tasks = List.of();
     }
     List<TaskResponse> taskResponses = tasks.stream()
         .map(TaskResponse::from)

--- a/src/main/java/kr/santanrudolph/everyvent/domain/calendar/CalendarService.java
+++ b/src/main/java/kr/santanrudolph/everyvent/domain/calendar/CalendarService.java
@@ -351,7 +351,7 @@ public class CalendarService {
             new EveryventException(ErrorCode.NOT_FOUND, "해당 캘린더는 존재하지 않거나 공식 캘린더가 아닙니다."));
 
     if (officialCalendar.getDeletedAt() != null) {
-      throw new EveryventException(ErrorCode.FORBIDDEN, "삭제된 원본 캘린더엔 더 이상 접근할 수 없습니다.");
+      throw new EveryventException(ErrorCode.NOT_FOUND, "삭제된 원본 캘린더엔 더 이상 접근할 수 없습니다.");
     }
 
     return officialCalendar;

--- a/src/main/java/kr/santanrudolph/everyvent/domain/calendar/CalendarService.java
+++ b/src/main/java/kr/santanrudolph/everyvent/domain/calendar/CalendarService.java
@@ -10,6 +10,8 @@ import kr.santanrudolph.everyvent.domain.calendar.entity.DistributedCalendar;
 import kr.santanrudolph.everyvent.domain.calendar.entity.OfficialCalendar;
 import kr.santanrudolph.everyvent.domain.calendar.entity.OriginalCalendar;
 import kr.santanrudolph.everyvent.domain.follow.FollowService;
+import kr.santanrudolph.everyvent.domain.task.Task;
+import kr.santanrudolph.everyvent.domain.task.TaskRepository;
 import kr.santanrudolph.everyvent.domain.user.enums.Role;
 import kr.santanrudolph.everyvent.domain.user.User;
 import kr.santanrudolph.everyvent.domain.user.UserRepository;
@@ -36,6 +38,7 @@ public class CalendarService {
   private final OfficialCalendarRepository officialCalendarRepository;
   private final UserRepository userRepository;
   private final FollowService followService;
+  private final TaskRepository taskRepository;
 
   @Transactional
   public OriginalCalendarResponse createCalendar(Long userId, OriginalCalendarRequest request) {
@@ -73,22 +76,21 @@ public class CalendarService {
   public List<DistributedCalendarResponse> distributeOfficialCalendar(Long adminId, Long calendarId) {
 
     OfficialCalendar officialCalendar = getOfficialCalendarOrThrow(calendarId, adminId);
-    OriginalCalendar originalCalendar = officialCalendar.getOriginalCalendar();
     validateDistribution(officialCalendar);
+
+    OriginalCalendar originalCalendar = officialCalendar.getOriginalCalendar();
 
     // 탈퇴하지 않은 사용자 중, 아직 해당 공식 캘린더 복제본을 가지지 않은 대상에게 배포
     List<User> targetUsers = userRepository.findTargetUsersForDistribution(originalCalendar.getId());
 
-    List<DistributedCalendar> calendarsToSave = targetUsers.stream()
-            .map(user -> DistributedCalendar.of(user, originalCalendar))
-            .collect(Collectors.toList());
+    List<DistributedCalendar> copies = createCalendarCopies(targetUsers, originalCalendar);
+    copyTasks(originalCalendar, copies);
 
-    List<DistributedCalendar> savedCalendars = calendarRepository.saveAll(calendarsToSave);
     officialCalendar.updateDistributedAt(Instant.now());
 
-    return savedCalendars.stream()
+    return copies.stream()
         .map(DistributedCalendarResponse::from)
-        .collect(Collectors.toList());
+        .toList();
   }
 
   public CalendarResponse getCalendar(Long calendarId, Long userId) {
@@ -363,6 +365,27 @@ public class CalendarService {
         request.getColor(),
         request.getCategory()
     );
+  }
+
+  private List<DistributedCalendar> createCalendarCopies(List<User> users, OriginalCalendar original) {
+    List<DistributedCalendar> list = users.stream()
+        .map(user -> DistributedCalendar.of(user, original))
+        .toList();
+    return calendarRepository.saveAll(list);
+  }
+
+  private void copyTasks(OriginalCalendar original, List<DistributedCalendar> copies) {
+    List<Task> originalTasks =
+        taskRepository.findByCalendarIdAndDeletedAtIsNull(original.getId());
+
+    List<Task> saveList = new ArrayList<>();
+    for (DistributedCalendar copy : copies) {
+      for (Task t : originalTasks) {
+        saveList.add(Task.create(copy, t.getName(), t.getDay()));
+      }
+    }
+
+    taskRepository.saveAll(saveList);
   }
 
   private void updateOriginalCalendar(OriginalCalendar originalCalendar,

--- a/src/main/java/kr/santanrudolph/everyvent/domain/calendar/CalendarService.java
+++ b/src/main/java/kr/santanrudolph/everyvent/domain/calendar/CalendarService.java
@@ -19,6 +19,7 @@ import kr.santanrudolph.everyvent.global.exception.ErrorCode;
 import kr.santanrudolph.everyvent.global.exception.EveryventException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -39,6 +40,7 @@ public class CalendarService {
   private final UserRepository userRepository;
   private final FollowService followService;
   private final TaskRepository taskRepository;
+  private final JdbcTemplate jdbcTemplate;
 
   @Transactional
   public OriginalCalendarResponse createCalendar(Long userId, OriginalCalendarRequest request) {
@@ -84,7 +86,7 @@ public class CalendarService {
     List<User> targetUsers = userRepository.findTargetUsersForDistribution(originalCalendar.getId());
 
     List<DistributedCalendar> copies = createCalendarCopies(targetUsers, originalCalendar);
-    copyTasks(originalCalendar, copies);
+    copyTasksBulk(originalCalendar.getId());
 
     officialCalendar.updateDistributedAt(Instant.now());
 
@@ -524,18 +526,19 @@ public class CalendarService {
     return calendarRepository.saveAll(list);
   }
 
-  private void copyTasks(OriginalCalendar original, List<DistributedCalendar> copies) {
-    List<Task> originalTasks =
-        taskRepository.findByCalendarIdAndDeletedAtIsNull(original.getId());
-
-    List<Task> saveList = new ArrayList<>();
-    for (DistributedCalendar copy : copies) {
-      for (Task t : originalTasks) {
-        saveList.add(Task.create(copy, t.getName(), t.getDay()));
-      }
-    }
-
-    taskRepository.saveAll(saveList);
+  private void copyTasksBulk(Long originalCalendarId) {
+    String sql = """
+        INSERT INTO tasks (calendar_id, name, day_of_month, is_completed, created_at, updated_at)
+        SELECT c.id, t.name, t.day_of_month, t.is_completed, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
+        FROM tasks t
+        JOIN calendar c
+          ON c.original_calendar_id = t.calendar_id
+        LEFT JOIN tasks existing
+          ON existing.calendar_id = c.id
+        WHERE t.calendar_id = ?
+          AND existing.id IS NULL;
+        """;
+    jdbcTemplate.update(sql, originalCalendarId);
   }
 
   private void updateOriginalCalendar(OriginalCalendar originalCalendar,

--- a/src/main/java/kr/santanrudolph/everyvent/domain/calendar/OfficialCalendarRepository.java
+++ b/src/main/java/kr/santanrudolph/everyvent/domain/calendar/OfficialCalendarRepository.java
@@ -3,10 +3,8 @@ package kr.santanrudolph.everyvent.domain.calendar;
 import kr.santanrudolph.everyvent.domain.calendar.entity.OfficialCalendar;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
-import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 

--- a/src/main/java/kr/santanrudolph/everyvent/domain/calendar/OfficialCalendarRepository.java
+++ b/src/main/java/kr/santanrudolph/everyvent/domain/calendar/OfficialCalendarRepository.java
@@ -18,12 +18,9 @@ public interface OfficialCalendarRepository extends JpaRepository<OfficialCalend
   @Query("""
     SELECT officialCalendar
     FROM OfficialCalendar officialCalendar
-    WHERE officialCalendar.originalCalendar.startDate = :start
-      AND officialCalendar.deletedAt IS NULL
+    WHERE officialCalendar.deletedAt IS NULL
   """)
-  List<OfficialCalendar> findAllByPeriod(
-          @Param("start") LocalDate start
-  );
+  List<OfficialCalendar> findAllOfficialCalendars();
 
   boolean existsByOriginalCalendarId(Long calendarId);
 }

--- a/src/main/java/kr/santanrudolph/everyvent/domain/calendar/dto/response/DailyTaskStats.java
+++ b/src/main/java/kr/santanrudolph/everyvent/domain/calendar/dto/response/DailyTaskStats.java
@@ -1,0 +1,12 @@
+package kr.santanrudolph.everyvent.domain.calendar.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class DailyTaskStats {
+  private int totalCount;
+  private int completedCount;
+  private int pendingCount;
+}

--- a/src/main/java/kr/santanrudolph/everyvent/domain/calendar/dto/response/DailyTasksOfCalendarResponse.java
+++ b/src/main/java/kr/santanrudolph/everyvent/domain/calendar/dto/response/DailyTasksOfCalendarResponse.java
@@ -1,0 +1,81 @@
+package kr.santanrudolph.everyvent.domain.calendar.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import kr.santanrudolph.everyvent.domain.calendar.entity.Calendar;
+import kr.santanrudolph.everyvent.domain.calendar.entity.OriginalCalendar;
+import kr.santanrudolph.everyvent.domain.calendar.enums.CalendarType;
+import kr.santanrudolph.everyvent.domain.calendar.enums.Category;
+import kr.santanrudolph.everyvent.domain.calendar.enums.Visibility;
+import kr.santanrudolph.everyvent.domain.task.dto.response.TaskResponse;
+import lombok.Getter;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Getter
+public class DailyTasksOfCalendarResponse extends CalendarResponse {
+
+  @JsonInclude(JsonInclude.Include.NON_NULL)
+  private LocalDate previewStartDate;
+  @JsonInclude(JsonInclude.Include.NON_NULL)
+  private LocalDate previewEndDate;
+  private LocalDate date;
+  private List<TaskResponse> tasks;
+
+  private DailyTasksOfCalendarResponse(
+      Long id,
+      Long userId,
+      CalendarType type,
+      String title,
+      String description,
+      LocalDate startDate,
+      LocalDate endDate,
+      LocalDate previewStartDate,
+      LocalDate previewEndDate,
+      Visibility visibility,
+      String color,
+      Category category,
+      Boolean isScrapable,
+      LocalDate date,
+      List<TaskResponse> tasks
+  ) {
+    super(id, userId, type, title, description, startDate, endDate, visibility, color, category, isScrapable);
+    this.previewStartDate = previewStartDate;
+    this.previewEndDate = previewEndDate;
+    this.date = date;
+    this.tasks = tasks;
+  }
+
+  public static DailyTasksOfCalendarResponse from(Calendar calendar,
+                                                  CalendarType type,
+                                                  LocalDate date,
+                                                  Boolean isScrapable,
+                                                  List<TaskResponse> tasks) {
+    LocalDate previewStartDate = null;
+    LocalDate previewEndDate = null;
+
+    if(calendar instanceof OriginalCalendar originalCalendar) {
+      previewStartDate = originalCalendar.getPreviewStartDate();
+      previewEndDate = originalCalendar.getPreviewEndDate();
+    }
+
+    return
+        new DailyTasksOfCalendarResponse(
+        calendar.getId(),
+        calendar.getUser().getId(),
+        type,
+        calendar.getTitle(),
+        calendar.getDescription(),
+        calendar.getStartDate(),
+        calendar.getEndDate(),
+        previewStartDate,
+        previewEndDate,
+        calendar.getVisibility(),
+        calendar.getColor(),
+        calendar.getCategory(),
+        isScrapable,
+        date,
+        tasks
+    );
+  }
+}

--- a/src/main/java/kr/santanrudolph/everyvent/domain/calendar/dto/response/MonthlyCalendarResponse.java
+++ b/src/main/java/kr/santanrudolph/everyvent/domain/calendar/dto/response/MonthlyCalendarResponse.java
@@ -1,0 +1,73 @@
+package kr.santanrudolph.everyvent.domain.calendar.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import kr.santanrudolph.everyvent.domain.calendar.entity.Calendar;
+import kr.santanrudolph.everyvent.domain.calendar.entity.OriginalCalendar;
+import kr.santanrudolph.everyvent.domain.calendar.enums.CalendarType;
+import kr.santanrudolph.everyvent.domain.calendar.enums.Category;
+import kr.santanrudolph.everyvent.domain.calendar.enums.Visibility;
+import lombok.Getter;
+
+import java.time.LocalDate;
+import java.util.Map;
+
+@Getter
+public class MonthlyCalendarResponse extends CalendarResponse {
+
+  @JsonInclude(JsonInclude.Include.NON_NULL)
+  private LocalDate previewStartDate;
+  @JsonInclude(JsonInclude.Include.NON_NULL)
+  private LocalDate previewEndDate;
+  private Map<Integer, Integer> dayTaskCount;
+
+  private MonthlyCalendarResponse(
+      Long id,
+      Long userId,
+      CalendarType type,
+      String title,
+      String description,
+      LocalDate startDate,
+      LocalDate endDate,
+      LocalDate previewStartDate,
+      LocalDate previewEndDate,
+      Visibility visibility,
+      String color,
+      Category category,
+      Boolean isScrapable,
+      Map<Integer, Integer> dayTaskCount
+  ) {
+    super(id, userId, type, title, description, startDate, endDate, visibility, color, category, isScrapable);
+    this.previewStartDate = previewStartDate;
+    this.previewEndDate = previewEndDate;
+    this.dayTaskCount = dayTaskCount;
+  }
+
+  public static MonthlyCalendarResponse from(Calendar calendar,
+                                             CalendarType type,
+                                             Boolean isScrapable,
+                                             Map<Integer, Integer> dayTaskCount) {
+    LocalDate previewStartDate = null;
+    LocalDate previewEndDate = null;
+
+    if(calendar instanceof OriginalCalendar originalCalendar) {
+      previewStartDate = originalCalendar.getPreviewStartDate();
+      previewEndDate = originalCalendar.getPreviewEndDate();
+    }
+    return new MonthlyCalendarResponse(
+        calendar.getId(),
+        calendar.getUser().getId(),
+        type,
+        calendar.getTitle(),
+        calendar.getDescription(),
+        calendar.getStartDate(),
+        calendar.getEndDate(),
+        previewStartDate,
+        previewEndDate,
+        calendar.getVisibility(),
+        calendar.getColor(),
+        calendar.getCategory(),
+        isScrapable,
+        dayTaskCount
+    );
+  }
+}

--- a/src/main/java/kr/santanrudolph/everyvent/domain/calendar/dto/response/MonthlyCalendarStatsResponse.java
+++ b/src/main/java/kr/santanrudolph/everyvent/domain/calendar/dto/response/MonthlyCalendarStatsResponse.java
@@ -1,0 +1,73 @@
+package kr.santanrudolph.everyvent.domain.calendar.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import kr.santanrudolph.everyvent.domain.calendar.entity.Calendar;
+import kr.santanrudolph.everyvent.domain.calendar.entity.OriginalCalendar;
+import kr.santanrudolph.everyvent.domain.calendar.enums.CalendarType;
+import kr.santanrudolph.everyvent.domain.calendar.enums.Category;
+import kr.santanrudolph.everyvent.domain.calendar.enums.Visibility;
+import lombok.Getter;
+
+import java.time.LocalDate;
+import java.util.Map;
+
+@Getter
+public class MonthlyCalendarStatsResponse extends CalendarResponse {
+
+  @JsonInclude(JsonInclude.Include.NON_NULL)
+  private LocalDate previewStartDate;
+  @JsonInclude(JsonInclude.Include.NON_NULL)
+  private LocalDate previewEndDate;
+  private Map<Integer, DailyTaskStats> dayStatus;
+
+  private MonthlyCalendarStatsResponse(
+      Long id,
+      Long userId,
+      CalendarType type,
+      String title,
+      String description,
+      LocalDate startDate,
+      LocalDate endDate,
+      LocalDate previewStartDate,
+      LocalDate previewEndDate,
+      Visibility visibility,
+      String color,
+      Category category,
+      Boolean isScrapable,
+      Map<Integer, DailyTaskStats> dayStatus
+  ) {
+    super(id, userId, type, title, description, startDate, endDate, visibility, color, category, isScrapable);
+    this.previewStartDate = previewStartDate;
+    this.previewEndDate = previewEndDate;
+    this.dayStatus = dayStatus;
+  }
+
+  public static MonthlyCalendarStatsResponse from(Calendar calendar,
+                                                  CalendarType type,
+                                                  Boolean isScrapable,
+                                                  Map<Integer, DailyTaskStats> dayStatus) {
+    LocalDate previewStartDate = null;
+    LocalDate previewEndDate = null;
+
+    if(calendar instanceof OriginalCalendar originalCalendar) {
+      previewStartDate = originalCalendar.getPreviewStartDate();
+      previewEndDate = originalCalendar.getPreviewEndDate();
+    }
+    return new MonthlyCalendarStatsResponse(
+        calendar.getId(),
+        calendar.getUser().getId(),
+        type,
+        calendar.getTitle(),
+        calendar.getDescription(),
+        calendar.getStartDate(),
+        calendar.getEndDate(),
+        previewStartDate,
+        previewEndDate,
+        calendar.getVisibility(),
+        calendar.getColor(),
+        calendar.getCategory(),
+        isScrapable,
+        dayStatus
+    );
+  }
+}

--- a/src/main/java/kr/santanrudolph/everyvent/domain/calendar/dto/response/OriginalCalendarResponse.java
+++ b/src/main/java/kr/santanrudolph/everyvent/domain/calendar/dto/response/OriginalCalendarResponse.java
@@ -23,12 +23,12 @@ public class OriginalCalendarResponse extends CalendarResponse {
                                    String description,
                                    LocalDate startDate,
                                    LocalDate endDate,
+                                   LocalDate previewStartDate,
+                                   LocalDate previewEndDate,
                                    Visibility visibility,
                                    String color,
                                    Category category,
-                                   Boolean isScrapable,
-                                   LocalDate previewStartDate,
-                                   LocalDate previewEndDate) {
+                                   Boolean isScrapable) {
 
     super(id, userId, type, title, description, startDate, endDate, visibility, color, category, isScrapable);
     this.previewStartDate = previewStartDate;
@@ -44,12 +44,12 @@ public class OriginalCalendarResponse extends CalendarResponse {
         .description(calendar.getDescription())
         .startDate(calendar.getStartDate())
         .endDate(calendar.getEndDate())
+        .previewStartDate(calendar.getPreviewStartDate())
+        .previewEndDate(calendar.getPreviewEndDate())
         .visibility(calendar.getVisibility())
         .color(calendar.getColor())
         .category(calendar.getCategory())
         .isScrapable(isScrapable)
-        .previewStartDate(calendar.getPreviewStartDate())
-        .previewEndDate(calendar.getPreviewEndDate())
         .build();
   }
 }

--- a/src/main/java/kr/santanrudolph/everyvent/domain/calendar/entity/OriginalCalendar.java
+++ b/src/main/java/kr/santanrudolph/everyvent/domain/calendar/entity/OriginalCalendar.java
@@ -26,11 +26,11 @@ public class OriginalCalendar extends Calendar {
                           String description,
                           LocalDate startDate,
                           LocalDate endDate,
+                          LocalDate previewStartDate,
+                          LocalDate previewEndDate,
                           Visibility visibility,
                           String color,
-                          Category category,
-                          LocalDate previewStartDate,
-                          LocalDate previewEndDate) {
+                          Category category) {
     super(user, title, description, startDate, endDate, visibility, color, category);
     updatePreviewPeriod(previewStartDate, previewEndDate);
   }

--- a/src/main/java/kr/santanrudolph/everyvent/global/config/SecurityConfig.java
+++ b/src/main/java/kr/santanrudolph/everyvent/global/config/SecurityConfig.java
@@ -35,7 +35,9 @@ public class SecurityConfig {
           auth
               .requestMatchers("/", "/error", "/favicon.ico").permitAll()
               .requestMatchers("/h2-console/**").permitAll()
-              .requestMatchers("/api/auth/**").permitAll();
+              .requestMatchers("/api/auth/**").permitAll()
+              .requestMatchers("/api/calendars/stats/monthly/user/**").permitAll()
+              .requestMatchers("/api/calendars/tasks/daily/user/**").permitAll();
 
           // dev 또는 local 프로파일일 때만 개발용 API 허용 (활성/기본 프로파일 모두 고려)
           if (environment.acceptsProfiles("dev", "local")) {


### PR DESCRIPTION
## 📝 무엇을 했나요?
**1. OriginalCalendar 생성자 리팩터링**
- previewStartDate/previewEndDate 파라미터를 startdDate, endDate 아래로 이동

**2. 공식 캘린더 배포 기능 개선**
- 공식 캘린더 배포 시, 캘린더와 함께 해당 캘린더의 태스크도 복제

**3. 공식 캘린더 조회 API 변경**
- 관리자용 조회를 월별 조회에서 전체 목록 조회로 변경

**4. 캘린더 삭제 기능 개선**
- 삭제 시 해당 캘린더의 태스크까지 함께 삭제 (softDelete)

**5. 이미 삭제된 캘린더 접근 시 에러코드 Forbidden → NotFound로 변경**

**6. 캘린더 정렬 로직 개선 (toCalendarResponseList)**
- startDate 기준 정렬 후 id로 보조 정렬 적용

**7. 월간 통계 / 일별 태스크 조회 DTO 추가**
- MonthlyCalendarStatsResponse, MonthlyCalendarResponse, DailyTasksOfCalendarResponse 추가
   - MonthlyCalendarStatsResponse: 캘린더 정보, 월별 통계(태스크 개수 및 태스크 완료 여부)
   - MonthlyCalendarResponse: 캘린더 정보, 월별 통계(태스크 개수)
   - DailyTasksOfCalendarResponse: 캘린더 정보, 일별 태스크 정보

**8. 월간 통계 / 일별 태스크 조회 API 추가**

**9. 비회원 접근 처리 기능 추가**
- SecurityConfig: permitAll 설정으로 비회원도 조회 API 접근 가능
- AuthenticationUtil: getCurrentUserIdOrNull 메서드 추가

## 💭 고민 지점과 리뷰 포인트
- 캘린더 복제 및 삭제 기능에서 태스크 복제/삭제 로직이 올바르게 적용됐는지
- 월간 통계 및 일별 태스크 조회 API에서 비회원 처리 로직(viewer == null)이 정확한지
- SecurityConfig에서 permitAll 설정이 필요한 엔드포인트에만 적용됐는지
- 생성자 파라미터 순서 변경, 정렬 기준 변경 등 리팩터링이 기존 로직에 영향 없는지

## 🔗 관련 이슈
#5 
#19

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 달별 캘린더 통계 조회(전체/캘린더별/공식 캘린더용) 추가
  * 일별 작업 목록 조회(전체 캘린더/개별 캘린더/공식 캘린더용) 추가
  * 관리자용 통계·일일 작업 전용 조회 경로 추가
  * 로그인 없이도 일부 통계 조회 허용

* **개선사항**
  * 캘린더 미리보기 기간 정보 노출 추가
  * 월별·일별 업무 집계(일별 통계 및 완료/미완료 카운트) 제공

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->