### PR TITLE
feat(calendar): 캘린더 비즈니스 정책을 CalendarPolicy로 분리

### DIFF
--- a/src/main/java/kr/santanrudolph/everyvent/domain/calendar/Calendar.java
+++ b/src/main/java/kr/santanrudolph/everyvent/domain/calendar/Calendar.java
@@ -222,42 +222,42 @@ public class Calendar extends BaseEntity {
 
   public void updateTitle(String title) {
     if (!isOriginalCalendar()) {
-      throw new EveryventException(ErrorCode.FORBIDDEN, "원본 캘린더가 아닌 캘린더는 제목을 변경할 수 없습니다.");
+      throw new EveryventException(ErrorCode.FORBIDDEN, "제목을 변경할 수 없습니다. 원본 캘린더가 아닙니다.");
     }
     this.title = title;
   }
 
   public void updateDescription(String description) {
     if (!isOriginalCalendar()) {
-      throw new EveryventException(ErrorCode.FORBIDDEN, "스크랩 캘린더는 설명을 변경할 수 없습니다.");
+      throw new EveryventException(ErrorCode.FORBIDDEN, "설명을 변경할 수 없습니다. 원본 캘린더가 아닙니다.");
     }
     this.description = description;
   }
 
   public void updateStartDate(LocalDate startDate) {
     if (!isOriginalCalendar()) {
-      throw new EveryventException(ErrorCode.FORBIDDEN, "스크랩 캘린더는 캘린더 시작일을 변경할 수 없습니다.");
+      throw new EveryventException(ErrorCode.FORBIDDEN, "시작일을 변경할 수 없습니다. 원본 캘린더가 아닙니다.");
     }
     this.startDate = startDate;
   }
 
   public void updateEndDate(LocalDate endDate) {
     if (!isOriginalCalendar()) {
-      throw new EveryventException(ErrorCode.FORBIDDEN, "스크랩 캘린더는 캘린더 종료일을 변경할 수 없습니다.");
+      throw new EveryventException(ErrorCode.FORBIDDEN, "종료일을 변경할 수 없습니다. 원본 캘린더가 아닙니다.");
     }
     this.endDate = endDate;
   }
 
   public void updateVisibility(Visibility visibility) {
     if (!isOriginalCalendar()) {
-      throw new EveryventException(ErrorCode.FORBIDDEN, "스크랩 캘린더는 공개범위를 변경할 수 없습니다.");
+      throw new EveryventException(ErrorCode.FORBIDDEN, "공개범위를 변경할 수 없습니다. 원본 캘린더가 아닙니다.");
     }
     this.visibility = visibility;
   }
 
   public void updateCategory(Category category) {
     if (!isOriginalCalendar()) {
-      throw new EveryventException(ErrorCode.FORBIDDEN, "스크랩 캘린더는 카테고리를 변경할 수 없습니다.");
+      throw new EveryventException(ErrorCode.FORBIDDEN, "카테고리를 변경할 수 없습니다. 원본 캘린더가 아닙니다.");
     }
     this.category = category;
   }
@@ -275,14 +275,14 @@ public class Calendar extends BaseEntity {
 
   public void updatePreviewStartDay(LocalDate previewStartDay) {
     if (!isOriginalCalendar()) {
-      throw new EveryventException(ErrorCode.FORBIDDEN, "스크랩 캘린더는 미리보기 시작일을 변경할 수 없습니다.");
+      throw new EveryventException(ErrorCode.FORBIDDEN, "미리보기 시작일을 변경할 수 없습니다. 원본 캘린더가 아닙니다.");
     }
     this.previewStartDay = previewStartDay;
   }
 
   public void updatePreviewEndDay(LocalDate previewEndDay) {
     if (!isOriginalCalendar()) {
-      throw new EveryventException(ErrorCode.FORBIDDEN, "스크랩 캘린더는 미리보기 종료일을 변경할 수 없습니다.");
+      throw new EveryventException(ErrorCode.FORBIDDEN, "미리보기 종료일을 변경할 수 없습니다. 원본 캘린더가 아닙니다.");
     }
     this.previewEndDay = previewEndDay;
   }

--- a/src/main/java/kr/santanrudolph/everyvent/domain/calendar/Calendar.java
+++ b/src/main/java/kr/santanrudolph/everyvent/domain/calendar/Calendar.java
@@ -222,7 +222,7 @@ public class Calendar extends BaseEntity {
 
   public void updateTitle(String title) {
     if (!isOriginalCalendar()) {
-      throw new EveryventException(ErrorCode.FORBIDDEN, "스크랩 캘린더는 제목을 변경할 수 없습니다.");
+      throw new EveryventException(ErrorCode.FORBIDDEN, "원본 캘린더가 아닌 캘린더는 제목을 변경할 수 없습니다.");
     }
     this.title = title;
   }

--- a/src/main/java/kr/santanrudolph/everyvent/domain/calendar/service/CalendarPolicy.java
+++ b/src/main/java/kr/santanrudolph/everyvent/domain/calendar/service/CalendarPolicy.java
@@ -1,0 +1,166 @@
+package kr.santanrudolph.everyvent.domain.calendar.service;
+
+import kr.santanrudolph.everyvent.domain.calendar.Calendar;
+import kr.santanrudolph.everyvent.domain.calendar.CalendarConstants;
+import kr.santanrudolph.everyvent.domain.calendar.enums.CalendarType;
+import kr.santanrudolph.everyvent.domain.calendar.enums.Visibility;
+import kr.santanrudolph.everyvent.domain.calendar.repository.CalendarRepository;
+import kr.santanrudolph.everyvent.domain.follow.FollowService;
+import kr.santanrudolph.everyvent.domain.user.User;
+import kr.santanrudolph.everyvent.domain.user.enums.Role;
+import kr.santanrudolph.everyvent.global.exception.ErrorCode;
+import kr.santanrudolph.everyvent.global.exception.EveryventException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+import java.time.YearMonth;
+
+@Component
+@RequiredArgsConstructor
+public class CalendarPolicy {
+  private final CalendarRepository calendarRepository;
+  private final FollowService followService;
+  private final ScrapService scrapService;
+
+  public boolean canView(User user, Calendar calendar) {
+    if (user.getRole() == Role.ADMIN) {
+      return true;
+    }
+
+    if (isOwner(user, calendar)) {
+      return true;
+    }
+
+    Visibility visibility = calendar.getVisibility();
+    if (visibility == Visibility.PUBLIC) {
+      return true;
+    }
+
+    Long followerId = user.getId();
+    Long targetId = calendar.getUser().getId();
+    if (visibility == Visibility.FOLLOWER) {
+      return followService.isFollowing(followerId, targetId);
+    }
+
+    if (visibility == Visibility.MUTUAL) {
+      return followService.isMutualFollow(followerId, targetId);
+    }
+
+    return false;
+  }
+
+  public boolean canScrap(User user, Calendar calendar) {
+    if (isOwner(user, calendar)) {
+      return false;
+    }
+
+    if (!canView(user, calendar)) {
+      return false;
+    }
+
+    return !scrapService.isScrapped(user, calendar.getId());
+  }
+
+  public boolean isOwner(User user, Calendar calendar) {
+    return calendar.getUser().getId().equals(user.getId());
+  }
+
+  public void validateCanCreate(User user, LocalDate startDate) {
+    try {
+      validateCalendarLimit(user, startDate);
+      validateFuture(startDate);
+    } catch (EveryventException e) {
+      throw new EveryventException(e.getErrorCode(), "캘린더를 만들 수 없습니다. " + e.getMessage());
+    }
+  }
+
+  public void validateCanUpdate(User user, Calendar calendar) {
+    try {
+      validateFuture(calendar.getStartDate());
+      validateDeleted(calendar);
+      validateOwner(user, calendar);
+      validateOriginalCalendar(calendar);
+    } catch (EveryventException e) {
+      throw new EveryventException(e.getErrorCode(), "캘린더를 수정할 수 없습니다. " + e.getMessage());
+    }
+  }
+
+  public void validateCanUpdateScrapColor(User user, Calendar calendar) {
+    try {
+      validateFuture(calendar.getStartDate());
+      validateDeleted(calendar);
+      validateOwner(user, calendar);
+      validateScrappedCalendar(calendar);
+    } catch (EveryventException e) {
+      throw new EveryventException(e.getErrorCode(), "캘린더 색상을 수정할 수 없습니다. " + e.getMessage());
+    }
+  }
+
+  public void validateCanDelete(User user, Calendar calendar) {
+    try {
+      validateFuture(calendar.getStartDate());
+      validateDeleted(calendar);
+      validateOwner(user, calendar);
+    } catch (EveryventException e) {
+      throw new EveryventException(e.getErrorCode(), e.getMessage());
+    }
+  }
+
+  public void validateCanView(User user, Calendar calendar) {
+    if (!canView(user, calendar)) {
+      throw new EveryventException(ErrorCode.FORBIDDEN, "해당 캘린더에 접근 권한이 없습니다.");
+    }
+  }
+
+  private void validateCalendarLimit(User user, LocalDate targetDate) {
+    int year = targetDate.getYear();
+    int month = targetDate.getMonthValue();
+
+    long count = calendarRepository.countByUserAndYearMonthAndTypes(
+        user, year, month, CalendarConstants.LIMITED_CALENDAR_TYPES
+    );
+
+    if (count >= CalendarConstants.MAX_CNT_PER_MONTH) {
+      throw new EveryventException(
+          ErrorCode.INVALID_INPUT,
+          String.format("%d년 %d월에 생성 가능한 캘린더 수를 초과했습니다.", year, month)
+      );
+    }
+  }
+
+  public void validateOwner(User user, Calendar calendar) {
+    if (!isOwner(user, calendar)) {
+      throw new EveryventException(ErrorCode.FORBIDDEN, "본인 캘린더가 아닙니다.");
+    }
+  }
+
+  private void validateFuture(LocalDate startDate) {
+    YearMonth calendarYearMonth = YearMonth.from(startDate);
+    YearMonth currentYearMonth = YearMonth.now();
+
+    if (calendarYearMonth.isAfter(currentYearMonth)) {
+      return;
+    }
+    throw new EveryventException(ErrorCode.INVALID_INPUT, "과거입니다.");
+  }
+
+  private void validateDeleted(Calendar calendar) {
+    if (calendar.isDeleted()) {
+      throw new EveryventException(ErrorCode.NOT_FOUND, "삭제된 캘린더입니다.");
+    }
+  }
+
+  private void validateOriginalCalendar(Calendar calendar) {
+    if (!calendar.isOriginalCalendar()) {
+      throw new EveryventException(ErrorCode.FORBIDDEN, "원본 캘린더가 아닙니다.");
+    }
+  }
+
+  private void validateScrappedCalendar(Calendar calendar) {
+    if (calendar.getCalendarType().equals(CalendarType.SCRAPED)) {
+      throw new EveryventException(ErrorCode.INVALID_INPUT, "스크랩한 캘린더가 아닙니다.");
+    }
+  }
+
+}

--- a/src/main/java/kr/santanrudolph/everyvent/domain/calendar/service/CalendarPolicy.java
+++ b/src/main/java/kr/santanrudolph/everyvent/domain/calendar/service/CalendarPolicy.java
@@ -19,148 +19,148 @@ import java.time.YearMonth;
 @Component
 @RequiredArgsConstructor
 public class CalendarPolicy {
-  private final CalendarRepository calendarRepository;
-  private final FollowService followService;
-  private final ScrapService scrapService;
+    private final CalendarRepository calendarRepository;
+    private final FollowService followService;
+    private final ScrapService scrapService;
 
-  public boolean canView(User user, Calendar calendar) {
-    if (user.getRole() == Role.ADMIN) {
-      return true;
+    public boolean canView(User user, Calendar calendar) {
+        if (user.getRole() == Role.ADMIN) {
+            return true;
+        }
+
+        if (isOwner(user, calendar)) {
+            return true;
+        }
+
+        Visibility visibility = calendar.getVisibility();
+        if (visibility == Visibility.PUBLIC) {
+            return true;
+        }
+
+        Long followerId = user.getId();
+        Long targetId = calendar.getUser().getId();
+        if (visibility == Visibility.FOLLOWER) {
+            return followService.isFollowing(followerId, targetId);
+        }
+
+        if (visibility == Visibility.MUTUAL) {
+            return followService.isMutualFollow(followerId, targetId);
+        }
+
+        return false;
     }
 
-    if (isOwner(user, calendar)) {
-      return true;
+    public boolean canScrap(User user, Calendar calendar) {
+        if (isOwner(user, calendar)) {
+            return false;
+        }
+
+        if (!canView(user, calendar)) {
+            return false;
+        }
+
+        return !scrapService.isScrapped(user, calendar.getId());
     }
 
-    Visibility visibility = calendar.getVisibility();
-    if (visibility == Visibility.PUBLIC) {
-      return true;
+    public boolean isOwner(User user, Calendar calendar) {
+        return calendar.getUser().getId().equals(user.getId());
     }
 
-    Long followerId = user.getId();
-    Long targetId = calendar.getUser().getId();
-    if (visibility == Visibility.FOLLOWER) {
-      return followService.isFollowing(followerId, targetId);
+    public void validateCanCreate(User user, LocalDate startDate) {
+        try {
+            validateCalendarLimit(user, startDate);
+            validateFuture(startDate);
+        } catch (EveryventException e) {
+            throw new EveryventException(e.getErrorCode(), "캘린더를 만들 수 없습니다. " + e.getMessage());
+        }
     }
 
-    if (visibility == Visibility.MUTUAL) {
-      return followService.isMutualFollow(followerId, targetId);
+    public void validateCanUpdate(User user, Calendar calendar) {
+        try {
+            validateFuture(calendar.getStartDate());
+            validateDeleted(calendar);
+            validateOwner(user, calendar);
+            validateOriginalCalendar(calendar);
+        } catch (EveryventException e) {
+            throw new EveryventException(e.getErrorCode(), "캘린더를 수정할 수 없습니다. " + e.getMessage());
+        }
     }
 
-    return false;
-  }
-
-  public boolean canScrap(User user, Calendar calendar) {
-    if (isOwner(user, calendar)) {
-      return false;
+    public void validateCanUpdateScrapColor(User user, Calendar calendar) {
+        try {
+            validateFuture(calendar.getStartDate());
+            validateDeleted(calendar);
+            validateOwner(user, calendar);
+            validateScrappedCalendar(calendar);
+        } catch (EveryventException e) {
+            throw new EveryventException(e.getErrorCode(), "캘린더 색상을 수정할 수 없습니다. " + e.getMessage());
+        }
     }
 
-    if (!canView(user, calendar)) {
-      return false;
+    public void validateCanDelete(User user, Calendar calendar) {
+        try {
+            validateFuture(calendar.getStartDate());
+            validateDeleted(calendar);
+            validateOwner(user, calendar);
+        } catch (EveryventException e) {
+            throw new EveryventException(e.getErrorCode(), e.getMessage());
+        }
     }
 
-    return !scrapService.isScrapped(user, calendar.getId());
-  }
-
-  public boolean isOwner(User user, Calendar calendar) {
-    return calendar.getUser().getId().equals(user.getId());
-  }
-
-  public void validateCanCreate(User user, LocalDate startDate) {
-    try {
-      validateCalendarLimit(user, startDate);
-      validateFuture(startDate);
-    } catch (EveryventException e) {
-      throw new EveryventException(e.getErrorCode(), "캘린더를 만들 수 없습니다. " + e.getMessage());
+    public void validateCanView(User user, Calendar calendar) {
+        if (!canView(user, calendar)) {
+            throw new EveryventException(ErrorCode.FORBIDDEN, "해당 캘린더에 접근 권한이 없습니다.");
+        }
     }
-  }
 
-  public void validateCanUpdate(User user, Calendar calendar) {
-    try {
-      validateFuture(calendar.getStartDate());
-      validateDeleted(calendar);
-      validateOwner(user, calendar);
-      validateOriginalCalendar(calendar);
-    } catch (EveryventException e) {
-      throw new EveryventException(e.getErrorCode(), "캘린더를 수정할 수 없습니다. " + e.getMessage());
+    private void validateCalendarLimit(User user, LocalDate targetDate) {
+        int year = targetDate.getYear();
+        int month = targetDate.getMonthValue();
+
+        long count = calendarRepository.countByUserAndYearMonthAndTypes(
+                user, year, month, CalendarConstants.LIMITED_CALENDAR_TYPES
+        );
+
+        if (count >= CalendarConstants.MAX_CNT_PER_MONTH) {
+            throw new EveryventException(
+                    ErrorCode.INVALID_INPUT,
+                    String.format("%d년 %d월에 생성 가능한 캘린더 수를 초과했습니다.", year, month)
+            );
+        }
     }
-  }
 
-  public void validateCanUpdateScrapColor(User user, Calendar calendar) {
-    try {
-      validateFuture(calendar.getStartDate());
-      validateDeleted(calendar);
-      validateOwner(user, calendar);
-      validateScrappedCalendar(calendar);
-    } catch (EveryventException e) {
-      throw new EveryventException(e.getErrorCode(), "캘린더 색상을 수정할 수 없습니다. " + e.getMessage());
+    public void validateOwner(User user, Calendar calendar) {
+        if (!isOwner(user, calendar)) {
+            throw new EveryventException(ErrorCode.FORBIDDEN, "본인 캘린더가 아닙니다.");
+        }
     }
-  }
 
-  public void validateCanDelete(User user, Calendar calendar) {
-    try {
-      validateFuture(calendar.getStartDate());
-      validateDeleted(calendar);
-      validateOwner(user, calendar);
-    } catch (EveryventException e) {
-      throw new EveryventException(e.getErrorCode(), e.getMessage());
+    private void validateFuture(LocalDate startDate) {
+        YearMonth calendarYearMonth = YearMonth.from(startDate);
+        YearMonth currentYearMonth = YearMonth.now();
+
+        if (calendarYearMonth.isAfter(currentYearMonth)) {
+            return;
+        }
+        throw new EveryventException(ErrorCode.INVALID_INPUT, "과거입니다.");
     }
-  }
 
-  public void validateCanView(User user, Calendar calendar) {
-    if (!canView(user, calendar)) {
-      throw new EveryventException(ErrorCode.FORBIDDEN, "해당 캘린더에 접근 권한이 없습니다.");
+    private void validateDeleted(Calendar calendar) {
+        if (calendar.isDeleted()) {
+            throw new EveryventException(ErrorCode.NOT_FOUND, "삭제된 캘린더입니다.");
+        }
     }
-  }
 
-  private void validateCalendarLimit(User user, LocalDate targetDate) {
-    int year = targetDate.getYear();
-    int month = targetDate.getMonthValue();
-
-    long count = calendarRepository.countByUserAndYearMonthAndTypes(
-        user, year, month, CalendarConstants.LIMITED_CALENDAR_TYPES
-    );
-
-    if (count >= CalendarConstants.MAX_CNT_PER_MONTH) {
-      throw new EveryventException(
-          ErrorCode.INVALID_INPUT,
-          String.format("%d년 %d월에 생성 가능한 캘린더 수를 초과했습니다.", year, month)
-      );
+    private void validateOriginalCalendar(Calendar calendar) {
+        if (!calendar.isOriginalCalendar()) {
+            throw new EveryventException(ErrorCode.FORBIDDEN, "원본 캘린더가 아닙니다.");
+        }
     }
-  }
 
-  public void validateOwner(User user, Calendar calendar) {
-    if (!isOwner(user, calendar)) {
-      throw new EveryventException(ErrorCode.FORBIDDEN, "본인 캘린더가 아닙니다.");
+    private void validateScrappedCalendar(Calendar calendar) {
+        if (!calendar.getCalendarType().equals(CalendarType.SCRAPED)) {
+            throw new EveryventException(ErrorCode.INVALID_INPUT, "스크랩한 캘린더가 아닙니다.");
+        }
     }
-  }
-
-  private void validateFuture(LocalDate startDate) {
-    YearMonth calendarYearMonth = YearMonth.from(startDate);
-    YearMonth currentYearMonth = YearMonth.now();
-
-    if (calendarYearMonth.isAfter(currentYearMonth)) {
-      return;
-    }
-    throw new EveryventException(ErrorCode.INVALID_INPUT, "과거입니다.");
-  }
-
-  private void validateDeleted(Calendar calendar) {
-    if (calendar.isDeleted()) {
-      throw new EveryventException(ErrorCode.NOT_FOUND, "삭제된 캘린더입니다.");
-    }
-  }
-
-  private void validateOriginalCalendar(Calendar calendar) {
-    if (!calendar.isOriginalCalendar()) {
-      throw new EveryventException(ErrorCode.FORBIDDEN, "원본 캘린더가 아닙니다.");
-    }
-  }
-
-  private void validateScrappedCalendar(Calendar calendar) {
-    if (calendar.getCalendarType().equals(CalendarType.SCRAPED)) {
-      throw new EveryventException(ErrorCode.INVALID_INPUT, "스크랩한 캘린더가 아닙니다.");
-    }
-  }
 
 }

--- a/src/main/java/kr/santanrudolph/everyvent/domain/calendar/service/CalendarPolicy.java
+++ b/src/main/java/kr/santanrudolph/everyvent/domain/calendar/service/CalendarPolicy.java
@@ -103,7 +103,7 @@ public class CalendarPolicy {
             validateDeleted(calendar);
             validateOwner(user, calendar);
         } catch (EveryventException e) {
-            throw new EveryventException(e.getErrorCode(), e.getMessage());
+            throw new EveryventException(e.getErrorCode(), "캘린더를 삭제할 수 없습니다." + e.getMessage());
         }
     }
 

--- a/src/main/java/kr/santanrudolph/everyvent/domain/calendar/service/CalendarService.java
+++ b/src/main/java/kr/santanrudolph/everyvent/domain/calendar/service/CalendarService.java
@@ -1,15 +1,11 @@
 package kr.santanrudolph.everyvent.domain.calendar.service;
 
 import kr.santanrudolph.everyvent.domain.calendar.Calendar;
-import kr.santanrudolph.everyvent.domain.calendar.CalendarConstants;
 import kr.santanrudolph.everyvent.domain.calendar.dto.*;
 import kr.santanrudolph.everyvent.domain.calendar.enums.CalendarType;
-import kr.santanrudolph.everyvent.domain.calendar.enums.Visibility;
 import kr.santanrudolph.everyvent.domain.calendar.repository.CalendarRepository;
-import kr.santanrudolph.everyvent.domain.follow.FollowService;
 import kr.santanrudolph.everyvent.domain.user.User;
 import kr.santanrudolph.everyvent.domain.user.UserService;
-import kr.santanrudolph.everyvent.domain.user.enums.Role;
 import kr.santanrudolph.everyvent.global.exception.ErrorCode;
 import kr.santanrudolph.everyvent.global.exception.EveryventException;
 import lombok.RequiredArgsConstructor;
@@ -36,7 +32,7 @@ public class CalendarService {
     private final CalendarRepository calendarRepository;
     private final UserService userService;
     private final ScrapService scrapService;
-    private final FollowService followService;
+    private final CalendarPolicy calendarPolicy;
 
 
     @Transactional
@@ -44,12 +40,7 @@ public class CalendarService {
 
         User user = userService.getCurrentUser();
 
-        try {
-            validateCalendarLimit(user, request.startDate());
-            validateFuture(request.startDate());
-        } catch (EveryventException e) {
-            throw new EveryventException(ErrorCode.INVALID_INPUT, "캘린더를 만들 수 없습니다. " + e.getMessage());
-        }
+        calendarPolicy.validateCanCreate(user, request.startDate());
 
         Calendar calendar = Calendar.createCalendarWithStartDay(
                 user,
@@ -74,10 +65,10 @@ public class CalendarService {
         Calendar calendar = findCalendarByIdAndDeletedAtIsNull(calendarId);
         User currentUser = userService.getCurrentUser();
 
-        validateCanViewCalendar(currentUser, calendar);
+        calendarPolicy.validateCanView(currentUser, calendar);
 
         Long scrapCount = scrapService.getScrapCount(calendarId);
-        boolean scrappable = isScrappable(currentUser, calendar);
+        boolean scrappable = calendarPolicy.canScrap(currentUser, calendar);
         return CalendarDetailResponse.from(calendar, scrappable, scrapCount);
     }
 
@@ -154,7 +145,7 @@ public class CalendarService {
         User currentUser = userService.getCurrentUser();
         Calendar calendar = findCalendarByIdAndDeletedAtIsNull(calendarId);
 
-        validateUpdateCalendar(currentUser, calendar);
+        calendarPolicy.validateCanUpdate(currentUser, calendar);
 
         if (request.title() != null) {
             calendar.updateTitle(request.title());
@@ -195,7 +186,7 @@ public class CalendarService {
         Calendar calendar = calendarRepository.findById(calendarId)
                 .orElseThrow(() -> new EveryventException(ErrorCode.NOT_FOUND, "캘린더를 찾을 수 없습니다."));
 
-        validateUpdateScrapColor(currentUser, calendar);
+        calendarPolicy.validateCanUpdateScrapColor(currentUser, calendar);
 
         calendar.updateColor(request.color());
 
@@ -203,16 +194,20 @@ public class CalendarService {
         return CalendarDetailResponse.from(calendar, SCRAPPABLE, scrapCount);
     }
 
-
     @Transactional
     public void deleteCalendar(Long calendarId) {
         User currentUser = userService.getCurrentUser();
 
         Calendar calendar = findCalendarByIdAndDeletedAtIsNull(calendarId);
 
-        validateCanDeleteCalendar(currentUser, calendar);
+        calendarPolicy.validateCanDelete(currentUser, calendar);
 
         calendar.softDelete();
+    }
+
+    public Calendar findCalendarByIdAndDeletedAtIsNull(Long calendarId) {
+        return calendarRepository.findByIdAndDeletedAtIsNull(calendarId)
+                .orElseThrow(() -> new EveryventException(ErrorCode.NOT_FOUND, "캘린더를 찾을 수 없습니다."));
     }
 
     private Map<Long, Long> getScrapCountMapFromCalendars(List<Calendar> calendars) {
@@ -248,139 +243,6 @@ public class CalendarService {
                         entry.getValue()
                 ))
                 .collect(Collectors.toCollection(ArrayList::new));
-    }
-
-    private Calendar findCalendarByIdAndDeletedAtIsNull(Long calendarId) {
-        return calendarRepository.findByIdAndDeletedAtIsNull(calendarId)
-                .orElseThrow(() -> new EveryventException(ErrorCode.NOT_FOUND, "캘린더를 찾을 수 없습니다."));
-    }
-
-    boolean canViewCalendar(User user, Calendar calendar) {
-        if (user.getRole() == Role.ADMIN) { // 관리자는 다 조회 가능.
-            return true;
-        }
-
-        if (isOwner(user, calendar)) {
-            return true;
-        }
-
-        Visibility visibility = calendar.getVisibility();
-        if (visibility == Visibility.PUBLIC) {
-            return true;
-        }
-
-        Long followerId = user.getId();
-        Long targetId = calendar.getUser().getId();
-        if (visibility == Visibility.FOLLOWER) {
-            return followService.isFollowing(followerId, targetId);
-        }
-
-        if (visibility == Visibility.MUTUAL) {
-            return followService.isMutualFollow(followerId, targetId);
-        }
-
-        return false;
-    }
-
-    boolean isScrappable(User user, Calendar calendar) {
-        if (isOwner(user, calendar)) {
-            return false;
-        }
-
-        if (!canViewCalendar(user, calendar)) {
-            return false;
-        }
-
-        return !scrapService.isScrapped(user, calendar.getId());
-    }
-
-    boolean isOwner(User user, Calendar calendar) {
-        return calendar.getUser().getId().equals(user.getId());
-    }
-
-    private void validateCanViewCalendar(User user, Calendar calendar) {
-        if (canViewCalendar(user, calendar)) {
-            return;
-        }
-        throw new EveryventException(ErrorCode.INVALID_INPUT, "해당 캘린더에 접근 권한이 없습니다.");
-    }
-
-    private void validateCalendarLimit(User user, LocalDate targetDate) {
-        int year = targetDate.getYear();
-        int month = targetDate.getMonthValue();
-
-        long count = calendarRepository.countByUserAndYearMonthAndTypes(
-                user, year, month, CalendarConstants.LIMITED_CALENDAR_TYPES
-        );
-
-        if (count >= CalendarConstants.MAX_CNT_PER_MONTH) {
-            throw new EveryventException(
-                    ErrorCode.INVALID_INPUT,
-                    String.format("%d년 %d월에 생성 가능한 캘린더 수를 초과했습니다.", year, month)
-            );
-        }
-    }
-
-    private void validateUpdateCalendar(User user, Calendar calendar) {
-        try {
-            validateFuture(calendar.getStartDate());
-            validateDeleted(calendar);
-            validateOwner(user, calendar);
-            validateOriginalCalendar(calendar);
-        } catch (EveryventException e) {
-            throw new EveryventException(ErrorCode.INVALID_INPUT, "캘린더를 수정할 수 없습니다. " + e.getMessage());
-        }
-    }
-
-    private void validateUpdateScrapColor(User user, Calendar calendar) {
-        try {
-            validateFuture(calendar.getStartDate());
-            validateDeleted(calendar);
-            validateOwner(user, calendar);
-            validateScrappedCalendar(calendar);
-        } catch (EveryventException e) {
-            throw new EveryventException(ErrorCode.INVALID_INPUT, "캘린더 색상을 수정할 수 없습니다. " + e.getMessage());
-        }
-    }
-
-    private void validateCanDeleteCalendar(User user, Calendar calendar) {
-        validateFuture(calendar.getStartDate());
-        validateDeleted(calendar);
-        validateOwner(user, calendar);
-    }
-
-    private void validateFuture(LocalDate startDate) {
-        YearMonth calendarYearMonth = YearMonth.from(startDate);
-        YearMonth currentYearMonth = YearMonth.now();
-
-        if (calendarYearMonth.isAfter(currentYearMonth)) {
-            return;
-        }
-        throw new EveryventException(ErrorCode.INVALID_INPUT, "미래의 캘린더가 아닙니다.");
-    }
-
-    private void validateDeleted(Calendar calendar) {
-        if (calendar.isDeleted()) {
-            throw new EveryventException(ErrorCode.NOT_FOUND, "삭제된 캘린더입니다.");
-        }
-    }
-
-    private void validateOwner(User user, Calendar calendar) {
-        if (!isOwner(user, calendar)) {
-            throw new EveryventException(ErrorCode.FORBIDDEN, "본인 캘린더가 아닙니다.");
-        }
-    }
-
-    private void validateOriginalCalendar(Calendar calendar) {
-        if (!calendar.isOriginalCalendar()) {
-            throw new EveryventException(ErrorCode.FORBIDDEN, "원본 캘린더가 아닙니다.");
-        }
-    }
-
-    private void validateScrappedCalendar(Calendar calendar) {
-        if (calendar.getCalendarType().equals(CalendarType.SCRAPED)) {
-            throw new EveryventException(ErrorCode.INVALID_INPUT, "스크랩한 캘린더가 아닙니다.");
-        }
     }
 
 }


### PR DESCRIPTION
## 📝 무엇을 했나요?

`CalendarService`의 코드가 길어지고, 서비스가 너무 많은 역할을 수행하고 있다고 느껴
**캘린더 비즈니스 정책 및 관련 검증 로직**을 `CalendarPolicy`로 분리했어요.

`CalendarPermission` 클래스를 별도로 만들어 
**유저의 행위(조회, 수정, 스크랩 등)에 대한 권한 검증 로직을 분리**하는 것도 고민했어요.
하지만 현재 서비스 규모에서는 과한 분리라고 생각하여
우선 CalendarPolicy에서 함께 관리하도록 구성했어요.

추후 정책 로직이 더 복잡해지거나 CalendarPolicy의 책임이 과도해질 경우,
권한 관련 로직을 CalendarPermission으로 분리할 계획이에요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 비원본 캘린더의 제목 수정 시도 시 오류 메시지를 개선하여 원본 캘린더만 제목을 변경할 수 있음을 명확히 안내합니다.

* **개선사항**
  * 캘린더 생성·조회·수정·삭제 전반의 권한 검사와 검증을 중앙화·강화하여 접근 제어가 일관되고 안정적으로 동작합니다.
  * 스크랩, 소유권, 공개 범위 관련 검증이 더 엄격해져 무단 접근과 잘못된 상태 변경을 방지합니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->