### PR TITLE
feat(calendar): 캘린더 생성, 조회, 수정, 삭제 구현

### DIFF
--- a/src/main/java/kr/santanrudolph/everyvent/domain/calendar/Calendar.java
+++ b/src/main/java/kr/santanrudolph/everyvent/domain/calendar/Calendar.java
@@ -29,7 +29,7 @@ public class Calendar extends BaseEntity {
   private Long id;
 
   @ManyToOne
-  @JoinColumn(name = "user_id")
+  @JoinColumn(name = "user_id", nullable = false)
   private User user;
 
   @Column(nullable = false)

--- a/src/main/java/kr/santanrudolph/everyvent/domain/calendar/Calendar.java
+++ b/src/main/java/kr/santanrudolph/everyvent/domain/calendar/Calendar.java
@@ -88,10 +88,11 @@ public class Calendar extends BaseEntity {
     return deletedAt != null;
   }
 
-  public static Calendar createCalendar(User user, String title, String description, LocalDate startDate,
-                                        LocalDate endDate, Visibility visibility, Category category,
-                                        CalendarColor color, Long originalCalendarId, CalendarType calendarType,
-                                        LocalDate previewStartDay, LocalDate previewEndDay) {
+  public static Calendar createCalendar(User user, String title, String description,
+                                        LocalDate startDate, LocalDate endDate,
+                                        LocalDate previewStartDay, LocalDate previewEndDay,
+                                        Visibility visibility, Category category,
+                                        CalendarColor color, Long originalCalendarId, CalendarType calendarType) {
 
     Calendar calendar = new Calendar();
     calendar.user = user;
@@ -111,7 +112,8 @@ public class Calendar extends BaseEntity {
   }
 
   public static Calendar createCalendarWithStartDay(User user, String title, String description,
-                                                    LocalDate startDate, Visibility visibility,
+                                                    LocalDate startDate, LocalDate previewStartDay,
+                                                    LocalDate previewEndDay, Visibility visibility,
                                                     CalendarColor color, Category category, CalendarType calendarType) {
 
     LocalDate endDate = startDate.plusDays(DEFAULT_PERIOD_DAYS);
@@ -121,18 +123,19 @@ public class Calendar extends BaseEntity {
         description,
         startDate,
         endDate,
+        previewStartDay,
+        previewEndDay,
         visibility,
         category,
         color,
         null,
-        calendarType,
-        null,
-        null
+        calendarType
     );
   }
 
   public static Calendar createCalendarWithStartAndEndDay(User user, String title, String description,
                                                           LocalDate startDate, LocalDate endDate,
+                                                          LocalDate previewStartDay, LocalDate previewEndDay,
                                                           Visibility visibility, CalendarColor color,
                                                           Category category, CalendarType calendarType) {
 
@@ -142,13 +145,14 @@ public class Calendar extends BaseEntity {
         description,
         startDate,
         endDate,
+        previewStartDay,
+        previewEndDay,
         visibility,
         category,
         color,
         null,
-        calendarType,
-        null,
-        null);
+        calendarType
+    );
   }
 
   public static Calendar createScrappedCalendar(User user, Calendar originalCalendar, CalendarColor color) {
@@ -163,28 +167,33 @@ public class Calendar extends BaseEntity {
         originalCalendar.getDescription(),
         originalCalendar.getStartDate(),
         originalCalendar.getEndDate(),
+        originalCalendar.getPreviewStartDay(),
+        originalCalendar.getPreviewEndDay(),
         Visibility.PUBLIC,
         originalCalendar.getCategory(),
         color,
         originalCalendar.getId(),
-        CalendarType.SCRAPED,
-        originalCalendar.getPreviewStartDay(),
-        originalCalendar.getPreviewEndDay()
+        CalendarType.SCRAPED
     );
   }
 
   public static Calendar createOfficialCalendar(User user, String title, String description,
-                                                LocalDate startDate, LocalDate endDate, CalendarColor color, Category category) {
+                                                LocalDate startDate, LocalDate endDate,
+                                                LocalDate previewStartDay, LocalDate previewEndDay,
+                                                CalendarColor color, Category category) {
     return createCalendarWithStartAndEndDay(
         user,
         title,
         description,
         startDate,
         endDate,
+        previewStartDay,
+        previewEndDay,
         Visibility.ADMIN,
         color,
         category,
-        CalendarType.OFFICIAL);
+        CalendarType.OFFICIAL
+    );
   }
 
   // 배포 캘린더의 공개범위는 항상 public (공개범위 변경 불가)
@@ -196,13 +205,13 @@ public class Calendar extends BaseEntity {
         , officialCalendar.getDescription()
         , officialCalendar.getStartDate()
         , officialCalendar.getEndDate()
+        , officialCalendar.getPreviewStartDay()
+        , officialCalendar.getPreviewEndDay()
         , Visibility.PUBLIC
         , officialCalendar.getCategory()
         , officialCalendar.getColor()
         , officialCalendar.getId()
         , CalendarType.DISTRIBUTED
-        , officialCalendar.getPreviewStartDay()
-        , officialCalendar.getPreviewEndDay()
     );
   }
 

--- a/src/main/java/kr/santanrudolph/everyvent/domain/calendar/CalendarConstants.java
+++ b/src/main/java/kr/santanrudolph/everyvent/domain/calendar/CalendarConstants.java
@@ -1,8 +1,19 @@
 package kr.santanrudolph.everyvent.domain.calendar;
 
+
+import kr.santanrudolph.everyvent.domain.calendar.enums.CalendarType;
+
+import java.util.List;
+
 public class CalendarConstants {
   public static final int DEFAULT_PERIOD_DAYS = 25;
   public static final int MAX_CNT_PER_MONTH = 3;
+
+  // 월별 생성 제한 대상 캘린더 타입 (PERSONAL, SCRAPED만 제한)
+  public static final List<CalendarType> LIMITED_CALENDAR_TYPES = List.of(
+      CalendarType.PERSONAL,
+      CalendarType.SCRAPED
+  );
 
 }
 

--- a/src/main/java/kr/santanrudolph/everyvent/domain/calendar/CalendarController.java
+++ b/src/main/java/kr/santanrudolph/everyvent/domain/calendar/CalendarController.java
@@ -12,11 +12,13 @@ import kr.santanrudolph.everyvent.domain.calendar.enums.Category;
 import kr.santanrudolph.everyvent.domain.calendar.enums.Visibility;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.time.LocalDate;
+import java.time.YearMonth;
 import java.util.List;
 
 @Slf4j
@@ -25,6 +27,8 @@ import java.util.List;
 @RequestMapping("/api/calendars")
 @RequiredArgsConstructor
 public class CalendarController {
+
+  private final CalendarService calendarService;
 
   @Operation(summary = "캘린더 생성", description = "유저가 내 캘린더(PERSONAL) 생성")
   @ApiResponses({
@@ -36,206 +40,20 @@ public class CalendarController {
   public ResponseEntity<CalendarDetailResponse> createCalendar(
       @Valid @RequestBody CalendarCreateRequest request) {
 
-    CalendarDetailResponse response = new CalendarDetailResponse(
-        1L,
-        1L,
-        request.title(),
-        request.description(),
-        request.startDate(),
-        request.startDate().plusDays(25),
-        request.previewStartDate(),
-        request.previewEndDate(),
-        request.visibility(),
-        request.color(),
-        request.category(),
-        null,
-        CalendarType.PERSONAL,
-        false,
-        0L
-    );
-
+    CalendarDetailResponse response = calendarService.createPersonalCalendar(request);
     return ResponseEntity.status(HttpStatus.CREATED).body(response);
   }
 
   @Operation(summary = "내 캘린더 목록 조회 (무한스크롤)", description = "커서 기반 무한스크롤로 내 캘린더 목록을 월별로 그루핑하여 조회합니다.\n" +
       "(내가 만든 캘린더, 스크랩한 캘린더, 배포받은 캘린더)\n" +
-      "- cursor: 마지막으로 받은 월 (YYYY-MM 형식, 첫 요청시 생략)\n" +
+      "- cursor: 이전 응답값에서 받은 nextCursor (YYYY-MM 형식, 첫 요청시 생략)\n" +
       "- size: 페이지 크기 (달 갯수를 의미합니다. 현재 예시는 7월~12월까지이므로 size=6 입니다.)")
   @GetMapping()
   public ResponseEntity<CalendarScrollResponse> getMyCalendars(
-      @RequestParam(required = false) String cursor,
+      @RequestParam(required = false) YearMonth cursor,
       @RequestParam(required = false, defaultValue = "10") Integer size) {
 
-    CalendarSummaryResponse calendar1 = new CalendarSummaryResponse(
-        1L,
-        1L,
-        "내 캘린더",
-        "설명",
-        LocalDate.of(2025, 12, 1),
-        LocalDate.of(2025, 12, 25),
-        Visibility.PUBLIC,
-        CalendarColor.BLUE,
-        Category.HOBBY,
-        null,
-        CalendarType.PERSONAL,
-        0L
-    );
-
-    CalendarSummaryResponse calendar2 = new CalendarSummaryResponse(
-        5L,
-        1L,
-        "내 캘린더2",
-        "설명",
-        LocalDate.of(2025, 12, 1),
-        LocalDate.of(2025, 12, 25),
-        Visibility.PRIVATE,
-        CalendarColor.YELLOW,
-        Category.CHALLENGE,
-        null,
-        CalendarType.PERSONAL,
-        0L
-    );
-
-    CalendarSummaryResponse calendar3 = new CalendarSummaryResponse(
-        6L,
-        1L,
-        "스크랩한 캘린더",
-        "설명",
-        LocalDate.of(2025, 12, 1),
-        LocalDate.of(2025, 12, 25),
-        Visibility.PRIVATE,
-        CalendarColor.YELLOW,
-        Category.CHALLENGE,
-        1L,
-        CalendarType.SCRAPED,
-        0L
-    );
-
-    CalendarSummaryResponse calendar4 = new CalendarSummaryResponse(
-        7L,
-        1L,
-        "배포받은 공식 캘린더",
-        "설명",
-        LocalDate.of(2025, 11, 1),
-        LocalDate.of(2025, 11, 25),
-        Visibility.PUBLIC,
-        CalendarColor.MINT,
-        Category.CHALLENGE,
-        100L,
-        CalendarType.DISTRIBUTED,
-        0L
-    );
-
-    CalendarSummaryResponse calendar5 = new CalendarSummaryResponse(
-        3L,
-        1L,
-        "내 캘린더3",
-        "설명",
-        LocalDate.of(2025, 11, 1),
-        LocalDate.of(2025, 11, 25),
-        Visibility.PRIVATE,
-        CalendarColor.YELLOW,
-        Category.CHALLENGE,
-        null,
-        CalendarType.PERSONAL,
-        0L
-    );
-
-    CalendarSummaryResponse calendar6 = new CalendarSummaryResponse(
-        4L,
-        1L,
-        "내 캘린더4",
-        "설명",
-        LocalDate.of(2025, 10, 1),
-        LocalDate.of(2025, 10, 25),
-        Visibility.PRIVATE,
-        CalendarColor.YELLOW,
-        Category.CHALLENGE,
-        null,
-        CalendarType.PERSONAL,
-        0L
-    );
-
-    CalendarSummaryResponse calendar7 = new CalendarSummaryResponse(
-        5L,
-        1L,
-        "내 캘린더2",
-        "설명",
-        LocalDate.of(2025, 9, 1),
-        LocalDate.of(2025, 9, 25),
-        Visibility.PRIVATE,
-        CalendarColor.YELLOW,
-        Category.CHALLENGE,
-        null,
-        CalendarType.PERSONAL,
-        0L
-    );
-
-    CalendarSummaryResponse calendar8 = new CalendarSummaryResponse(
-        8L,
-        1L,
-        "내 캘린더8",
-        "설명",
-        LocalDate.of(2025, 9, 1),
-        LocalDate.of(2025, 9, 25),
-        Visibility.PRIVATE,
-        CalendarColor.PEACH,
-        Category.CHALLENGE,
-        null,
-        CalendarType.PERSONAL,
-        0L
-    );
-
-    CalendarSummaryResponse calendar9 = new CalendarSummaryResponse(
-        9L,
-        1L,
-        "내 캘린더9",
-        "설명",
-        LocalDate.of(2025, 8, 1),
-        LocalDate.of(2025, 8, 25),
-        Visibility.PRIVATE,
-        CalendarColor.LAVENDER,
-        Category.HOBBY,
-        null,
-        CalendarType.PERSONAL,
-        0L
-    );
-
-    CalendarSummaryResponse calendar10 = new CalendarSummaryResponse(
-        10L,
-        1L,
-        "내 캘린더10",
-        "설명",
-        LocalDate.of(2025, 7, 1),
-        LocalDate.of(2025, 7, 25),
-        Visibility.PUBLIC,
-        CalendarColor.MINT,
-        Category.CHALLENGE,
-        null,
-        CalendarType.PERSONAL,
-        0L
-    );
-
-    // 월별로 그루핑
-    List<CalendarMonthGroup> monthGroups = List.of(
-        new CalendarMonthGroup(2025, 12, List.of(calendar1, calendar2, calendar3)),
-        new CalendarMonthGroup(2025, 11, List.of(calendar4, calendar5)),
-        new CalendarMonthGroup(2025, 10, List.of(calendar6)),
-        new CalendarMonthGroup(2025, 9, List.of(calendar7, calendar8)),
-        new CalendarMonthGroup(2025, 8, List.of(calendar9)),
-        new CalendarMonthGroup(2025, 7, List.of(calendar10))
-    );
-
-    // 무한스크롤 응답 생성
-    String nextCursor = "2025-06";  // 다음 조회 시작월
-    boolean hasNext = true;  // 실제 구현시 DB 조회 결과에 따라 결정
-
-    CalendarScrollResponse response = new CalendarScrollResponse(
-        monthGroups,
-        nextCursor,
-        hasNext
-    );
-
+    CalendarScrollResponse response = calendarService.getMyCalendars(cursor, size);
     return ResponseEntity.ok(response);
   }
 
@@ -248,101 +66,32 @@ public class CalendarController {
   @GetMapping("/{calendarId}")
   public ResponseEntity<CalendarDetailResponse> getCalendar(@PathVariable Long calendarId) {
 
-    CalendarDetailResponse response = new CalendarDetailResponse(
-        calendarId,
-        2L,
-        "캘린더 제목",
-        "캘린더 설명",
-        LocalDate.of(2024, 12, 1),
-        LocalDate.of(2024, 12, 25),
-        LocalDate.of(2024, 12, 5),
-        LocalDate.of(2024, 12, 20),
-        Visibility.PUBLIC,
-        CalendarColor.MINT,
-        Category.HOBBY,
-        null,
-        CalendarType.PERSONAL,
-        true,   // 이미 스크랩한 캘린더 판단 로직 필요...
-        0L
-    );
-
+    CalendarDetailResponse response = calendarService.getCalendar(calendarId);
     return ResponseEntity.ok(response);
   }
 
-  @Operation(summary = "이번달 인기 캘린더 목록 조회 (비회원 접근 가능)", description = "이번달 인기 캘린더 30개를 조회합니다.\n" +
-      "전체공개 캘린더만 조회됩니다.")
-  @GetMapping("/popular")
-  public ResponseEntity<PopularCalendarsResponse> getPopularCalendars() {
-
-    List<CalendarSummaryResponse> calendars = List.of(
-        new CalendarSummaryResponse(
-            101L, 11L, "인기 캘린더 1", "설명",
-            LocalDate.of(2025, 12, 1), LocalDate.of(2025, 12, 25),
-            Visibility.PUBLIC, CalendarColor.BLUE, Category.CHALLENGE,
-            null, CalendarType.PERSONAL, 150L
-        ),
-        new CalendarSummaryResponse(
-            102L, 12L, "인기 캘린더 2", "설명",
-            LocalDate.of(2025, 12, 1), LocalDate.of(2025, 12, 25),
-            Visibility.PUBLIC, CalendarColor.PEACH, Category.HOBBY,
-            null, CalendarType.PERSONAL, 120L
-        ),
-        new CalendarSummaryResponse(
-            103L, 13L, "인기 캘린더 3", "설명",
-            LocalDate.of(2025, 12, 1), LocalDate.of(2025, 12, 25),
-            Visibility.PUBLIC, CalendarColor.MINT, Category.CHALLENGE,
-            null, CalendarType.PERSONAL, 100L
-        ),
-        new CalendarSummaryResponse(
-            104L, 14L, "인기 캘린더 4", "설명",
-            LocalDate.of(2025, 12, 1), LocalDate.of(2025, 12, 25),
-            Visibility.PUBLIC, CalendarColor.LAVENDER, Category.HOBBY,
-            null, CalendarType.PERSONAL, 90L
-        ),
-        new CalendarSummaryResponse(
-            105L, 15L, "인기 캘린더 5", "설명",
-            LocalDate.of(2025, 12, 1), LocalDate.of(2025, 12, 25),
-            Visibility.PUBLIC, CalendarColor.YELLOW, Category.CHALLENGE,
-            null, CalendarType.PERSONAL, 85L
-        ),
-        new CalendarSummaryResponse(
-            106L, 16L, "인기 캘린더 6", "설명",
-            LocalDate.of(2025, 12, 1), LocalDate.of(2025, 12, 25),
-            Visibility.PUBLIC, CalendarColor.BLUE, Category.HOBBY,
-            null, CalendarType.PERSONAL, 75L
-        ),
-        new CalendarSummaryResponse(
-            107L, 17L, "인기 캘린더 7", "설명",
-            LocalDate.of(2025, 12, 1), LocalDate.of(2025, 12, 25),
-            Visibility.PUBLIC, CalendarColor.PEACH, Category.CHALLENGE,
-            null, CalendarType.PERSONAL, 70L
-        ),
-        new CalendarSummaryResponse(
-            108L, 18L, "인기 캘린더 8", "설명",
-            LocalDate.of(2025, 12, 1), LocalDate.of(2025, 12, 25),
-            Visibility.PUBLIC, CalendarColor.MINT, Category.HOBBY,
-            null, CalendarType.PERSONAL, 65L
-        ),
-        new CalendarSummaryResponse(
-            109L, 19L, "인기 캘린더 9", "설명",
-            LocalDate.of(2025, 12, 1), LocalDate.of(2025, 12, 25),
-            Visibility.PUBLIC, CalendarColor.LAVENDER, Category.CHALLENGE,
-            null, CalendarType.PERSONAL, 60L
-        ),
-        new CalendarSummaryResponse(
-            110L, 20L, "인기 캘린더 10", "설명",
-            LocalDate.of(2025, 12, 1), LocalDate.of(2025, 12, 25),
-            Visibility.PUBLIC, CalendarColor.YELLOW, Category.HOBBY,
-            null, CalendarType.PERSONAL, 55L
-        )
-    );
-
-    PopularCalendarsResponse response = new PopularCalendarsResponse(calendars);
-
+  @Operation(
+      summary = "월별 통합 캘린더 조회",
+      description = """
+            특정 년월의 내 모든 캘린더를 조회합니다. (최대 4개)
+            - 조회 결과가 없을 경우 빈 배열([])을 반환합니다.
+            - 본인의 캘린더만 조회 가능합니다.
+          """
+  )
+  @GetMapping("/calendars/monthly")
+  public ResponseEntity<List<CalendarDetailResponse>> getMonthlyCalendars(
+      @RequestParam
+      @DateTimeFormat(pattern = "yyyy-MM")
+      YearMonth yearMonth
+  ) {
+    List<CalendarDetailResponse> response = calendarService.getMonthlyCalendars(yearMonth);
     return ResponseEntity.ok(response);
   }
 
-  @Operation(summary = "캘린더 수정", description = "제목, 설명, 공개범위, 색상, 카테고리를 수정할 수 있습니다. 수정이 필요한 필드만 포함해서 보냅니다. (모든 필드를 추가하지 않아도 됨)")
+  @Operation(summary = "내가 만든 캘린더 수정", description = "제목, 설명, 공개범위, 색상, 카테고리를 수정할 수 있습니다. 수정이 필요한 필드만 포함해서 보냅니다. (모든 " +
+      "필드를" +
+      " " +
+      "추가하지 않아도 됨)")
   @ApiResponses({
       @ApiResponse(responseCode = "200", description = "수정 성공"),
       @ApiResponse(responseCode = "400", description = "INVALID_INPUT: 스크랩/배포본 수정 제한"),
@@ -354,25 +103,7 @@ public class CalendarController {
       @PathVariable Long calendarId,
       @Valid @RequestBody CalendarUpdateRequest request) {
 
-    CalendarDetailResponse response = new CalendarDetailResponse(
-        calendarId,
-        1L,
-        request.title() != null ? request.title() : "기존 제목",
-        request.description() != null ? request.description() : "기존 설명",
-        LocalDate.of(2024, 12, 1),
-        LocalDate.of(2024, 12, 25),
-        LocalDate.of(2024, 12, 5),
-        LocalDate.of(2024, 12, 20),
-        request.visibility() != null ? request.visibility() : Visibility.PUBLIC,
-        request.color() != null ? request.color() : CalendarColor.BLUE,
-        request.category() != null ? request.category() : Category.CHALLENGE,
-        null,  // 원본 캘린더
-        CalendarType.PERSONAL,
-        true,
-        0L
-    );
-
-
+    CalendarDetailResponse response = calendarService.updatePersonalCalendar(calendarId, request);
     return ResponseEntity.ok(response);
   }
 
@@ -385,11 +116,12 @@ public class CalendarController {
   })
   @DeleteMapping("/{calendarId}")
   public ResponseEntity<Void> deleteCalendar(@PathVariable Long calendarId) {
+    calendarService.deleteCalendar(calendarId);
     return ResponseEntity.noContent().build();
   }
 
 
-  @Operation(summary = "캘린더 스크랩", description = "다른 사용자의 공개 캘린더를 내 컬렉션에 저장합니다. userId는 현재 유저입니다.")
+  @Operation(summary = "캘린더 스크랩", description = "다른 사용자의 공개 캘린더를 내 컬렉션에 저장합니다.")
   @ApiResponses({
       @ApiResponse(responseCode = "201", description = "스크랩 성공"),
       @ApiResponse(responseCode = "400", description = "INVALID_INPUT: 자기 캘린더 스크랩 시도"),
@@ -434,24 +166,7 @@ public class CalendarController {
       @PathVariable Long calendarId,
       @Valid @RequestBody ScrapCalendarRequest request) {
 
-    CalendarDetailResponse response = new CalendarDetailResponse(
-        calendarId,
-        1L,
-        "스크랩한 캘린더",
-        "설명",
-        LocalDate.of(2024, 12, 1),
-        LocalDate.of(2024, 12, 25),
-        LocalDate.of(2024, 12, 5),
-        LocalDate.of(2024, 12, 20),
-        Visibility.PRIVATE,
-        request.color(),  // 변경된 색상
-        Category.HOBBY,
-        10L,  // 원본 ID
-        CalendarType.SCRAPED,
-        false,
-        1L
-    );
-
+    CalendarDetailResponse response = calendarService.updateScrapColor(calendarId, request);
     return ResponseEntity.ok(response);
   }
 
@@ -467,60 +182,79 @@ public class CalendarController {
     return ResponseEntity.noContent().build();
   }
 
+  // todo: 특정 캘린더를 스크랩한 사람 목록 조회하기
 
-  @Operation(summary = "월별 통합 캘린더 조회", description = "특정 년월의 내 모든 캘린더를 조회합니다. (최대 4개)\n" +
-      "내가 만든 캘린더, 스크랩한 캘린더, 배포받은 공식 캘린더가 포함됩니다. 본인의 것만 조회 가능합니다.")
-  @GetMapping("/monthly")
-  public ResponseEntity<List<CalendarSummaryResponse>> getMonthlyCalendars(
-      @RequestParam int year,
-      @RequestParam int month) {
+  @Operation(summary = "이번달 인기 캘린더 목록 조회 (비회원 접근 가능)", description = "이번달 인기 캘린더 30개를 조회합니다.\n" +
+      "전체공개 캘린더만 조회됩니다.")
+  @GetMapping("/popular")
+  public ResponseEntity<PopularCalendarsResponse> getPopularCalendars() {
 
-    CalendarSummaryResponse calendar1 = new CalendarSummaryResponse(
-        1L,
-        1L,
-        "내가 만든 12월 캘린더",
-        "개인 캘린더 설명",
-        LocalDate.of(year, month, 1),
-        LocalDate.of(year, month, 25),
-        Visibility.PUBLIC,
-        CalendarColor.BLUE,
-        Category.HOBBY,
-        null,
-        CalendarType.PERSONAL,
-        0L
+    List<CalendarListResponse> calendars = List.of(
+        new CalendarListResponse(
+            101L, 11L, "인기 캘린더 1", "설명",
+            LocalDate.of(2025, 12, 1), LocalDate.of(2025, 12, 25),
+            Visibility.PUBLIC, CalendarColor.BLUE, Category.CHALLENGE,
+            null, CalendarType.PERSONAL, 150L
+        ),
+        new CalendarListResponse(
+            102L, 12L, "인기 캘린더 2", "설명",
+            LocalDate.of(2025, 12, 1), LocalDate.of(2025, 12, 25),
+            Visibility.PUBLIC, CalendarColor.PEACH, Category.HOBBY,
+            null, CalendarType.PERSONAL, 120L
+        ),
+        new CalendarListResponse(
+            103L, 13L, "인기 캘린더 3", "설명",
+            LocalDate.of(2025, 12, 1), LocalDate.of(2025, 12, 25),
+            Visibility.PUBLIC, CalendarColor.MINT, Category.CHALLENGE,
+            null, CalendarType.PERSONAL, 100L
+        ),
+        new CalendarListResponse(
+            104L, 14L, "인기 캘린더 4", "설명",
+            LocalDate.of(2025, 12, 1), LocalDate.of(2025, 12, 25),
+            Visibility.PUBLIC, CalendarColor.LAVENDER, Category.HOBBY,
+            null, CalendarType.PERSONAL, 90L
+        ),
+        new CalendarListResponse(
+            105L, 15L, "인기 캘린더 5", "설명",
+            LocalDate.of(2025, 12, 1), LocalDate.of(2025, 12, 25),
+            Visibility.PUBLIC, CalendarColor.YELLOW, Category.CHALLENGE,
+            null, CalendarType.PERSONAL, 85L
+        ),
+        new CalendarListResponse(
+            106L, 16L, "인기 캘린더 6", "설명",
+            LocalDate.of(2025, 12, 1), LocalDate.of(2025, 12, 25),
+            Visibility.PUBLIC, CalendarColor.BLUE, Category.HOBBY,
+            null, CalendarType.PERSONAL, 75L
+        ),
+        new CalendarListResponse(
+            107L, 17L, "인기 캘린더 7", "설명",
+            LocalDate.of(2025, 12, 1), LocalDate.of(2025, 12, 25),
+            Visibility.PUBLIC, CalendarColor.PEACH, Category.CHALLENGE,
+            null, CalendarType.PERSONAL, 70L
+        ),
+        new CalendarListResponse(
+            108L, 18L, "인기 캘린더 8", "설명",
+            LocalDate.of(2025, 12, 1), LocalDate.of(2025, 12, 25),
+            Visibility.PUBLIC, CalendarColor.MINT, Category.HOBBY,
+            null, CalendarType.PERSONAL, 65L
+        ),
+        new CalendarListResponse(
+            109L, 19L, "인기 캘린더 9", "설명",
+            LocalDate.of(2025, 12, 1), LocalDate.of(2025, 12, 25),
+            Visibility.PUBLIC, CalendarColor.LAVENDER, Category.CHALLENGE,
+            null, CalendarType.PERSONAL, 60L
+        ),
+        new CalendarListResponse(
+            110L, 20L, "인기 캘린더 10", "설명",
+            LocalDate.of(2025, 12, 1), LocalDate.of(2025, 12, 25),
+            Visibility.PUBLIC, CalendarColor.YELLOW, Category.HOBBY,
+            null, CalendarType.PERSONAL, 55L
+        )
     );
 
-    CalendarSummaryResponse calendar2 = new CalendarSummaryResponse(
-        2L,
-        1L,
-        "스크랩한 12월 캘린더",
-        "스크랩 캘린더 설명",
-        LocalDate.of(year, month, 1),
-        LocalDate.of(year, month, 25),
-        Visibility.PRIVATE,
-        CalendarColor.YELLOW,
-        Category.CHALLENGE,
-        10L,  // 원본 캘린더 ID
-        CalendarType.SCRAPED,
-        50L
-    );
+    PopularCalendarsResponse response = new PopularCalendarsResponse(calendars);
 
-    CalendarSummaryResponse calendar3 = new CalendarSummaryResponse(
-        3L,
-        1L,
-        "배포받은 공식 캘린더",
-        "공식 캘린더 설명",
-        LocalDate.of(year, month, 1),
-        LocalDate.of(year, month, 25),
-        Visibility.PUBLIC,
-        CalendarColor.MINT,
-        Category.CHALLENGE,
-        100L,  // 공식 캘린더 원본 ID
-        CalendarType.DISTRIBUTED,
-        0L
-    );
-
-    return ResponseEntity.ok(List.of(calendar1, calendar2, calendar3));
+    return ResponseEntity.ok(response);
   }
 }
 

--- a/src/main/java/kr/santanrudolph/everyvent/domain/calendar/CalendarController.java
+++ b/src/main/java/kr/santanrudolph/everyvent/domain/calendar/CalendarController.java
@@ -78,7 +78,7 @@ public class CalendarController {
             - 본인의 캘린더만 조회 가능합니다.
           """
   )
-  @GetMapping("/calendars/monthly")
+  @GetMapping("/monthly")
   public ResponseEntity<List<CalendarDetailResponse>> getMonthlyCalendars(
       @RequestParam
       @DateTimeFormat(pattern = "yyyy-MM")

--- a/src/main/java/kr/santanrudolph/everyvent/domain/calendar/CalendarRepository.java
+++ b/src/main/java/kr/santanrudolph/everyvent/domain/calendar/CalendarRepository.java
@@ -1,0 +1,58 @@
+package kr.santanrudolph.everyvent.domain.calendar;
+
+import kr.santanrudolph.everyvent.domain.calendar.enums.CalendarType;
+import kr.santanrudolph.everyvent.domain.user.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+public interface CalendarRepository extends JpaRepository<Calendar, Long> {
+
+  @Query("""
+      SELECT COUNT(c)
+      FROM Calendar c
+      WHERE c.user = :user
+        AND YEAR(c.startDate) = :year
+        AND MONTH(c.startDate) = :month
+        AND c.calendarType IN :types
+        AND c.deletedAt IS NULL
+      """)
+  long countByUserAndYearMonthAndTypes(
+      @Param("user") User user,
+      @Param("year") int year,
+      @Param("month") int month,
+      @Param("types") List<CalendarType> types
+  );
+
+  @Query("""
+      SELECT c
+      FROM Calendar c
+      WHERE c.user = :user
+        AND c.deletedAt IS NULL
+      ORDER BY c.startDate DESC
+      """)
+  List<Calendar> findAllByUserAndDeletedAtIsNull(@Param("user") User user);
+
+  @Query("""
+          SELECT c
+          FROM Calendar c
+          WHERE c.user = :user
+            AND c.deletedAt IS NULL
+            AND c.startDate >= :startDate
+            AND c.startDate <= :endDate
+          ORDER BY c.startDate DESC
+      """)
+  List<Calendar> findByUserAndStartDateBetween(
+      @Param("user") User user,
+      @Param("startDate") LocalDate startDate,
+      @Param("endDate") LocalDate endDate
+  );
+
+
+  Optional<Calendar> findFirstByUserAndDeletedAtIsNullAndStartDateBeforeOrderByStartDateDesc(User user, LocalDate startDate);
+
+}

--- a/src/main/java/kr/santanrudolph/everyvent/domain/calendar/CalendarService.java
+++ b/src/main/java/kr/santanrudolph/everyvent/domain/calendar/CalendarService.java
@@ -245,7 +245,7 @@ public class CalendarService {
             entry.getKey().getMonthValue(),
             entry.getValue()
         ))
-        .toList();
+        .collect(Collectors.toCollection(ArrayList::new));
   }
 
   private Calendar findCalendarById(Long calendarId) {

--- a/src/main/java/kr/santanrudolph/everyvent/domain/calendar/CalendarService.java
+++ b/src/main/java/kr/santanrudolph/everyvent/domain/calendar/CalendarService.java
@@ -104,8 +104,8 @@ public class CalendarService {
     }
 
     YearMonth endYearMonth = startYearMonth.minusMonths(size);
-    LocalDate startDate = startYearMonth.atDay(1);
-    LocalDate endDate = endYearMonth.atEndOfMonth();
+    LocalDate startDate = endYearMonth.atDay(1);
+    LocalDate endDate = startYearMonth.atEndOfMonth();
 
     List<Calendar> calendars = calendarRepository.findByUserAndStartDateBetween(
         user,

--- a/src/main/java/kr/santanrudolph/everyvent/domain/calendar/CalendarService.java
+++ b/src/main/java/kr/santanrudolph/everyvent/domain/calendar/CalendarService.java
@@ -1,0 +1,377 @@
+package kr.santanrudolph.everyvent.domain.calendar;
+
+import kr.santanrudolph.everyvent.domain.calendar.dto.*;
+import kr.santanrudolph.everyvent.domain.calendar.enums.CalendarType;
+import kr.santanrudolph.everyvent.domain.calendar.enums.Visibility;
+import kr.santanrudolph.everyvent.domain.calendar.scrap.ScrapService;
+import kr.santanrudolph.everyvent.domain.follow.FollowService;
+import kr.santanrudolph.everyvent.domain.user.User;
+import kr.santanrudolph.everyvent.domain.user.UserService;
+import kr.santanrudolph.everyvent.domain.user.enums.Role;
+import kr.santanrudolph.everyvent.global.exception.ErrorCode;
+import kr.santanrudolph.everyvent.global.exception.EveryventException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.YearMonth;
+import java.util.*;
+import java.util.stream.Collectors;
+
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class CalendarService {
+
+  private static final boolean SCRAPPABLE = true;
+  private static final boolean NOT_SCRAPPABLE = false;
+  private static final long INITIAL_SCRAP_COUNT = 0L;
+
+  private final CalendarRepository calendarRepository;
+  private final UserService userService;
+  private final ScrapService scrapService;
+  private final FollowService followService;
+
+
+  @Transactional
+  public CalendarDetailResponse createPersonalCalendar(CalendarCreateRequest request) {
+
+    User user = userService.getCurrentUser();
+
+    try {
+      validateCalendarLimit(user, request.startDate());
+      validateFuture(request.startDate());
+    } catch (Exception e) {
+      throw new EveryventException(ErrorCode.INVALID_INPUT, e.getMessage() + " 캘린더를 만들 수 없습니다.");
+    }
+
+    Calendar calendar = Calendar.createCalendarWithStartDay(
+        user,
+        request.title(),
+        request.description(),
+        request.startDate(),
+        request.previewStartDate(),
+        request.previewEndDate(),
+        request.visibility(),
+        request.color(),
+        request.category(),
+        CalendarType.PERSONAL
+    );
+
+
+    Calendar saved = calendarRepository.save(calendar);
+
+    return CalendarDetailResponse.from(saved, NOT_SCRAPPABLE, INITIAL_SCRAP_COUNT);
+  }
+
+  public CalendarDetailResponse getCalendar(Long calendarId) {
+    Calendar calendar = findCalendarById(calendarId);
+    User currentUser = userService.getCurrentUser();
+
+    validateCanViewCalendar(currentUser, calendar);
+
+    Long scrapCount = scrapService.getScrapCount(calendarId);
+    boolean scrappable = isScrappable(currentUser, calendar);
+    return CalendarDetailResponse.from(calendar, scrappable, scrapCount);
+  }
+
+  public CalendarScrollResponse getMyCalendars(YearMonth cursor, Integer size) {
+    User user = userService.getCurrentUser();
+
+    if (size <= 0) {
+      throw new EveryventException(ErrorCode.INVALID_INPUT, "size는 1 이상이어야 합니다.");
+    }
+
+    YearMonth startYearMonth;
+    if (cursor == null) {
+      startYearMonth = calendarRepository
+          .findFirstByUserAndDeletedAtIsNullAndStartDateBeforeOrderByStartDateDesc(
+              user,
+              LocalDate.now().plusYears(10)  // todo: 비즈니스 로직 상 10년 후까지 포함. 리팩토링 필요
+          )
+          .map(calendar -> YearMonth.from(calendar.getStartDate()))
+          .orElse(null);
+    } else {
+      startYearMonth = cursor;
+    }
+
+    if (startYearMonth == null) { // 최근 캘린더 존재하지 않음
+      return new CalendarScrollResponse(null, null, false);
+    }
+
+    YearMonth endYearMonth = startYearMonth.minusMonths(size);
+    LocalDate startDate = startYearMonth.atDay(1);
+    LocalDate endDate = endYearMonth.atEndOfMonth();
+
+    List<Calendar> calendars = calendarRepository.findByUserAndStartDateBetween(
+        user,
+        startDate,
+        endDate
+    );
+
+    Map<Long, Long> scrapCountsMap = getScrapCountMapFromCalendars(calendars);
+
+    List<CalendarMonthGroup> calendarMonthGroups = groupCalendarsByMonth(calendars, scrapCountsMap);
+
+    boolean hasNext = calendarMonthGroups.size() > size;
+    String nextCursor = null;
+
+    if (hasNext) {
+      CalendarMonthGroup lastGroup = calendarMonthGroups.remove(calendarMonthGroups.size() - 1);
+      nextCursor = lastGroup.toYearMonth().toString();
+    }
+
+    return new CalendarScrollResponse(calendarMonthGroups, nextCursor, hasNext);
+  }
+
+  public List<CalendarDetailResponse> getMonthlyCalendars(YearMonth yearMonth) {
+    LocalDate startDate = yearMonth.atDay(1);
+    LocalDate endDate = yearMonth.atEndOfMonth();
+    List<Calendar> calendars = calendarRepository.findByUserAndStartDateBetween(
+        userService.getCurrentUser(),
+        startDate,
+        endDate
+    );
+
+    Map<Long, Long> scrapCountsMap = getScrapCountMapFromCalendars(calendars);
+
+    return calendars.stream()
+        .map(calendar -> CalendarDetailResponse.from(
+            calendar,
+            NOT_SCRAPPABLE,
+            scrapCountsMap.getOrDefault(calendar.getId(), 0L)))
+        .toList();
+  }
+
+  @Transactional
+  public CalendarDetailResponse updatePersonalCalendar(Long calendarId, CalendarUpdateRequest request) {
+    User currentUser = userService.getCurrentUser();
+    Calendar calendar = findCalendarById(calendarId);
+
+    validateUpdateCalendar(currentUser, calendar);
+
+    if (request.title() != null) {
+      calendar.updateTitle(request.title());
+    }
+    if (request.description() != null) {
+      calendar.updateDescription(request.description());
+    }
+    if (request.startDate() != null) {
+      calendar.updateStartDate(request.startDate());
+    }
+    if (request.endDate() != null) {
+      calendar.updateEndDate(request.endDate());
+    }
+    if (request.previewStartDate() != null) {
+      calendar.updatePreviewStartDay(request.previewStartDate());
+    }
+    if (request.previewEndDate() != null) {
+      calendar.updatePreviewEndDay(request.previewEndDate());
+    }
+    if (request.visibility() != null) {
+      calendar.updateVisibility(request.visibility());
+    }
+    if (request.color() != null) {
+      calendar.updateColor(request.color());
+    }
+    if (request.category() != null) {
+      calendar.updateCategory(request.category());
+    }
+
+    Long scrapCount = scrapService.getScrapCount(calendar.getId());
+
+    return CalendarDetailResponse.from(calendar, false, scrapCount);
+  }
+
+  @Transactional
+  public CalendarDetailResponse updateScrapColor(Long calendarId, ScrapCalendarRequest request) {
+    User currentUser = userService.getCurrentUser();
+    Calendar calendar = calendarRepository.findById(calendarId)
+        .orElseThrow(() -> new EveryventException(ErrorCode.NOT_FOUND, "캘린더를 찾을 수 없습니다."));
+
+    validateUpdateScrapColor(currentUser, calendar);
+
+    calendar.updateColor(request.color());
+
+    Long scrapCount = scrapService.getScrapCount(calendar.getId());
+    return CalendarDetailResponse.from(calendar, SCRAPPABLE, scrapCount);
+  }
+
+
+  @Transactional
+  public void deleteCalendar(Long calendarId) {
+    User currentUser = userService.getCurrentUser();
+
+    Calendar calendar = findCalendarById(calendarId);
+
+    validateCanDeleteCalendar(currentUser, calendar);
+
+    calendar.softDelete();
+  }
+
+  private Map<Long, Long> getScrapCountMapFromCalendars(List<Calendar> calendars) {
+    if (calendars == null || calendars.isEmpty()) {
+      return Collections.emptyMap();
+    }
+
+    List<Long> calendarIds = calendars.stream()
+        .map(Calendar::getId)
+        .toList();
+    return scrapService.getScrapCountMap(calendarIds);
+  }
+
+  private List<CalendarMonthGroup> groupCalendarsByMonth(List<Calendar> calendars, Map<Long, Long> scrapCountMap) {
+    Map<YearMonth, List<CalendarListResponse>> groupedByMonth =
+        calendars.stream()
+            .collect(Collectors.groupingBy(
+                calendar -> YearMonth.from(calendar.getStartDate()),
+                LinkedHashMap::new,
+                Collectors.mapping(
+                    calendar
+                        -> CalendarListResponse.fromCalendar(
+                        calendar, scrapCountMap.getOrDefault(calendar.getId(), 0L)
+                    ),
+                    Collectors.toList()
+                )
+            ));
+
+    return groupedByMonth.entrySet().stream()
+        .map(entry -> new CalendarMonthGroup(
+            entry.getKey().getYear(),
+            entry.getKey().getMonthValue(),
+            entry.getValue()
+        ))
+        .toList();
+  }
+
+  private Calendar findCalendarById(Long calendarId) {
+    return calendarRepository.findById(calendarId)
+        .orElseThrow(() -> new EveryventException(ErrorCode.NOT_FOUND, "캘린더를 찾을 수 없습니다."));
+  }
+
+  boolean canViewCalendar(User user, Calendar calendar) {
+    if (user.getRole() == Role.ADMIN) { // 관리자는 다 조회 가능.
+      return true;
+    }
+
+    if (isOwner(user, calendar)) {
+      return true;
+    }
+
+    Visibility visibility = calendar.getVisibility();
+    if (visibility == Visibility.PUBLIC) {
+      return true;
+    }
+
+    Long followerId = user.getId();
+    Long targetId = calendar.getUser().getId();
+    if (visibility == Visibility.FOLLOWER) {
+      return followService.isFollowing(followerId, targetId);
+    }
+
+    if (visibility == Visibility.MUTUAL) {
+      return followService.isMutualFollow(followerId, targetId);
+    }
+
+    return false;
+  }
+
+  boolean isScrappable(User user, Calendar calendar) {
+    if (isOwner(user, calendar)) {
+      return false;
+    }
+
+    if (!canViewCalendar(user, calendar)) {
+      return false;
+    }
+
+    return !scrapService.isScrapped(user, calendar.getId());
+  }
+
+  boolean isOwner(User user, Calendar calendar) {
+    return calendar.getUser().getId().equals(user.getId());
+  }
+
+  private void validateCanViewCalendar(User user, Calendar calendar) {
+    if (canViewCalendar(user, calendar)) {
+      return;
+    }
+    throw new EveryventException(ErrorCode.INVALID_INPUT, "해당 캘린더에 접근 권한이 없습니다.");
+  }
+
+  private void validateCalendarLimit(User user, LocalDate targetDate) {
+    int year = targetDate.getYear();
+    int month = targetDate.getMonthValue();
+
+    long count = calendarRepository.countByUserAndYearMonthAndTypes(
+        user, year, month, CalendarConstants.LIMITED_CALENDAR_TYPES
+    );
+
+    if (count >= CalendarConstants.MAX_CNT_PER_MONTH) {
+      throw new EveryventException(
+          ErrorCode.INVALID_INPUT,
+          String.format("%d년 %d월에 생성 가능한 캘린더 수를 초과했습니다.", year, month)
+      );
+    }
+  }
+
+  private void validateUpdateCalendar(User user, Calendar calendar) {
+    try {
+      validateFuture(calendar.getStartDate());
+      validateDeleted(calendar);
+      validateOwner(user, calendar);
+      validateOriginalCalendar(calendar);
+    } catch (EveryventException e) {
+      throw new EveryventException(ErrorCode.INVALID_INPUT, e.getMessage() + " 캘린더를 수정할 수 없습니다.");
+    }
+  }
+
+  private void validateUpdateScrapColor(User user, Calendar calendar) {
+    try {
+      validateFuture(calendar.getStartDate());
+      validateDeleted(calendar);
+      validateOwner(user, calendar);
+    } catch (EveryventException e) {
+      throw new EveryventException(ErrorCode.INVALID_INPUT, e.getMessage() + "캘린더 색상을 수정할 수 없습니다.");
+    }
+  }
+
+  private void validateCanDeleteCalendar(User user, Calendar calendar) {
+    validateFuture(calendar.getStartDate());
+    validateDeleted(calendar);
+    validateOwner(user, calendar);
+  }
+
+  private void validateFuture(LocalDate startDate) {
+    YearMonth calendarYearMonth = YearMonth.from(startDate);
+    YearMonth currentYearMonth = YearMonth.now();
+
+    if (calendarYearMonth.isAfter(currentYearMonth)) {
+      return;
+    }
+    throw new EveryventException(ErrorCode.INVALID_INPUT, "미래의 캘린더가 아닙니다.");
+  }
+
+  private void validateDeleted(Calendar calendar) {
+    if (calendar.isDeleted()) {
+      throw new EveryventException(ErrorCode.NOT_FOUND, "삭제된 캘린더입니다.");
+    }
+  }
+
+  private void validateOwner(User user, Calendar calendar) {
+    if (!isOwner(user, calendar)) {
+      throw new EveryventException(ErrorCode.FORBIDDEN, "본인 캘린더가 아닙니다.");
+    }
+  }
+
+  private void validateOriginalCalendar(Calendar calendar) {
+    if (!calendar.isOriginalCalendar()) {
+      throw new EveryventException(ErrorCode.FORBIDDEN, "원본 캘린더가 아닙니다.");
+    }
+  }
+
+}

--- a/src/main/java/kr/santanrudolph/everyvent/domain/calendar/CalendarService.java
+++ b/src/main/java/kr/santanrudolph/everyvent/domain/calendar/CalendarService.java
@@ -45,8 +45,8 @@ public class CalendarService {
     try {
       validateCalendarLimit(user, request.startDate());
       validateFuture(request.startDate());
-    } catch (Exception e) {
-      throw new EveryventException(ErrorCode.INVALID_INPUT, e.getMessage() + " 캘린더를 만들 수 없습니다.");
+    } catch (EveryventException e) {
+      throw new EveryventException(ErrorCode.INVALID_INPUT, " 캘린더를 만들 수 없습니다." + e.getMessage());
     }
 
     Calendar calendar = Calendar.createCalendarWithStartDay(
@@ -326,7 +326,7 @@ public class CalendarService {
       validateOwner(user, calendar);
       validateOriginalCalendar(calendar);
     } catch (EveryventException e) {
-      throw new EveryventException(ErrorCode.INVALID_INPUT, e.getMessage() + " 캘린더를 수정할 수 없습니다.");
+      throw new EveryventException(ErrorCode.INVALID_INPUT, " 캘린더를 수정할 수 없습니다. " + e.getMessage());
     }
   }
 
@@ -336,7 +336,7 @@ public class CalendarService {
       validateDeleted(calendar);
       validateOwner(user, calendar);
     } catch (EveryventException e) {
-      throw new EveryventException(ErrorCode.INVALID_INPUT, e.getMessage() + "캘린더 색상을 수정할 수 없습니다.");
+      throw new EveryventException(ErrorCode.INVALID_INPUT, "캘린더 색상을 수정할 수 없습니다. " + e.getMessage());
     }
   }
 

--- a/src/main/java/kr/santanrudolph/everyvent/domain/calendar/dto/CalendarDetailResponse.java
+++ b/src/main/java/kr/santanrudolph/everyvent/domain/calendar/dto/CalendarDetailResponse.java
@@ -1,5 +1,6 @@
 package kr.santanrudolph.everyvent.domain.calendar.dto;
 
+import kr.santanrudolph.everyvent.domain.calendar.Calendar;
 import kr.santanrudolph.everyvent.domain.calendar.enums.CalendarColor;
 import kr.santanrudolph.everyvent.domain.calendar.enums.CalendarType;
 import kr.santanrudolph.everyvent.domain.calendar.enums.Category;
@@ -24,4 +25,25 @@ public record CalendarDetailResponse(
     boolean scrappable,
     Long scrapCount
 ) {
+
+  public static CalendarDetailResponse from(Calendar calendar, boolean scrappable, Long scrapCount) {
+    return new CalendarDetailResponse(
+        calendar.getId(),
+        calendar.getUser().getId(),
+        calendar.getTitle(),
+        calendar.getDescription(),
+        calendar.getStartDate(),
+        calendar.getEndDate(),
+        calendar.getPreviewStartDay(),
+        calendar.getPreviewEndDay(),
+        calendar.getVisibility(),
+        calendar.getColor(),
+        calendar.getCategory(),
+        calendar.getOriginalCalendarId(),
+        calendar.getCalendarType(),
+        scrappable,
+        scrapCount
+    );
+  }
+
 }

--- a/src/main/java/kr/santanrudolph/everyvent/domain/calendar/dto/CalendarListResponse.java
+++ b/src/main/java/kr/santanrudolph/everyvent/domain/calendar/dto/CalendarListResponse.java
@@ -1,5 +1,6 @@
 package kr.santanrudolph.everyvent.domain.calendar.dto;
 
+import kr.santanrudolph.everyvent.domain.calendar.Calendar;
 import kr.santanrudolph.everyvent.domain.calendar.enums.CalendarColor;
 import kr.santanrudolph.everyvent.domain.calendar.enums.CalendarType;
 import kr.santanrudolph.everyvent.domain.calendar.enums.Category;
@@ -7,7 +8,7 @@ import kr.santanrudolph.everyvent.domain.calendar.enums.Visibility;
 
 import java.time.LocalDate;
 
-public record CalendarSummaryResponse(
+public record CalendarListResponse(
     Long id,
     Long userId,
     String title,
@@ -21,4 +22,21 @@ public record CalendarSummaryResponse(
     CalendarType type,
     Long scrapCount
 ) {
+
+  public static CalendarListResponse fromCalendar(Calendar calendar, Long scrapCount) {
+    return new CalendarListResponse(
+        calendar.getId(),
+        calendar.getUser().getId(),
+        calendar.getTitle(),
+        calendar.getDescription(),
+        calendar.getStartDate(),
+        calendar.getEndDate(),
+        calendar.getVisibility(),
+        calendar.getColor(),
+        calendar.getCategory(),
+        calendar.getOriginalCalendarId(),
+        calendar.getCalendarType(),
+        scrapCount
+    );
+  }
 }

--- a/src/main/java/kr/santanrudolph/everyvent/domain/calendar/dto/CalendarMonthGroup.java
+++ b/src/main/java/kr/santanrudolph/everyvent/domain/calendar/dto/CalendarMonthGroup.java
@@ -1,10 +1,14 @@
 package kr.santanrudolph.everyvent.domain.calendar.dto;
 
+import java.time.YearMonth;
 import java.util.List;
 
 public record CalendarMonthGroup(
     int year,
     int month,
-    List<CalendarSummaryResponse> calendars
+    List<CalendarListResponse> calendars
 ) {
+  public YearMonth toYearMonth() {
+    return YearMonth.of(year, month);
+  }
 }

--- a/src/main/java/kr/santanrudolph/everyvent/domain/calendar/dto/PopularCalendarsResponse.java
+++ b/src/main/java/kr/santanrudolph/everyvent/domain/calendar/dto/PopularCalendarsResponse.java
@@ -3,6 +3,6 @@ package kr.santanrudolph.everyvent.domain.calendar.dto;
 import java.util.List;
 
 public record PopularCalendarsResponse(
-    List<CalendarSummaryResponse> calendars
+    List<CalendarListResponse> calendars
 ) {
 }

--- a/src/main/java/kr/santanrudolph/everyvent/domain/calendar/official/Official.java
+++ b/src/main/java/kr/santanrudolph/everyvent/domain/calendar/official/Official.java
@@ -1,6 +1,7 @@
-package kr.santanrudolph.everyvent.domain.calendar;
+package kr.santanrudolph.everyvent.domain.calendar.official;
 
 import jakarta.persistence.*;
+import kr.santanrudolph.everyvent.domain.calendar.Calendar;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;

--- a/src/main/java/kr/santanrudolph/everyvent/domain/calendar/official/OfficialCalendarController.java
+++ b/src/main/java/kr/santanrudolph/everyvent/domain/calendar/official/OfficialCalendarController.java
@@ -1,4 +1,4 @@
-package kr.santanrudolph.everyvent.domain.calendar;
+package kr.santanrudolph.everyvent.domain.calendar.official;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -59,9 +59,9 @@ public class OfficialCalendarController {
 
   @Operation(summary = "모든 공식 캘린더 목록 조회", description = "모든 공식 캘린더를 조회합니다.")
   @GetMapping()
-  public ResponseEntity<List<CalendarSummaryResponse>> getOfficialCalendars() {
+  public ResponseEntity<List<CalendarListResponse>> getOfficialCalendars() {
 
-    CalendarSummaryResponse official = new CalendarSummaryResponse(
+    CalendarListResponse official = new CalendarListResponse(
         100L,
         1L,
         "2024 크리스마스 어드벤트",
@@ -76,7 +76,7 @@ public class OfficialCalendarController {
         0L
     );
 
-    CalendarSummaryResponse official2 = new CalendarSummaryResponse(
+    CalendarListResponse official2 = new CalendarListResponse(
         101L,
         1L,
         "2024 크리스마스 어드벤트2",
@@ -91,7 +91,7 @@ public class OfficialCalendarController {
         0L
     );
 
-    CalendarSummaryResponse official3 = new CalendarSummaryResponse(
+    CalendarListResponse official3 = new CalendarListResponse(
         103L,
         1L,
         "2024 크리스마스 어드벤트3",

--- a/src/main/java/kr/santanrudolph/everyvent/domain/calendar/scrap/Scrap.java
+++ b/src/main/java/kr/santanrudolph/everyvent/domain/calendar/scrap/Scrap.java
@@ -1,0 +1,63 @@
+package kr.santanrudolph.everyvent.domain.calendar.scrap;
+
+import jakarta.persistence.*;
+import kr.santanrudolph.everyvent.domain.calendar.Calendar;
+import kr.santanrudolph.everyvent.domain.user.User;
+import kr.santanrudolph.everyvent.global.entity.BaseEntity;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Scrap extends BaseEntity {
+
+  @Id
+  private Long id;
+
+  @OneToOne
+  @MapsId
+  @JoinColumn(name = "id")
+  private Calendar calendar;
+
+  @Column(nullable = false)
+  private Long scrapCount = 0L;
+
+  @ManyToMany
+  @JoinTable(
+      name = "scrap_user",
+      joinColumns = @JoinColumn(name = "scrap_id"),
+      inverseJoinColumns = @JoinColumn(name = "user_id")
+  )
+  private List<User> scrappers = new ArrayList<>();
+
+  public static Scrap create(Calendar calendar) {
+    Scrap scrap = new Scrap();
+    scrap.calendar = calendar;
+    scrap.scrapCount = 0L;
+    scrap.scrappers = new ArrayList<>();
+    return scrap;
+  }
+
+  public void addScrapper(User user) {
+    if (!scrappers.contains(user)) {
+      scrappers.add(user);
+      scrapCount++;
+    }
+  }
+
+  public void removeScrapper(User user) {
+    if (scrappers.remove(user)) {
+      scrapCount--;
+    }
+  }
+
+  public boolean hasScrapper(User user) {
+    return scrappers.contains(user);
+  }
+
+}

--- a/src/main/java/kr/santanrudolph/everyvent/domain/calendar/scrap/ScrapCountProjection.java
+++ b/src/main/java/kr/santanrudolph/everyvent/domain/calendar/scrap/ScrapCountProjection.java
@@ -1,0 +1,7 @@
+package kr.santanrudolph.everyvent.domain.calendar.scrap;
+
+public interface ScrapCountProjection {
+  Long getCalendarId();
+
+  Long getScrapCount();
+}

--- a/src/main/java/kr/santanrudolph/everyvent/domain/calendar/scrap/ScrapRepository.java
+++ b/src/main/java/kr/santanrudolph/everyvent/domain/calendar/scrap/ScrapRepository.java
@@ -1,0 +1,43 @@
+package kr.santanrudolph.everyvent.domain.calendar.scrap;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface ScrapRepository extends JpaRepository<Scrap, Long> {
+
+
+  List<Scrap> findAllByIdIn(List<Long> calendarIds);
+
+  @Query("""
+      SELECT s.scrapCount FROM Scrap s WHERE s.calendar.id = :calendarId
+      """)
+  Long countScrapsByCalendarId(@Param("calendarId") Long calendarId);
+
+  @Query("""
+      SELECT s.id AS calendarId, s.scrapCount AS scrapCount
+      FROM Scrap s
+      WHERE s.id in :calendarIds
+      """)
+  List<ScrapCountProjection> findScrapCountsByCalendarIds(@Param("calendarIds") List<Long> calendarIds);
+
+
+  @Query("""
+          SELECT
+              CASE
+                  WHEN COUNT(scrappers) > 0 THEN true
+                  ELSE false
+              END
+          FROM Scrap s
+              JOIN s.scrappers scrappers
+          WHERE s.id = :calendarId
+            AND scrappers.id = :scrapperId
+      """)
+  boolean existsScrapper(
+      @Param("calendarId") Long calendarId,
+      @Param("scrapperId") Long scrapperId
+  );
+}

--- a/src/main/java/kr/santanrudolph/everyvent/domain/calendar/scrap/ScrapService.java
+++ b/src/main/java/kr/santanrudolph/everyvent/domain/calendar/scrap/ScrapService.java
@@ -1,0 +1,53 @@
+package kr.santanrudolph.everyvent.domain.calendar.scrap;
+
+import kr.santanrudolph.everyvent.domain.calendar.Calendar;
+import kr.santanrudolph.everyvent.domain.user.User;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ScrapService {
+  private final ScrapRepository scrapRepository;
+
+  @Transactional
+  public Scrap addScrap(User user, Calendar calendar) {
+    Scrap scrap = scrapRepository.findById(calendar.getId()).orElse(Scrap.create(calendar));
+
+    scrap.addScrapper(user);
+    return scrapRepository.save(scrap);
+  }
+
+  public Long getScrapCount(Long calendarId) {
+    Scrap scrap = scrapRepository.findById(calendarId).orElse(null);
+    if (scrap == null) {
+      return 0L;
+    }
+    return scrap.getScrapCount();
+  }
+
+  public boolean isScrapped(User user, Long calendarId) {
+    return scrapRepository.existsScrapper(calendarId, user.getId());
+  }
+
+  public Map<Long, Long> getScrapCountMap(List<Long> calendarIds) {
+    return scrapRepository
+        .findScrapCountsByCalendarIds(calendarIds)
+        .stream()
+        .collect(
+            Collectors
+                .toMap(
+                    ScrapCountProjection::getCalendarId,
+                    ScrapCountProjection::getScrapCount
+                ));
+  }
+
+}

--- a/src/main/java/kr/santanrudolph/everyvent/domain/task/dto/TaskCreateRequest.java
+++ b/src/main/java/kr/santanrudolph/everyvent/domain/task/dto/TaskCreateRequest.java
@@ -14,9 +14,7 @@ public record TaskCreateRequest(
 
     @NotBlank(message = "태스크 내용은 필수입니다.")
     @Size(max = 500, message = "태스크 내용은 최대 500자까지 입력 가능합니다.")
-    String content,
+    String content
 
-    @NotNull(message = "미리보기 가능 여부는 필수입니다.")
-    Boolean canPreview
 ) {
 }

--- a/src/main/java/kr/santanrudolph/everyvent/domain/task/dto/TaskResponse.java
+++ b/src/main/java/kr/santanrudolph/everyvent/domain/task/dto/TaskResponse.java
@@ -1,33 +1,25 @@
 package kr.santanrudolph.everyvent.domain.task.dto;
 
+
 import kr.santanrudolph.everyvent.domain.task.Task;
-import kr.santanrudolph.everyvent.global.util.TimeUtil;
-import lombok.AllArgsConstructor;
-import lombok.Data;
 
-import java.time.LocalDate;
 
-@Data
-@AllArgsConstructor
-public class TaskResponse {
-
-  private final Long id;
-  private final Long calendarId;
-  private final int day;
-  private final boolean isBeforeToday;
-  private String content;
-  private boolean completed;
-
-  public TaskResponse toTaskResponse(Task task, boolean canPreview) {
-    boolean isBeforeToday = TimeUtil.isAfter(TimeUtil.today(), task.getDay());
-
+public record TaskResponse(
+    Long id,
+    Long calendarId,
+    int day,
+    boolean isLock,
+    String content,
+    Boolean completed // null 상태 표현을 위함
+) {
+  public static TaskResponse from(Task task, boolean isLock) {
     return new TaskResponse(
         task.getId(),
         task.getCalendar().getId(),
         task.getDay().getDayOfMonth(),
-        isBeforeToday,
-        task.getContent(),
-        task.getCompleted()
+        isLock,
+        isLock ? task.getContent() : null,
+        isLock ? task.getCompleted() : null
     );
   }
 }

--- a/src/main/java/kr/santanrudolph/everyvent/domain/task/dto/TaskResponse.java
+++ b/src/main/java/kr/santanrudolph/everyvent/domain/task/dto/TaskResponse.java
@@ -18,8 +18,8 @@ public record TaskResponse(
         task.getCalendar().getId(),
         task.getDay().getDayOfMonth(),
         isLock,
-        isLock ? task.getContent() : null,
-        isLock ? task.getCompleted() : null
+        isLock ? null : task.getContent(),
+        isLock ? null : task.getCompleted()
     );
   }
 }

--- a/src/main/java/kr/santanrudolph/everyvent/domain/task/dto/TaskUpdateRequest.java
+++ b/src/main/java/kr/santanrudolph/everyvent/domain/task/dto/TaskUpdateRequest.java
@@ -4,9 +4,7 @@ import jakarta.validation.constraints.Size;
 
 public record TaskUpdateRequest(
     @Size(max = 500, message = "태스크 내용은 최대 500자까지 입력 가능합니다.")
-    String content,
-
-    Boolean canPreview
+    String content
 ) {
-    // 모든 필드 optional (부분 수정 지원)
+
 }

--- a/src/main/java/kr/santanrudolph/everyvent/global/config/CorsConfig.java
+++ b/src/main/java/kr/santanrudolph/everyvent/global/config/CorsConfig.java
@@ -12,6 +12,9 @@ import java.util.Arrays;
 @Configuration
 public class CorsConfig {
 
+  @Value("${frontend.local.url}")
+  private String localFrontendUrl;
+
   @Value("${frontend.url}")
   private String frontendUrl;
 
@@ -21,7 +24,8 @@ public class CorsConfig {
 
     // 허용할 출처 (로컬 개발 + 배포 환경)
     configuration.setAllowedOrigins(Arrays.asList(
-        frontendUrl  // 환경별 프론트엔드 URL
+        localFrontendUrl,
+        frontendUrl
     ));
 
     // 허용할 HTTP 메서드

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -24,9 +24,6 @@ spring:
         format_sql: true
         show_sql: true
 
-frontend:
-  url: http://localhost:5173  # 로컬 프론트엔드 URL
-
 logging:
   level:
     org.hibernate.SQL: debug

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -29,9 +29,6 @@ spring:
         show_sql: false
         default_batch_fetch_size: 100
 
-frontend:
-  url: http://localhost:5173  # 로컬 프론트엔드 URL
-
 logging:
   level:
     org.hibernate.SQL: info

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -35,3 +35,8 @@ jwt:
   access-token-expiration: 3600000
   refresh-token-expiration: 604800000
   auth-code-expiration: 60  # 인증 코드 유효 시간 추후 시간 줄일 예정
+
+frontend:
+  url: https://everyvent-client.vercel.app
+  local:
+    url: http://localhost:5173


### PR DESCRIPTION
## 📝 무엇을 했나요?

### 1. 구현한 API
| 메서드 | 경로 | 설명 |
|--------|------|------|
| POST   | /api/calendars | 캘린더 생성 |
| GET    | /api/calendars | 무한 스크롤용 내 캘린더 목록 조회 |
| GET    | /api/calendars/{calendarId} | RBAC 기반 캘린더 상세 조회 |
| GET    | /api/calendars/monthly | 월별 통합 캘린더 조회 |
| PATCH  | /api/calendars/{calendarId} | 내가 만든 캘린더 수정 |
| PATCH  | /api/calendars/{calendarId} | 스크랩한 캘린더 색상 수정 |
| DELETE | /api/calendars/{calendarId} | 캘린더 삭제 |

### 2. 프론트와 공유할 사항
- 태스크 생성에서 **미리보기 필드**를 제거했어요.
- `https://everyvent-client.vercel.app` cors 허용 설정 추가했어요 ! 
- **비공개 캘린더 생성** 시에도 미리보기 필드를 포함해야해요. 대신 `null`로 보내면 돼요 .
→ 모든 캘린더 생성 요청 구조 통일 목적  
- 스크랩 관련 기능은 다음 PR에서 구현 예정이에요.

## 💭 고민 지점과 리뷰 포인트
- @meteorqz6 태스크 수정 시, **같은 content(내용)으로 day(일자)만 변경도 가능**하게 해야 할까요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 캘린더 생성 시 미리보기 날짜 범위(preview) 지원 추가
  * 월별 캘린더 조회용 신규 엔드포인트 추가
  * 캘린더 스크랩 기능 도입 및 스크랩 횟수 집계 제공

* **개선사항**
  * 캘린더 목록/상세 응답 형식 통합 및 응답 구조 정비
  * 캘린더 관련 서비스/컨트롤러로 로직 위임 (엔드포인트 응답 간소화)
  * 작업 DTO에서 preview 필드 제거로 접근 제어 단순화
  * 로컬 개발을 위한 CORS 허용 대상 확장 및 환경 설정 정리

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->