### PR TITLE
feat(task): 태스크 생성, 수정, 조회, 삭제 기능 구현 

### DIFF
--- a/src/main/java/kr/santanrudolph/everyvent/domain/calendar/service/CalendarService.java
+++ b/src/main/java/kr/santanrudolph/everyvent/domain/calendar/service/CalendarService.java
@@ -4,7 +4,7 @@ import kr.santanrudolph.everyvent.domain.calendar.Calendar;
 import kr.santanrudolph.everyvent.domain.calendar.dto.*;
 import kr.santanrudolph.everyvent.domain.calendar.enums.CalendarType;
 import kr.santanrudolph.everyvent.domain.calendar.repository.CalendarRepository;
-import kr.santanrudolph.everyvent.domain.task.TaskService;
+import kr.santanrudolph.everyvent.domain.task.TaskRepository;
 import kr.santanrudolph.everyvent.domain.user.User;
 import kr.santanrudolph.everyvent.domain.user.UserService;
 import kr.santanrudolph.everyvent.global.exception.ErrorCode;
@@ -31,9 +31,9 @@ public class CalendarService {
   private static final long INITIAL_SCRAP_COUNT = 0L;
 
   private final CalendarRepository calendarRepository;
+  private final TaskRepository taskRepository;
   private final UserService userService;
   private final ScrapService scrapService;
-  private final TaskService taskService;
   private final CalendarPolicy calendarPolicy;
 
 
@@ -202,7 +202,8 @@ public class CalendarService {
     Calendar calendar = findCalendarByIdAndDeletedAtIsNull(calendarId);
 
     calendarPolicy.validateCanDelete(currentUser, calendar);
-    taskService.deleteTasksByCalendarId(calendarId);
+
+    taskRepository.deleteByCalendarId(calendarId);
     calendar.softDelete();
   }
 

--- a/src/main/java/kr/santanrudolph/everyvent/domain/calendar/service/CalendarService.java
+++ b/src/main/java/kr/santanrudolph/everyvent/domain/calendar/service/CalendarService.java
@@ -4,6 +4,7 @@ import kr.santanrudolph.everyvent.domain.calendar.Calendar;
 import kr.santanrudolph.everyvent.domain.calendar.dto.*;
 import kr.santanrudolph.everyvent.domain.calendar.enums.CalendarType;
 import kr.santanrudolph.everyvent.domain.calendar.repository.CalendarRepository;
+import kr.santanrudolph.everyvent.domain.task.TaskService;
 import kr.santanrudolph.everyvent.domain.user.User;
 import kr.santanrudolph.everyvent.domain.user.UserService;
 import kr.santanrudolph.everyvent.global.exception.ErrorCode;
@@ -25,224 +26,224 @@ import java.util.stream.Collectors;
 @Transactional(readOnly = true)
 public class CalendarService {
 
-    private static final boolean SCRAPPABLE = true;
-    private static final boolean NOT_SCRAPPABLE = false;
-    private static final long INITIAL_SCRAP_COUNT = 0L;
+  private static final boolean SCRAPPABLE = true;
+  private static final boolean NOT_SCRAPPABLE = false;
+  private static final long INITIAL_SCRAP_COUNT = 0L;
 
-    private final CalendarRepository calendarRepository;
-    private final UserService userService;
-    private final ScrapService scrapService;
-    private final CalendarPolicy calendarPolicy;
-
-
-    @Transactional
-    public CalendarDetailResponse createPersonalCalendar(CalendarCreateRequest request) {
-
-        User user = userService.getCurrentUser();
-
-        calendarPolicy.validateCanCreate(user, request.startDate());
-
-        Calendar calendar = Calendar.createCalendarWithStartDay(
-                user,
-                request.title(),
-                request.description(),
-                request.startDate(),
-                request.previewStartDate(),
-                request.previewEndDate(),
-                request.visibility(),
-                request.color(),
-                request.category(),
-                CalendarType.PERSONAL
-        );
+  private final CalendarRepository calendarRepository;
+  private final UserService userService;
+  private final ScrapService scrapService;
+  private final TaskService taskService;
+  private final CalendarPolicy calendarPolicy;
 
 
-        Calendar saved = calendarRepository.save(calendar);
+  @Transactional
+  public CalendarDetailResponse createPersonalCalendar(CalendarCreateRequest request) {
 
-        return CalendarDetailResponse.from(saved, NOT_SCRAPPABLE, INITIAL_SCRAP_COUNT);
+    User user = userService.getCurrentUser();
+
+    calendarPolicy.validateCanCreate(user, request.startDate());
+
+    Calendar calendar = Calendar.createCalendarWithStartDay(
+        user,
+        request.title(),
+        request.description(),
+        request.startDate(),
+        request.previewStartDate(),
+        request.previewEndDate(),
+        request.visibility(),
+        request.color(),
+        request.category(),
+        CalendarType.PERSONAL
+    );
+
+
+    Calendar saved = calendarRepository.save(calendar);
+
+    return CalendarDetailResponse.from(saved, NOT_SCRAPPABLE, INITIAL_SCRAP_COUNT);
+  }
+
+  public CalendarDetailResponse getCalendar(Long calendarId) {
+    Calendar calendar = findCalendarByIdAndDeletedAtIsNull(calendarId);
+    User currentUser = userService.getCurrentUser();
+
+    calendarPolicy.validateCanView(currentUser, calendar);
+
+    Long scrapCount = scrapService.getScrapCount(calendarId);
+    boolean scrappable = calendarPolicy.canScrap(currentUser, calendar);
+    return CalendarDetailResponse.from(calendar, scrappable, scrapCount);
+  }
+
+  public CalendarScrollResponse getMyCalendars(YearMonth cursor, Integer size) {
+    User user = userService.getCurrentUser();
+
+    if (size <= 0) {
+      throw new EveryventException(ErrorCode.INVALID_INPUT, "size는 1 이상이어야 합니다.");
     }
 
-    public CalendarDetailResponse getCalendar(Long calendarId) {
-        Calendar calendar = findCalendarByIdAndDeletedAtIsNull(calendarId);
-        User currentUser = userService.getCurrentUser();
-
-        calendarPolicy.validateCanView(currentUser, calendar);
-
-        Long scrapCount = scrapService.getScrapCount(calendarId);
-        boolean scrappable = calendarPolicy.canScrap(currentUser, calendar);
-        return CalendarDetailResponse.from(calendar, scrappable, scrapCount);
+    YearMonth startYearMonth;
+    if (cursor == null) {
+      startYearMonth = calendarRepository
+          .findFirstByUserAndDeletedAtIsNullAndStartDateBeforeOrderByStartDateDesc(
+              user,
+              LocalDate.now().plusYears(10)  // todo: 비즈니스 로직 상 10년 후까지 포함. 리팩토링 필요
+          )
+          .map(calendar -> YearMonth.from(calendar.getStartDate()))
+          .orElse(null);
+    } else {
+      startYearMonth = cursor;
     }
 
-    public CalendarScrollResponse getMyCalendars(YearMonth cursor, Integer size) {
-        User user = userService.getCurrentUser();
-
-        if (size <= 0) {
-            throw new EveryventException(ErrorCode.INVALID_INPUT, "size는 1 이상이어야 합니다.");
-        }
-
-        YearMonth startYearMonth;
-        if (cursor == null) {
-            startYearMonth = calendarRepository
-                    .findFirstByUserAndDeletedAtIsNullAndStartDateBeforeOrderByStartDateDesc(
-                            user,
-                            LocalDate.now().plusYears(10)  // todo: 비즈니스 로직 상 10년 후까지 포함. 리팩토링 필요
-                    )
-                    .map(calendar -> YearMonth.from(calendar.getStartDate()))
-                    .orElse(null);
-        } else {
-            startYearMonth = cursor;
-        }
-
-        if (startYearMonth == null) { // 최근 캘린더 존재하지 않음
-            return new CalendarScrollResponse(null, null, false);
-        }
-
-        YearMonth endYearMonth = startYearMonth.minusMonths(size);
-        LocalDate startDate = endYearMonth.atDay(1);
-        LocalDate endDate = startYearMonth.atEndOfMonth();
-
-        List<Calendar> calendars = calendarRepository.findByUserAndStartDateBetween(
-                user,
-                startDate,
-                endDate
-        );
-
-        Map<Long, Long> scrapCountsMap = getScrapCountMapFromCalendars(calendars);
-
-        List<CalendarMonthGroup> calendarMonthGroups = groupCalendarsByMonth(calendars, scrapCountsMap);
-
-        boolean hasNext = calendarMonthGroups.size() > size;
-        String nextCursor = null;
-
-        if (hasNext) {
-            CalendarMonthGroup lastGroup = calendarMonthGroups.remove(calendarMonthGroups.size() - 1);
-            nextCursor = lastGroup.toYearMonth().toString();
-        }
-
-        return new CalendarScrollResponse(calendarMonthGroups, nextCursor, hasNext);
+    if (startYearMonth == null) { // 최근 캘린더 존재하지 않음
+      return new CalendarScrollResponse(null, null, false);
     }
 
-    public List<CalendarDetailResponse> getMonthlyCalendars(YearMonth yearMonth) {
-        LocalDate startDate = yearMonth.atDay(1);
-        LocalDate endDate = yearMonth.atEndOfMonth();
-        List<Calendar> calendars = calendarRepository.findByUserAndStartDateBetween(
-                userService.getCurrentUser(),
-                startDate,
-                endDate
-        );
+    YearMonth endYearMonth = startYearMonth.minusMonths(size);
+    LocalDate startDate = endYearMonth.atDay(1);
+    LocalDate endDate = startYearMonth.atEndOfMonth();
 
-        Map<Long, Long> scrapCountsMap = getScrapCountMapFromCalendars(calendars);
+    List<Calendar> calendars = calendarRepository.findByUserAndStartDateBetween(
+        user,
+        startDate,
+        endDate
+    );
 
-        return calendars.stream()
-                .map(calendar -> CalendarDetailResponse.from(
-                        calendar,
-                        NOT_SCRAPPABLE,
-                        scrapCountsMap.getOrDefault(calendar.getId(), 0L)))
-                .toList();
+    Map<Long, Long> scrapCountsMap = getScrapCountMapFromCalendars(calendars);
+
+    List<CalendarMonthGroup> calendarMonthGroups = groupCalendarsByMonth(calendars, scrapCountsMap);
+
+    boolean hasNext = calendarMonthGroups.size() > size;
+    String nextCursor = null;
+
+    if (hasNext) {
+      CalendarMonthGroup lastGroup = calendarMonthGroups.remove(calendarMonthGroups.size() - 1);
+      nextCursor = lastGroup.toYearMonth().toString();
     }
 
-    @Transactional
-    public CalendarDetailResponse updatePersonalCalendar(Long calendarId, CalendarUpdateRequest request) {
-        User currentUser = userService.getCurrentUser();
-        Calendar calendar = findCalendarByIdAndDeletedAtIsNull(calendarId);
+    return new CalendarScrollResponse(calendarMonthGroups, nextCursor, hasNext);
+  }
 
-        calendarPolicy.validateCanUpdate(currentUser, calendar);
+  public List<CalendarDetailResponse> getMonthlyCalendars(YearMonth yearMonth) {
+    LocalDate startDate = yearMonth.atDay(1);
+    LocalDate endDate = yearMonth.atEndOfMonth();
+    List<Calendar> calendars = calendarRepository.findByUserAndStartDateBetween(
+        userService.getCurrentUser(),
+        startDate,
+        endDate
+    );
 
-        if (request.title() != null) {
-            calendar.updateTitle(request.title());
-        }
-        if (request.description() != null) {
-            calendar.updateDescription(request.description());
-        }
-        if (request.startDate() != null) {
-            calendar.updateStartDate(request.startDate());
-        }
-        if (request.endDate() != null) {
-            calendar.updateEndDate(request.endDate());
-        }
-        if (request.previewStartDate() != null) {
-            calendar.updatePreviewStartDay(request.previewStartDate());
-        }
-        if (request.previewEndDate() != null) {
-            calendar.updatePreviewEndDay(request.previewEndDate());
-        }
-        if (request.visibility() != null) {
-            calendar.updateVisibility(request.visibility());
-        }
-        if (request.color() != null) {
-            calendar.updateColor(request.color());
-        }
-        if (request.category() != null) {
-            calendar.updateCategory(request.category());
-        }
+    Map<Long, Long> scrapCountsMap = getScrapCountMapFromCalendars(calendars);
 
-        Long scrapCount = scrapService.getScrapCount(calendar.getId());
+    return calendars.stream()
+        .map(calendar -> CalendarDetailResponse.from(
+            calendar,
+            NOT_SCRAPPABLE,
+            scrapCountsMap.getOrDefault(calendar.getId(), 0L)))
+        .toList();
+  }
 
-        return CalendarDetailResponse.from(calendar, false, scrapCount);
+  @Transactional
+  public CalendarDetailResponse updatePersonalCalendar(Long calendarId, CalendarUpdateRequest request) {
+    User currentUser = userService.getCurrentUser();
+    Calendar calendar = findCalendarByIdAndDeletedAtIsNull(calendarId);
+
+    calendarPolicy.validateCanUpdate(currentUser, calendar);
+
+    if (request.title() != null) {
+      calendar.updateTitle(request.title());
+    }
+    if (request.description() != null) {
+      calendar.updateDescription(request.description());
+    }
+    if (request.startDate() != null) {
+      calendar.updateStartDate(request.startDate());
+    }
+    if (request.endDate() != null) {
+      calendar.updateEndDate(request.endDate());
+    }
+    if (request.previewStartDate() != null) {
+      calendar.updatePreviewStartDay(request.previewStartDate());
+    }
+    if (request.previewEndDate() != null) {
+      calendar.updatePreviewEndDay(request.previewEndDate());
+    }
+    if (request.visibility() != null) {
+      calendar.updateVisibility(request.visibility());
+    }
+    if (request.color() != null) {
+      calendar.updateColor(request.color());
+    }
+    if (request.category() != null) {
+      calendar.updateCategory(request.category());
     }
 
-    @Transactional
-    public CalendarDetailResponse updateScrapColor(Long calendarId, ScrapCalendarRequest request) {
-        User currentUser = userService.getCurrentUser();
-        Calendar calendar = calendarRepository.findById(calendarId)
-                .orElseThrow(() -> new EveryventException(ErrorCode.NOT_FOUND, "캘린더를 찾을 수 없습니다."));
+    Long scrapCount = scrapService.getScrapCount(calendar.getId());
 
-        calendarPolicy.validateCanUpdateScrapColor(currentUser, calendar);
+    return CalendarDetailResponse.from(calendar, false, scrapCount);
+  }
 
-        calendar.updateColor(request.color());
+  @Transactional
+  public CalendarDetailResponse updateScrapColor(Long calendarId, ScrapCalendarRequest request) {
+    User currentUser = userService.getCurrentUser();
+    Calendar calendar = calendarRepository.findById(calendarId)
+        .orElseThrow(() -> new EveryventException(ErrorCode.NOT_FOUND, "캘린더를 찾을 수 없습니다."));
 
-        Long scrapCount = scrapService.getScrapCount(calendar.getId());
-        return CalendarDetailResponse.from(calendar, SCRAPPABLE, scrapCount);
+    calendarPolicy.validateCanUpdateScrapColor(currentUser, calendar);
+
+    calendar.updateColor(request.color());
+
+    Long scrapCount = scrapService.getScrapCount(calendar.getId());
+    return CalendarDetailResponse.from(calendar, SCRAPPABLE, scrapCount);
+  }
+
+  @Transactional
+  public void deleteCalendar(Long calendarId) {
+    User currentUser = userService.getCurrentUser();
+    Calendar calendar = findCalendarByIdAndDeletedAtIsNull(calendarId);
+
+    calendarPolicy.validateCanDelete(currentUser, calendar);
+    taskService.deleteTasksByCalendarId(calendarId);
+    calendar.softDelete();
+  }
+
+  public Calendar findCalendarByIdAndDeletedAtIsNull(Long calendarId) {
+    return calendarRepository.findByIdAndDeletedAtIsNull(calendarId)
+        .orElseThrow(() -> new EveryventException(ErrorCode.NOT_FOUND, "캘린더를 찾을 수 없습니다."));
+  }
+
+  private Map<Long, Long> getScrapCountMapFromCalendars(List<Calendar> calendars) {
+    if (calendars == null || calendars.isEmpty()) {
+      return Collections.emptyMap();
     }
 
-    @Transactional
-    public void deleteCalendar(Long calendarId) {
-        User currentUser = userService.getCurrentUser();
+    List<Long> calendarIds = calendars.stream()
+        .map(Calendar::getId)
+        .toList();
+    return scrapService.getScrapCountMap(calendarIds);
+  }
 
-        Calendar calendar = findCalendarByIdAndDeletedAtIsNull(calendarId);
+  private List<CalendarMonthGroup> groupCalendarsByMonth(List<Calendar> calendars, Map<Long, Long> scrapCountMap) {
+    Map<YearMonth, List<CalendarListResponse>> groupedByMonth =
+        calendars.stream()
+            .collect(Collectors.groupingBy(
+                calendar -> YearMonth.from(calendar.getStartDate()),
+                LinkedHashMap::new,
+                Collectors.mapping(
+                    calendar
+                        -> CalendarListResponse.fromCalendar(
+                        calendar, scrapCountMap.getOrDefault(calendar.getId(), 0L)
+                    ),
+                    Collectors.toList()
+                )
+            ));
 
-        calendarPolicy.validateCanDelete(currentUser, calendar);
-
-        calendar.softDelete();
-    }
-
-    public Calendar findCalendarByIdAndDeletedAtIsNull(Long calendarId) {
-        return calendarRepository.findByIdAndDeletedAtIsNull(calendarId)
-                .orElseThrow(() -> new EveryventException(ErrorCode.NOT_FOUND, "캘린더를 찾을 수 없습니다."));
-    }
-
-    private Map<Long, Long> getScrapCountMapFromCalendars(List<Calendar> calendars) {
-        if (calendars == null || calendars.isEmpty()) {
-            return Collections.emptyMap();
-        }
-
-        List<Long> calendarIds = calendars.stream()
-                .map(Calendar::getId)
-                .toList();
-        return scrapService.getScrapCountMap(calendarIds);
-    }
-
-    private List<CalendarMonthGroup> groupCalendarsByMonth(List<Calendar> calendars, Map<Long, Long> scrapCountMap) {
-        Map<YearMonth, List<CalendarListResponse>> groupedByMonth =
-                calendars.stream()
-                        .collect(Collectors.groupingBy(
-                                calendar -> YearMonth.from(calendar.getStartDate()),
-                                LinkedHashMap::new,
-                                Collectors.mapping(
-                                        calendar
-                                                -> CalendarListResponse.fromCalendar(
-                                                calendar, scrapCountMap.getOrDefault(calendar.getId(), 0L)
-                                        ),
-                                        Collectors.toList()
-                                )
-                        ));
-
-        return groupedByMonth.entrySet().stream()
-                .map(entry -> new CalendarMonthGroup(
-                        entry.getKey().getYear(),
-                        entry.getKey().getMonthValue(),
-                        entry.getValue()
-                ))
-                .collect(Collectors.toCollection(ArrayList::new));
-    }
+    return groupedByMonth.entrySet().stream()
+        .map(entry -> new CalendarMonthGroup(
+            entry.getKey().getYear(),
+            entry.getKey().getMonthValue(),
+            entry.getValue()
+        ))
+        .collect(Collectors.toCollection(ArrayList::new));
+  }
 
 }

--- a/src/main/java/kr/santanrudolph/everyvent/domain/task/Task.java
+++ b/src/main/java/kr/santanrudolph/everyvent/domain/task/Task.java
@@ -4,9 +4,6 @@ package kr.santanrudolph.everyvent.domain.task;
 import jakarta.persistence.*;
 import kr.santanrudolph.everyvent.global.entity.BaseEntity;
 import kr.santanrudolph.everyvent.domain.calendar.Calendar;
-import kr.santanrudolph.everyvent.global.exception.ErrorCode;
-import kr.santanrudolph.everyvent.global.exception.EveryventException;
-import kr.santanrudolph.everyvent.global.util.TimeUtil;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -32,26 +29,27 @@ public class Task extends BaseEntity {
   @Column(nullable = false)
   private String content;
 
-  @Column(nullable = false)
-  private boolean completed;
+  @Column
+  private Boolean completed;
 
-  public boolean getCompleted() {
-    return completed;
-  }
-
-  public static Task createTask(Calendar calendar, LocalDate day) {
+  public static Task createTask(Calendar calendar, LocalDate day, String content) {
     Task task = new Task();
     task.calendar = calendar;
     task.day = day;
+    task.content = content;
     task.completed = false;
     return task;
   }
 
+  public void updateContent(String content) {
+    this.content = content;
+  }
+
   public void complete() {
-    if (TimeUtil.isAfter(this.day, TimeUtil.today())) {
-      throw new EveryventException(ErrorCode.FORBIDDEN, "미래의 태스크는 완료할 수 없습니다.");
-    }
     this.completed = true;
   }
 
+  public void uncomplete() {
+    this.completed = false;
+  }
 }

--- a/src/main/java/kr/santanrudolph/everyvent/domain/task/TaskController.java
+++ b/src/main/java/kr/santanrudolph/everyvent/domain/task/TaskController.java
@@ -111,7 +111,7 @@ public class TaskController {
     return ResponseEntity.noContent().build();
   }
 
-  @Operation(summary = "태스크 완료 상태 변경", description = "태스크의 완료/미완료 상태를 변경합니다. completed 쿼리 파라미터로 true/false를 전달합니다.")
+  @Operation(summary = "태스크 완료 상태 변경", description = "태스크의 완료/미완료 상태를 변경합니다.")
   @ApiResponses({
       @ApiResponse(responseCode = "200", description = "처리 성공"),
       @ApiResponse(responseCode = "400", description = "INVALID_INPUT: 미래 태스크 완료 불가"),
@@ -122,7 +122,7 @@ public class TaskController {
   public ResponseEntity<TaskResponse> updateTaskCompletion(
       @PathVariable Long calendarId,
       @PathVariable Long taskId,
-      @RequestParam Boolean completed) {
+      @RequestBody Boolean completed) {
 
     TaskResponse response = taskService.updateTaskCompletion(calendarId, taskId, completed);
     return ResponseEntity.ok(response);

--- a/src/main/java/kr/santanrudolph/everyvent/domain/task/TaskController.java
+++ b/src/main/java/kr/santanrudolph/everyvent/domain/task/TaskController.java
@@ -1,5 +1,6 @@
 package kr.santanrudolph.everyvent.domain.task;
 
+
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
@@ -17,11 +18,13 @@ import org.springframework.web.bind.annotation.*;
 import java.util.List;
 
 @Slf4j
-@Tag(name = "태스크", description = "캘린더 태스크 관련 API. (내부 동작 미구현)")
+@Tag(name = "태스크", description = "캘린더 태스크 관련 API")
 @RestController
 @RequestMapping("/api/calendars/{calendarId}/tasks")
 @RequiredArgsConstructor
 public class TaskController {
+
+  private final TaskService taskService;
 
 
   @Operation(summary = "태스크 생성", description = "캘린더에 여러 태스크를 한 번에 생성합니다. 각 태스크별로 미리보기 여부를 지정할 수 있습니다. 미리보기는 해당 캘린더가 시작되는 달의 1일부터 쭉 볼 수 있습니다.")
@@ -35,17 +38,7 @@ public class TaskController {
       @PathVariable Long calendarId,
       @Valid @RequestBody List<TaskCreateRequest> requests) {
 
-    List<TaskResponse> responses = requests.stream()
-        .map(request -> new TaskResponse(
-            1L,  // 실제로는 생성된 ID
-            calendarId,
-            request.day(),
-            false,  // isBeforeToday
-            request.content(),
-            false  // completed
-        ))
-        .toList();
-
+    List<TaskResponse> responses = taskService.createTasks(calendarId, requests);
     return ResponseEntity.status(HttpStatus.CREATED).body(responses);
   }
 
@@ -56,98 +49,34 @@ public class TaskController {
       @ApiResponse(responseCode = "403", description = "FORBIDDEN: 접근 권한 없음"),
       @ApiResponse(responseCode = "404", description = "NOT_FOUND")
   })
+  @GetMapping("/all")
+  public ResponseEntity<List<TaskResponse>> getTasksAllInformation(
+      @PathVariable Long calendarId) {
+
+    List<TaskResponse> responses = taskService.getTasksAllInformation(calendarId);
+    return ResponseEntity.ok(responses);
+  }
+
+
+  @Operation(summary = "특정 캘린더의 모든 태스크 조회",
+      description = """
+          특정 캘린더의 모든 태스크 목록을 조회합니다.
+          아직 열리지 않은 날짜는 isLock = true로, content와 completed는 null로 보냅니다.
+          존재하지 않는 day는 포함하지 않고 보냅니다.
+          """)
+  @ApiResponses({
+      @ApiResponse(responseCode = "200", description = "조회 성공"),
+      @ApiResponse(responseCode = "403", description = "FORBIDDEN: 접근 권한 없음"),
+      @ApiResponse(responseCode = "404", description = "NOT_FOUND")
+  })
   @GetMapping
   public ResponseEntity<List<TaskResponse>> getTasks(
       @PathVariable Long calendarId) {
 
-    TaskResponse task1 = new TaskResponse(
-        1L,
-        calendarId,
-        1,
-        false,  // isBeforeToday
-        "태스크 내용 1",
-        true    // completed
-    );
-
-    TaskResponse task2 = new TaskResponse(
-        2L,
-        calendarId,
-        2,
-        true,   // isBeforeToday
-        "태스크 내용 2",
-        true    // completed
-    );
-
-    return ResponseEntity.ok(List.of(task1, task2));
+    List<TaskResponse> responses = taskService.getTasks(calendarId);
+    return ResponseEntity.ok(responses);
   }
 
-/*
-  @Operation(summary = "캘린더별 태스크 상세 조회", description = "특정 태스크 상세 조회. canPreview=false이고 unlockDate 전이면 잠겨있음")
-  @ApiResponses({
-      @ApiResponse(responseCode = "200", description = "조회 성공"),
-      @ApiResponse(responseCode = "403", description = "FORBIDDEN: 접근 권한 없음 또는 아직 잠김"),
-      @ApiResponse(responseCode = "404", description = "NOT_FOUND")
-  })
-  @GetMapping("/{taskId}")
-  public ResponseEntity<TaskResponse> getTask(
-      @PathVariable Long calendarId,
-      @PathVariable Long taskId) {
-
-    TaskResponse response = new TaskResponse(
-        taskId,
-        calendarId,
-        5,
-        "태스크 상세 내용",
-        true,
-        false,
-        false
-    );
-
-    return ResponseEntity.ok(response);
-  }*/
-
-  // 특정 날짜의 task를 전부 조회합니다.
-  @Operation(summary = "특정 캘린더의 day별 태스크 목록 조회", description = "캘린더의 일별 태스크 목록을 조회합니다." +
-      "예: 1번 캘린더의 5일의 태스크 목록 조회")
-  @ApiResponses({
-      @ApiResponse(responseCode = "200", description = "조회 성공"),
-      @ApiResponse(responseCode = "403", description = "FORBIDDEN: 접근 권한 없음 또는 아직 잠김"),
-      @ApiResponse(responseCode = "404", description = "NOT_FOUND")
-  })
-  @GetMapping("/{day}")
-  public ResponseEntity<List<TaskResponse>> getTasksByCalendarIdAndDay(
-      @PathVariable Long calendarId,
-      @PathVariable Integer day) {
-
-    TaskResponse response1 = new TaskResponse(
-        1L,
-        calendarId,
-        day,
-        false,  // isBeforeToday
-        "태스크 상세 내용 1",
-        false   // completed
-    );
-
-    TaskResponse response2 = new TaskResponse(
-        2L,
-        calendarId,
-        day,
-        false,  // isBeforeToday
-        "태스크 상세 내용 2",
-        false   // completed
-    );
-
-    TaskResponse response3 = new TaskResponse(
-        3L,
-        calendarId,
-        day,
-        false,  // isBeforeToday
-        "태스크 상세 내용 3",
-        false   // completed
-    );
-
-    return ResponseEntity.ok(List.of(response1, response2, response3));
-  }
 
   @Operation(summary = "태스크 수정", description = "태스크 내용 및 미리보기 설정 수정")
   @ApiResponses({
@@ -162,15 +91,7 @@ public class TaskController {
       @PathVariable Long taskId,
       @Valid @RequestBody TaskUpdateRequest request) {
 
-    TaskResponse response = new TaskResponse(
-        taskId,
-        calendarId,
-        5,
-        false,  // isBeforeToday
-        request.content() != null ? request.content() : "기존 내용",
-        false   // completed
-    );
-
+    TaskResponse response = taskService.updateTask(calendarId, taskId, request);
     return ResponseEntity.ok(response);
   }
 
@@ -185,6 +106,8 @@ public class TaskController {
   public ResponseEntity<Void> deleteTask(
       @PathVariable Long calendarId,
       @PathVariable Long taskId) {
+
+    taskService.deleteTask(calendarId, taskId);
     return ResponseEntity.noContent().build();
   }
 
@@ -201,15 +124,7 @@ public class TaskController {
       @PathVariable Long taskId,
       @RequestParam Boolean completed) {
 
-    TaskResponse response = new TaskResponse(
-        taskId,
-        calendarId,
-        5,
-        false,  // isBeforeToday
-        "태스크 내용",
-        completed
-    );
-
+    TaskResponse response = taskService.updateTaskCompletion(calendarId, taskId, completed);
     return ResponseEntity.ok(response);
   }
 }

--- a/src/main/java/kr/santanrudolph/everyvent/domain/task/TaskRepository.java
+++ b/src/main/java/kr/santanrudolph/everyvent/domain/task/TaskRepository.java
@@ -1,0 +1,34 @@
+package kr.santanrudolph.everyvent.domain.task;
+
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public interface TaskRepository extends JpaRepository<Task, Long> {
+
+  @Query("""
+      SELECT t
+      FROM Task t
+      JOIN FETCH t.calendar
+      WHERE t.calendar.id = :calendarId
+      ORDER BY t.day ASC
+      """)
+  List<Task> findAllByCalendarId(@Param("calendarId") Long calendarId);
+
+  @Query("""
+      SELECT COUNT(t)
+      FROM Task t
+      WHERE t.calendar.id = :calendarId
+        AND t.day = :day
+      """)
+  long countByCalendarIdAndDay(
+      @Param("calendarId") Long calendarId,
+      @Param("day") LocalDate day
+  );
+
+  void deleteByCalendarId(Long calendarId);
+}

--- a/src/main/java/kr/santanrudolph/everyvent/domain/task/TaskService.java
+++ b/src/main/java/kr/santanrudolph/everyvent/domain/task/TaskService.java
@@ -1,0 +1,240 @@
+package kr.santanrudolph.everyvent.domain.task;
+
+
+import kr.santanrudolph.everyvent.domain.calendar.Calendar;
+import kr.santanrudolph.everyvent.domain.calendar.service.CalendarPolicy;
+import kr.santanrudolph.everyvent.domain.calendar.service.CalendarService;
+import kr.santanrudolph.everyvent.domain.task.dto.TaskCreateRequest;
+import kr.santanrudolph.everyvent.domain.task.dto.TaskResponse;
+import kr.santanrudolph.everyvent.domain.task.dto.TaskUpdateRequest;
+import kr.santanrudolph.everyvent.domain.user.User;
+import kr.santanrudolph.everyvent.domain.user.UserService;
+import kr.santanrudolph.everyvent.global.exception.ErrorCode;
+import kr.santanrudolph.everyvent.global.exception.EveryventException;
+import kr.santanrudolph.everyvent.global.util.TimeUtil;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.DateTimeException;
+import java.time.LocalDate;
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class TaskService {
+
+  private static final int MAX_TASKS_PER_DAY = 3;
+  private static final boolean UNLOCKED = false;
+
+  private final TaskRepository taskRepository;
+  private final CalendarService calendarService;
+  private final UserService userService;
+  private final CalendarPolicy calendarPolicy;
+
+  @Transactional
+  public List<TaskResponse> createTasks(Long calendarId, List<TaskCreateRequest> requests) {
+    User currentUser = userService.getCurrentUser();
+    Calendar calendar = calendarService.findCalendarByIdAndDeletedAtIsNull(calendarId);
+
+    try {
+      calendarPolicy.validateCanUpdate(currentUser, calendar);
+    } catch (EveryventException e) {
+      throw new EveryventException(e.getErrorCode(), "태스크를 생성할 수 없습니다. " + e.getMessage());
+    }
+
+    List<Task> tasks = requestsToTasks(calendar, requests);
+    List<Task> results = taskRepository.saveAll(tasks);
+
+    return results.stream()
+        .map(task -> TaskResponse.from(task, UNLOCKED))
+        .toList();
+  }
+
+  public List<TaskResponse> getTasksAllInformation(Long calendarId) {
+    User currentUser = userService.getCurrentUser();
+    Calendar calendar = calendarService.findCalendarByIdAndDeletedAtIsNull(calendarId);
+
+    try {
+      calendarPolicy.validateCanView(currentUser, calendar);
+    } catch (EveryventException e) {
+      throw new EveryventException(e.getErrorCode(), "태스크를 조회할 수 없습니다. " + e.getMessage());
+    }
+
+    List<Task> tasks = taskRepository.findAllByCalendarId(calendarId);
+
+    return tasks.stream()
+        .map(task -> TaskResponse.from(task, UNLOCKED))
+        .toList();
+  }
+
+
+  public List<TaskResponse> getTasks(Long calendarId) {
+    User currentUser = userService.getCurrentUser();
+    Calendar calendar = calendarService.findCalendarByIdAndDeletedAtIsNull(calendarId);
+
+    try {
+      calendarPolicy.validateCanView(currentUser, calendar);
+    } catch (EveryventException e) {
+      throw new EveryventException(e.getErrorCode(), "태스크를 조회할 수 없습니다. " + e.getMessage());
+    }
+
+    List<Task> tasks = taskRepository.findAllByCalendarId(calendarId);
+
+    return tasks.stream()
+        .map(task -> TaskResponse.from(task, isLocked(calendar, task)))
+        .toList();
+  }
+
+  @Transactional
+  public TaskResponse updateTask(Long calendarId, Long taskId, TaskUpdateRequest request) {
+    User currentUser = userService.getCurrentUser();
+    Calendar calendar = calendarService.findCalendarByIdAndDeletedAtIsNull(calendarId);
+    Task task = findTaskById(taskId);
+
+    try {
+      calendarPolicy.validateCanUpdate(currentUser, calendar);
+      validateTaskBelongsToCalendar(task, calendarId);
+    } catch (EveryventException e) {
+      throw new EveryventException(e.getErrorCode(), "태스크를 수정할 수 없습니다. " + e.getMessage());
+    }
+
+    if (request.content() != null) {
+      task.updateContent(request.content());
+    }
+
+    return TaskResponse.from(task, UNLOCKED);
+  }
+
+  @Transactional
+  public void deleteTask(Long calendarId, Long taskId) {
+    User currentUser = userService.getCurrentUser();
+    Calendar calendar = calendarService.findCalendarByIdAndDeletedAtIsNull(calendarId);
+    Task task = findTaskById(taskId);
+
+    try {
+      calendarPolicy.validateCanUpdate(currentUser, calendar);
+      validateTaskBelongsToCalendar(task, calendarId);
+    } catch (EveryventException e) {
+      throw new EveryventException(e.getErrorCode(), "태스크를 삭제할 수 없습니다. " + e.getMessage());
+    }
+
+    taskRepository.delete(task);
+  }
+
+  @Transactional
+  public void deleteTasksByCalendarId(Long calendarId) {
+    User currentUser = userService.getCurrentUser();
+    Calendar calendar = calendarService.findCalendarByIdAndDeletedAtIsNull(calendarId);
+
+    try {
+      calendarPolicy.validateCanUpdate(currentUser, calendar);
+    } catch (EveryventException e) {
+      throw new EveryventException(e.getErrorCode(), "태스크들을 삭제할 수 없습니다. " + e.getMessage());
+    }
+
+    taskRepository.deleteByCalendarId(calendarId);
+  }
+
+  @Transactional
+  public TaskResponse updateTaskCompletion(Long calendarId, Long taskId, Boolean completed) {
+    User currentUser = userService.getCurrentUser();
+    Calendar calendar = calendarService.findCalendarByIdAndDeletedAtIsNull(calendarId);
+    Task task = findTaskById(taskId);
+
+    try {
+      calendarPolicy.validateCanView(currentUser, calendar);
+      validateTaskBelongsToCalendar(task, calendarId);
+    } catch (EveryventException e) {
+      throw new EveryventException(e.getErrorCode(), "태스크 완료 상태를 변경할 수 없습니다. " + e.getMessage());
+    }
+
+    if (isLocked(calendar, task)) {
+      throw new EveryventException(ErrorCode.FORBIDDEN, "태스크 완료 상태를 변경할 수 없습니다. 아직 열리지 않았습니다.");
+    }
+
+    if (completed) {
+      task.complete();
+    } else {
+      task.uncomplete();
+    }
+
+    return TaskResponse.from(task, false);
+  }
+
+  private Task findTaskById(Long taskId) {
+    return taskRepository.findById(taskId)
+        .orElseThrow(() -> new EveryventException(ErrorCode.NOT_FOUND, "태스크를 찾을 수 없습니다."));
+  }
+
+  private List<Task> requestsToTasks(Calendar calendar, List<TaskCreateRequest> requests) {
+    return requests.stream()
+        .map(request -> {
+          LocalDate taskDay = parseTaskDay(calendar, request);
+
+          validateDateWithinCalendarRange(calendar, taskDay);
+          validateTaskLimit(calendar, taskDay);
+
+          return Task.createTask(calendar, taskDay, request.content());
+        })
+        .toList();
+  }
+
+  private LocalDate parseTaskDay(Calendar calendar, TaskCreateRequest request) {
+    LocalDate startDay = calendar.getStartDate();
+    try {
+      return startDay.withDayOfMonth(request.day());
+    } catch (DateTimeException e) {
+      throw new EveryventException(
+          ErrorCode.INVALID_INPUT,
+          String.format("%d월에는 %d일이 존재하지 않습니다.", startDay.getMonthValue(), request.day())
+      );
+    }
+  }
+
+  private void validateTaskLimit(Calendar calendar, LocalDate day) {
+    long calendarId = calendar.getId();
+    long count = taskRepository.countByCalendarIdAndDay(calendarId, day);
+
+    if (count >= MAX_TASKS_PER_DAY) {
+      throw new EveryventException(
+          ErrorCode.INVALID_INPUT,
+          String.format("하루에 최대 %d개의 태스크만 생성할 수 있습니다.", MAX_TASKS_PER_DAY)
+      );
+    }
+  }
+
+  private void validateDateWithinCalendarRange(Calendar calendar, LocalDate day) {
+    if (day.isBefore(calendar.getStartDate()) || day.isAfter(calendar.getEndDate())) {
+      throw new EveryventException(
+          ErrorCode.INVALID_INPUT, "태스크 날짜는 캘린더 기간 내에 있어야 합니다."
+      );
+    }
+  }
+
+  private void validateTaskBelongsToCalendar(Task task, Long calendarId) {
+    if (!task.getCalendar().getId().equals(calendarId)) {
+      throw new EveryventException(ErrorCode.INVALID_INPUT, "해당 태스크는 이 캘린더에 속하지 않습니다.");
+    }
+  }
+
+  private boolean isLocked(Calendar calendar, Task task) {
+    LocalDate now = TimeUtil.today();
+
+    LocalDate previewStartDay = calendar.getPreviewStartDay();
+    LocalDate previewEndDay = calendar.getPreviewEndDay();
+
+    // 미리보기 범위 안에 있으면 잠겨있지 않음
+    if (previewStartDay != null && previewEndDay != null) {
+      if (TimeUtil.isInRange(previewStartDay, previewEndDay, task.getDay())) {
+        return false;
+      }
+    }
+
+    // 해당 날짜가 미래면 잠겨있음
+    return task.getDay().isAfter(now);
+  }
+}

--- a/src/main/java/kr/santanrudolph/everyvent/domain/task/TaskService.java
+++ b/src/main/java/kr/santanrudolph/everyvent/domain/task/TaskService.java
@@ -145,16 +145,7 @@ public class TaskService {
     Calendar calendar = calendarService.findCalendarByIdAndDeletedAtIsNull(calendarId);
     Task task = findTaskById(taskId);
 
-    try {
-      calendarPolicy.validateCanView(currentUser, calendar);
-      validateTaskBelongsToCalendar(task, calendarId);
-    } catch (EveryventException e) {
-      throw new EveryventException(e.getErrorCode(), "태스크 완료 상태를 변경할 수 없습니다. " + e.getMessage());
-    }
-
-    if (isLocked(calendar, task)) {
-      throw new EveryventException(ErrorCode.FORBIDDEN, "태스크 완료 상태를 변경할 수 없습니다. 아직 열리지 않았습니다.");
-    }
+    validateCanComplete(currentUser, calendar, task);
 
     if (completed) {
       task.complete();
@@ -221,6 +212,19 @@ public class TaskService {
     }
   }
 
+  private void validateCanComplete(User currentUser, Calendar calendar, Task task) {
+    try {
+      calendarPolicy.validateCanView(currentUser, calendar);
+      validateTaskBelongsToCalendar(task, calendar.getId());
+    } catch (EveryventException e) {
+      throw new EveryventException(e.getErrorCode(), "태스크 완료 상태를 변경할 수 없습니다. " + e.getMessage());
+    }
+
+    if (isFutureTask(task)) {
+      throw new EveryventException(ErrorCode.FORBIDDEN, "태스크 완료 상태를 변경할 수 없습니다. 미래의 태스크입니다.");
+    }
+  }
+
   private boolean isLocked(Calendar calendar, Task task) {
     LocalDate now = TimeUtil.today();
 
@@ -236,5 +240,9 @@ public class TaskService {
 
     // 해당 날짜가 미래면 잠겨있음
     return task.getDay().isAfter(now);
+  }
+
+  private boolean isFutureTask(Task task) {
+    return TimeUtil.isAfter(task.getDay(), TimeUtil.today());
   }
 }

--- a/src/main/java/kr/santanrudolph/everyvent/domain/task/TaskService.java
+++ b/src/main/java/kr/santanrudolph/everyvent/domain/task/TaskService.java
@@ -19,7 +19,8 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.DateTimeException;
 import java.time.LocalDate;
-import java.util.List;
+import java.util.*;
+import java.util.stream.Collectors;
 
 @Slf4j
 @Service
@@ -148,12 +149,15 @@ public class TaskService {
   }
 
   private List<Task> requestsToTasks(Calendar calendar, List<TaskCreateRequest> requests) {
+    Map<Integer, Long> requestedTaskCountByDay = requests.stream()
+        .collect(Collectors.groupingBy(TaskCreateRequest::day, Collectors.counting()));
+
     return requests.stream()
         .map(request -> {
           LocalDate taskDay = parseTaskDay(calendar, request);
 
           validateDateWithinCalendarRange(calendar, taskDay);
-          validateTaskLimit(calendar, taskDay);
+          validateTaskLimit(calendar, taskDay, requestedTaskCountByDay.get(request.day()));
 
           return Task.createTask(calendar, taskDay, request.content());
         })
@@ -172,11 +176,11 @@ public class TaskService {
     }
   }
 
-  private void validateTaskLimit(Calendar calendar, LocalDate day) {
+  private void validateTaskLimit(Calendar calendar, LocalDate day, long requestedTaskCountByDay) {
     long calendarId = calendar.getId();
     long count = taskRepository.countByCalendarIdAndDay(calendarId, day);
 
-    if (count >= MAX_TASKS_PER_DAY) {
+    if (count + requestedTaskCountByDay > MAX_TASKS_PER_DAY) {
       throw new EveryventException(
           ErrorCode.INVALID_INPUT,
           String.format("하루에 최대 %d개의 태스크만 생성할 수 있습니다.", MAX_TASKS_PER_DAY)

--- a/src/main/java/kr/santanrudolph/everyvent/domain/task/TaskService.java
+++ b/src/main/java/kr/santanrudolph/everyvent/domain/task/TaskService.java
@@ -126,20 +126,6 @@ public class TaskService {
   }
 
   @Transactional
-  public void deleteTasksByCalendarId(Long calendarId) {
-    User currentUser = userService.getCurrentUser();
-    Calendar calendar = calendarService.findCalendarByIdAndDeletedAtIsNull(calendarId);
-
-    try {
-      calendarPolicy.validateCanUpdate(currentUser, calendar);
-    } catch (EveryventException e) {
-      throw new EveryventException(e.getErrorCode(), "태스크들을 삭제할 수 없습니다. " + e.getMessage());
-    }
-
-    taskRepository.deleteByCalendarId(calendarId);
-  }
-
-  @Transactional
   public TaskResponse updateTaskCompletion(Long calendarId, Long taskId, Boolean completed) {
     User currentUser = userService.getCurrentUser();
     Calendar calendar = calendarService.findCalendarByIdAndDeletedAtIsNull(calendarId);

--- a/src/main/java/kr/santanrudolph/everyvent/domain/task/dto/TaskResponse.java
+++ b/src/main/java/kr/santanrudolph/everyvent/domain/task/dto/TaskResponse.java
@@ -8,18 +8,18 @@ public record TaskResponse(
     Long id,
     Long calendarId,
     int day,
-    boolean isLock,
+    boolean isLocked,
     String content,
     Boolean completed // null 상태 표현을 위함
 ) {
-  public static TaskResponse from(Task task, boolean isLock) {
+  public static TaskResponse from(Task task, boolean isLocked) {
     return new TaskResponse(
         task.getId(),
         task.getCalendar().getId(),
         task.getDay().getDayOfMonth(),
-        isLock,
-        isLock ? null : task.getContent(),
-        isLock ? null : task.getCompleted()
+        isLocked,
+        isLocked ? null : task.getContent(),
+        isLocked ? null : task.getCompleted()
     );
   }
 }

--- a/src/main/java/kr/santanrudolph/everyvent/domain/task/dto/TaskUpdateRequest.java
+++ b/src/main/java/kr/santanrudolph/everyvent/domain/task/dto/TaskUpdateRequest.java
@@ -1,8 +1,10 @@
 package kr.santanrudolph.everyvent.domain.task.dto;
 
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 
 public record TaskUpdateRequest(
+    @NotBlank(message = "태스크 내용은 필수입니다.")
     @Size(max = 500, message = "태스크 내용은 최대 500자까지 입력 가능합니다.")
     String content
 ) {


### PR DESCRIPTION
## 📝 무엇을 했나요?
태스크 관련 기능들을 구현했어요.
구현이 완료된 API 엔드포인트들은 다음과 같아요.

- **태스크 생성**: `POST /api/calendars/{calendarId}/tasks`
- **캘린더의 태스크들 조회:** `GET /api/calendars/{calendarId}/tasks`
- **개발용 캘린더의 태스크들 조회**: `GET /api/calendars/{calendarId}/tasks/all `
(개발용이라 모든 필드가 unlock입니다.)
- **태스크 내용 수정**: `PATCH /api/calendars/{calendarId}/tasks/{taskId}`
- **태스크 삭제**: `DELETE /api/calendars/{calendarId}/tasks/{taskId}`
- **태스크 상태 변경**: `PATCH /api/calendars/{calendarId}/tasks/{taskId}/complete`

## 💭 고민 지점과 리뷰 포인트
@bomii1 , @meteorqz6 
현재 비즈니스 규칙상 이번 달의 캘린더와 태스크를 생성할 수 없어,
화면 구현 시 진행 중인 캘린더 / 태스크 데이터를 확인하기 어려울 수 있을 것 같다는 생각을 했어요.

그래서 화면 구현을 위해 DB에 미리 들어있으면 좋은 캘린더나 태스크 데이터가 있다면 알려주세요.
말씀 주시면 해당 데이터를 기준으로 맞춰둘게요!

만약 별도의 데이터 요청이 번거롭다면,
아래와 같이 비즈니스 규칙을 임시로 완화하는 방향도 고려하고 있어요!

1. 캘린더 생성은 다음달 부터 가능 (이번 달 캘린더 생성 불가, 다음 달 부터 가능)
2. 태스크 생성, 수정, 삭제는 다음달 캘린더의 태스크만 가능 (이번달 캘린더는 완료처리만 가능)
3. 태스크 완료 상태 변경은 오늘 날짜까지만 가능 (미래의 태스크는 완료처리 불가능)

## 🔗 관련 이슈
Close #72 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 캘린더 페이지네이션 조회 및 월별 캘린더 조회 추가
  * 개인 캘린더 수정 및 삭제 기능 추가
  * 업무 생성(복수 지원), 전체 조회(모든 정보), 일별 조회 기능 추가
  * 업무 내용 수정 및 완료/미완료 토글 기능 추가
  * 잠금(locked)/잠금해제 표시를 포함한 업무 잠금 로직 제공
  * API 엔드포인트 구조 및 설명 정리

* **버그 수정/검증**
  * 업무 내용에 대한 입력 검증(빈값 차단) 강화

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->