### PR TITLE
feat(auth): 프론트엔드 환경별 동적 OAuth 리다이렉트 지원

### DIFF
--- a/src/main/java/kr/santanrudolph/everyvent/auth/security/CustomAuthorizationRequestResolver.java
+++ b/src/main/java/kr/santanrudolph/everyvent/auth/security/CustomAuthorizationRequestResolver.java
@@ -1,0 +1,72 @@
+package kr.santanrudolph.everyvent.auth.security;
+
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
+import org.springframework.security.oauth2.client.web.DefaultOAuth2AuthorizationRequestResolver;
+import org.springframework.security.oauth2.client.web.OAuth2AuthorizationRequestResolver;
+import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+public class CustomAuthorizationRequestResolver implements OAuth2AuthorizationRequestResolver {
+
+  private static final String REDIRECT_URI_SESSION_KEY = "OAUTH2_REDIRECT_URI";
+
+  private final OAuth2AuthorizationRequestResolver defaultResolver;
+  private final RedirectUriValidator redirectUriValidator;
+
+
+  public CustomAuthorizationRequestResolver(
+      ClientRegistrationRepository clientRegistrationRepository,
+      RedirectUriValidator redirectUriValidator) {
+    this.defaultResolver = new DefaultOAuth2AuthorizationRequestResolver(
+        clientRegistrationRepository,
+        "/oauth2/authorization"
+    );
+    this.redirectUriValidator = redirectUriValidator;
+  }
+
+
+  // socialProvider 정보가 없을 때 oauth 처리하는 메서드
+  @Override
+  public OAuth2AuthorizationRequest resolve(HttpServletRequest request) {
+    OAuth2AuthorizationRequest authRequest = defaultResolver.resolve(request);
+    if (authRequest != null) {
+      storeRedirectUriIfValid(request);
+    }
+    return authRequest;
+  }
+
+  // // socialProvider가 확정된 상태에서 OAuth 인가 요청을 처리
+  @Override
+  public OAuth2AuthorizationRequest resolve(
+      HttpServletRequest request,
+      String clientRegistrationId) {
+
+    OAuth2AuthorizationRequest authRequest =
+        defaultResolver.resolve(request, clientRegistrationId);
+
+    if (authRequest != null) {
+      storeRedirectUriIfValid(request);
+    }
+    return authRequest;
+  }
+
+  private void storeRedirectUriIfValid(HttpServletRequest request) {
+    String redirectUri = request.getParameter("redirect_uri");
+    String uriToStore;
+
+    if (redirectUri != null && redirectUriValidator.isAllowed(redirectUri)) {
+      uriToStore = redirectUri;
+    } else {
+      uriToStore = redirectUriValidator.getDefaultRedirectUri();
+      if (redirectUri != null) {
+        log.warn("Invalid redirect_uri rejected: {}, using default", redirectUri);
+      }
+    }
+
+    request.getSession().setAttribute(REDIRECT_URI_SESSION_KEY, uriToStore);
+  }
+}

--- a/src/main/java/kr/santanrudolph/everyvent/auth/security/OAuth2SuccessHandler.java
+++ b/src/main/java/kr/santanrudolph/everyvent/auth/security/OAuth2SuccessHandler.java
@@ -2,13 +2,15 @@ package kr.santanrudolph.everyvent.auth.security;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
+
 import java.io.IOException;
 import java.time.Instant;
 import java.util.UUID;
+
 import kr.santanrudolph.everyvent.auth.repository.RedisTokenRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
 import org.springframework.stereotype.Component;
@@ -19,15 +21,15 @@ import org.springframework.web.util.UriComponentsBuilder;
 @RequiredArgsConstructor
 public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
 
+  private static final String REDIRECT_URI_SESSION_KEY = "OAUTH2_REDIRECT_URI";
+
   private final JwtTokenProvider jwtTokenProvider;
   private final RedisTokenRepository redisTokenRepository;
-
-  @Value("${frontend.url:http://localhost:3030}")
-  private String frontendUrl;
+  private final RedirectUriValidator redirectUriValidator;
 
   @Override
   public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
-      Authentication authentication) throws IOException {
+                                      Authentication authentication) throws IOException {
     EveryventOAuth2User oAuth2User = (EveryventOAuth2User) authentication.getPrincipal();
     Long userId = oAuth2User.getUserId();
 
@@ -47,11 +49,37 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
     log.info("AuthCode generated for User ID: {}", userId);
 
     // 프론트엔드로 인증 코드만 전달 (토큰은 URL에 노출되지 않음)
-    String targetUrl = UriComponentsBuilder.fromUriString(frontendUrl + "/oauth/callback")
+    String redirectUri = getValidatedRedirectUri(request);
+    String targetUrl = UriComponentsBuilder.fromUriString(redirectUri + "/oauth/callback")
         .queryParam("code", authCode)
         .build().toUriString();
 
+    // OAuth2 로그인 완료 후 불필요한 세션 데이터 제거
+    HttpSession session = request.getSession(false);
+    if (session != null) {
+      session.removeAttribute(REDIRECT_URI_SESSION_KEY);
+    }
+
     log.info("Redirecting to: {}", targetUrl);
     getRedirectStrategy().sendRedirect(request, response, targetUrl);
+  }
+
+  private String getValidatedRedirectUri(HttpServletRequest request) {
+    HttpSession session = request.getSession(false);
+
+    if (session != null) {
+      String storedUri = (String) session.getAttribute(REDIRECT_URI_SESSION_KEY);
+
+      // 세션에서 꺼낸 uri 다시 검증
+      if (storedUri != null && redirectUriValidator.isAllowed(storedUri)) {
+        log.info("Using redirect URI from session: {}", storedUri);
+        return storedUri;
+      }
+    }
+
+    // Fallback(uri 파싱 실패): 기본값 사용
+    String defaultUri = redirectUriValidator.getDefaultRedirectUri();
+    log.warn("Session redirect URI missing or invalid, using default: {}", defaultUri);
+    return defaultUri;
   }
 }

--- a/src/main/java/kr/santanrudolph/everyvent/auth/security/RedirectUriValidator.java
+++ b/src/main/java/kr/santanrudolph/everyvent/auth/security/RedirectUriValidator.java
@@ -1,0 +1,130 @@
+package kr.santanrudolph.everyvent.auth.security;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.List;
+
+import lombok.Getter;
+import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@ConfigurationProperties(prefix = "oauth2.redirect")
+@Getter
+@Setter
+public class RedirectUriValidator {
+
+  private static final String DEFAULT_REDIRECT_URI = "http://localhost:5173";
+
+  private List<String> allowedUris;
+
+  public boolean isAllowed(String redirectUri) {
+    if (!isPresent(redirectUri)) {
+      return false;
+    }
+
+    URI uri = parseUri(redirectUri);
+    if (uri == null) {
+      return false;
+    }
+
+    if (!hasValidHttpScheme(uri)) {
+      return false;
+    }
+
+    if (!isWhitelisted(redirectUri)) {
+      log.warn("Redirect URI not in whitelist: {}", redirectUri);
+      return false;
+    }
+
+    return true;
+  }
+
+
+  public String getDefaultRedirectUri() {
+    log.info("Using default redirect URI: {}", DEFAULT_REDIRECT_URI);
+    return DEFAULT_REDIRECT_URI;
+  }
+
+  private boolean isPresent(String redirectUri) {
+    if (redirectUri == null || redirectUri.isBlank()) {
+      log.warn("Redirect URI is null or blank");
+      return false;
+    }
+    return true;
+  }
+
+  private URI parseUri(String redirectUri) {
+    try {
+      return new URI(redirectUri);
+    } catch (URISyntaxException e) {
+      log.warn("Malformed redirect URI: {}", redirectUri, e);
+      return null;
+    }
+  }
+
+  private boolean hasValidHttpScheme(URI uri) {
+    String scheme = uri.getScheme();
+
+    if (!"http".equalsIgnoreCase(scheme) && !"https".equalsIgnoreCase(scheme)) {
+      log.warn("Invalid scheme in redirect URI: {}", scheme);
+      return false;
+    }
+    return true;
+  }
+
+  private boolean isWhitelisted(String redirectUri) {
+    String normalizedUrl = normalizeUrl(redirectUri);
+
+    return allowedUris.stream()
+        .map(this::normalizeUrl)
+        .anyMatch(normalizedUrl::equals);
+  }
+
+  private String normalizeUrl(String url) {
+    try {
+      URI uri = new URI(url);
+
+      String scheme = uri.getScheme().toLowerCase();
+      String host = uri.getHost().toLowerCase();
+      int port = normalizePort(scheme, uri.getPort());
+      String path = normalizePath(uri.getPath());
+
+      StringBuilder normalizedUrl = new StringBuilder();
+      normalizedUrl.append(scheme).append("://").append(host);
+
+      if (port != -1) {
+        normalizedUrl.append(":").append(port);
+      }
+
+      if (path != null && !path.isEmpty()) {
+        normalizedUrl.append(path);
+      }
+
+      return normalizedUrl.toString();
+
+    } catch (URISyntaxException e) {
+      log.warn("Failed to normalize URL: {}", url, e);
+      return url;
+    }
+  }
+
+  private int normalizePort(String scheme, int port) {
+    if ((scheme.equals("http") && port == 80) ||
+        (scheme.equals("https") && port == 443)) {
+      return -1;
+    }
+    return port;
+  }
+
+  private String normalizePath(String path) {
+    if (path != null && path.endsWith("/")) {
+      return path.substring(0, path.length() - 1);
+    }
+    return path;
+  }
+}
+

--- a/src/main/java/kr/santanrudolph/everyvent/auth/security/RedirectUriValidator.java
+++ b/src/main/java/kr/santanrudolph/everyvent/auth/security/RedirectUriValidator.java
@@ -4,22 +4,23 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.List;
 
-import lombok.Getter;
-import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 @Slf4j
 @Component
-@ConfigurationProperties(prefix = "oauth2.redirect")
-@Getter
-@Setter
 public class RedirectUriValidator {
 
   private static final String DEFAULT_REDIRECT_URI = "http://localhost:5173";
 
-  private List<String> allowedUris;
+  private final List<String> allowedUris;
+
+  public RedirectUriValidator(
+      @Value("${frontend.url}") String frontendUrl,
+      @Value("${frontend.local.url}") String localUrl) {
+    this.allowedUris = List.of(frontendUrl, localUrl);
+  }
 
   public boolean isAllowed(String redirectUri) {
     if (!isPresent(redirectUri)) {

--- a/src/main/java/kr/santanrudolph/everyvent/global/config/SecurityConfig.java
+++ b/src/main/java/kr/santanrudolph/everyvent/global/config/SecurityConfig.java
@@ -1,5 +1,6 @@
 package kr.santanrudolph.everyvent.global.config;
 
+import kr.santanrudolph.everyvent.auth.security.CustomAuthorizationRequestResolver;
 import kr.santanrudolph.everyvent.auth.security.JwtAuthenticationFilter;
 import kr.santanrudolph.everyvent.auth.service.KakaoOAuthService;
 import kr.santanrudolph.everyvent.auth.security.OAuth2SuccessHandler;
@@ -29,6 +30,7 @@ public class SecurityConfig {
   private final OAuth2SuccessHandler oAuth2SuccessHandler;
   private final JwtAuthenticationFilter jwtAuthenticationFilter;
   private final Environment environment;
+  private final CustomAuthorizationRequestResolver customAuthorizationRequestResolver;
 
   @Value("${SWAGGER_USERNAME}")
   private String swaggerUsername;
@@ -59,7 +61,7 @@ public class SecurityConfig {
         .cors(cors -> cors.configurationSource(corsConfig.corsConfigurationSource()))
         .csrf(csrf -> csrf.disable())
         .sessionManagement(session -> session
-            .sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+            .sessionCreationPolicy(SessionCreationPolicy.IF_REQUIRED))
 
         .authorizeHttpRequests(auth -> {
 
@@ -85,6 +87,9 @@ public class SecurityConfig {
             .frameOptions(frame -> frame.sameOrigin()))
 
         .oauth2Login(oauth2 -> oauth2
+            .authorizationEndpoint(authorization -> authorization
+                .authorizationRequestResolver(customAuthorizationRequestResolver)
+            )
             .userInfoEndpoint(info -> info.userService(kakaoOAuthService))
             .successHandler(oAuth2SuccessHandler));
 


### PR DESCRIPTION
## 📝 무엇을 했나요?
저번 PR에서 `frontend.url`을 `https://everyvent-client.vercel.app`로 변경하고 `frontend.local.url` (`http://localhost:5173`)을 추가했어요.  
하지만 소셜 로그인 시 항상 production URL인 `https://everyvent-client.vercel.app`로 리다이렉트되어, 
프론트엔드 로컬 환경에서 로그인이 동작하지 않는 문제가 있었어요.

## 해결 방법
프론트엔드가 OAuth 요청 시 **쿼리 파라미터로 `redirect_uri`를 전달**하면,  
백엔드에서 이를 검증하고 해당 URL로 리다이렉트하도록 개선했어요.

## 주요 구현
1. **CustomAuthorizationRequestResolver**
   - OAuth 요청 시작 시 `redirect_uri` 쿼리 파라미터 추출
   - `RedirectUriValidator`로 화이트리스트 검증
   - 검증된 URI를 `HttpSession`에 저장

2. **RedirectUriValidator**
   - `frontend.url`, `frontend.local.url`을 화이트리스트로 사용
   - URL 정규화 및 스킴 검증 (http/https만 허용)
   - Open Redirect 공격 방지

3. **OAuth2SuccessHandler**
   - 세션에서 검증된 `redirect_uri` 조회
   - 세션에 저장한 url 재검증
   - 동적 리다이렉트 수행 후 세션 정리하여 메모리 누수 방지

4. **SecurityConfig**
   - 세션 정책 변경: `STATELESS` → `IF_REQUIRED` (OAuth 플로우 중에만 세션 생성)


## 💭 고민 지점과 리뷰 포인트
<!-- 예상되는 리팩터링 지점이 있다면 추가로 작성해 주세요.-->
@meteorqz6 , @bomii1 
프론트엔드의 테스트 편의성을 위해, 
`redirect_uri`가 없거나 검증 실패 시 `http://localhost:5173`으로 리다이렉트 되도록 구현했어요.  
프론트엔드 로컬 테스트 시, 
현재 프론트엔드 로직(쿼리 파라미터 포함 안하는 로직) 에서는 바로 `http://localhost:5173/oauth/callback`으로 리다이렉트 돼요. 

소셜로그인 호출 예시는 다음과 같아요.

### 기존
- 소셜 로그인 → 항상 `https://everyvent-client.vercel.app/oauth/callback`로 리다이렉트  
- 로컬 테스트 불가 ❌

### 추가된 기능

**- 로컬테스트 시 요청해야할 uri**
```http
GET /oauth2/authorization/kakao?redirect_uri=http://localhost:5173
→ http://localhost:5173/oauth/callback 로 리다이렉트
```

**- 배포 서버에서 요청해야할 uri**
```http
GET /oauth2/authorization/kakao?redirect_uri=https://everyvent-client.vercel.app
→ https://everyvent-client.vercel.app/oauth/callback 로 리다이렉트
```

**- redirect_uri 없는 경우 리다이렉트 되는 주소**

```http
GET /oauth2/authorization/kakao
→ http://localhost:5173/oauth/callback 리다이렉트
```



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리즈 노트

* **보안 개선**
  * OAuth2 인증 흐름에서 리다이렉트 URI 검증 강화
  * 화이트리스트 기반 리다이렉트 URI 관리 추가
  * 세션을 통한 보안 인증 상태 관리 개선

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->