### PR TITLE
fix(auth): oauth 로그인 후 세션 무효화하여 내 정보 조회 수정 API 오류 해결

### DIFF
--- a/src/main/java/kr/santanrudolph/everyvent/auth/security/OAuth2SuccessHandler.java
+++ b/src/main/java/kr/santanrudolph/everyvent/auth/security/OAuth2SuccessHandler.java
@@ -54,10 +54,11 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
         .queryParam("code", authCode)
         .build().toUriString();
 
-    // OAuth2 로그인 완료 후 불필요한 세션 데이터 제거
+    // OAuth2 로그인 완료 후 세션 무효화 (이후 API 호출은 JWT로만 인증)
     HttpSession session = request.getSession(false);
     if (session != null) {
-      session.removeAttribute(REDIRECT_URI_SESSION_KEY);
+      session.invalidate();
+      log.info("Session invalidated after OAuth2 login success");
     }
 
     log.info("Redirecting to: {}", targetUrl);


### PR DESCRIPTION

## 📝 무엇을 했나요?

`AuthenticationUtil.getCurrentUserId()`에서 Principal을 Long 타입으로 기대했지만, 
`EveryventOAuth2User` 객체가 반환되어 내 정보 조회/수정 API에서 타입 캐스팅 에러가 발생했어요

---

### 원인
이전 작업에서 프론트엔드 환경별 동적 리다이렉트를 위해 `redirect_url`을 세션에 저장했는데, 
 이로 인해 OAuth2 세션이 유지되면서 이후 **내 정보 API 호출 시 JWT 인증이 아닌 OAuth2 세션 인증이 우선 적용**되어 발생한 문제였어요.
<img width="1360" height="980" alt="image" src="https://github.com/user-attachments/assets/a17d0f9a-116b-4070-9abb-82c4b17b1783" />

---
### 해결 방법
OAuth2 로그인 성공 후 `session.invalidate()`로 세션을 완전히 무효화하여, 이후 모든 API 호출은 JWT 기반 인증만 사용하도록 수정했어요