### PR TITLE
feat(scrap): 스크랩 기능 구현

### DIFF
--- a/src/main/java/kr/santanrudolph/everyvent/domain/calendar/controller/CalendarController.java
+++ b/src/main/java/kr/santanrudolph/everyvent/domain/calendar/controller/CalendarController.java
@@ -29,235 +29,237 @@ import java.util.List;
 @RequiredArgsConstructor
 public class CalendarController {
 
-    private final CalendarService calendarService;
+  private final CalendarService calendarService;
 
-    @Operation(summary = "캘린더 생성", description = "유저가 내 캘린더(PERSONAL) 생성")
-    @ApiResponses({
-            @ApiResponse(responseCode = "201", description = "생성 성공"),
-            @ApiResponse(responseCode = "400", description = "INVALID_INPUT"),
-            @ApiResponse(responseCode = "409", description = "ALREADY_EXIST: 캘린더 3개 이상")
-    })
-    @PostMapping
-    public ResponseEntity<CalendarDetailResponse> createCalendar(
-            @Valid @RequestBody CalendarCreateRequest request) {
+  @Operation(summary = "캘린더 생성", description = "유저가 내 캘린더(PERSONAL) 생성")
+  @ApiResponses({
+      @ApiResponse(responseCode = "201", description = "생성 성공"),
+      @ApiResponse(responseCode = "400", description = "INVALID_INPUT"),
+      @ApiResponse(responseCode = "409", description = "ALREADY_EXIST: 캘린더 3개 이상")
+  })
+  @PostMapping
+  public ResponseEntity<CalendarDetailResponse> createCalendar(
+      @Valid @RequestBody CalendarCreateRequest request) {
 
-        CalendarDetailResponse response = calendarService.createPersonalCalendar(request);
-        return ResponseEntity.status(HttpStatus.CREATED).body(response);
-    }
+    CalendarDetailResponse response = calendarService.createPersonalCalendar(request);
+    return ResponseEntity.status(HttpStatus.CREATED).body(response);
+  }
 
-    @Operation(summary = "내 캘린더 목록 조회 (무한스크롤)", description = """
-            커서 기반 무한스크롤로 내 캘린더 목록을 월별로 그루핑하여 조회합니다.
-            (내가 만든 캘린더, 스크랩한 캘린더, 배포받은 캘린더)
-            - cursor: 이전 응답값에서 받은 nextCursor (YYYY-MM 형식, 첫 요청시 생략)
-            - size: 페이지 크기 (달 갯수를 의미합니다. 현재 예시는 7월~12월까지이므로 size=6 입니다.)""")
-    @GetMapping()
-    public ResponseEntity<CalendarScrollResponse> getMyCalendars(
-            @RequestParam(required = false) YearMonth cursor,
-            @RequestParam(required = false, defaultValue = "10") Integer size) {
+  @Operation(summary = "내 캘린더 목록 조회 (무한스크롤)", description = """
+      커서 기반 무한스크롤로 내 캘린더 목록을 월별로 그루핑하여 조회합니다.
+      (내가 만든 캘린더, 스크랩한 캘린더, 배포받은 캘린더)
+      - cursor: 이전 응답값에서 받은 nextCursor (YYYY-MM 형식, 첫 요청시 생략)
+      - size: 페이지 크기 (달 갯수를 의미합니다. 현재 예시는 7월~12월까지이므로 size=6 입니다.)""")
+  @GetMapping()
+  public ResponseEntity<CalendarScrollResponse> getMyCalendars(
+      @RequestParam(required = false) YearMonth cursor,
+      @RequestParam(required = false, defaultValue = "10") Integer size) {
 
-        CalendarScrollResponse response = calendarService.getMyCalendars(cursor, size);
-        return ResponseEntity.ok(response);
-    }
+    CalendarScrollResponse response = calendarService.getMyCalendars(cursor, size);
+    return ResponseEntity.ok(response);
+  }
 
-    @Operation(summary = "캘린더 개별 조회", description = "공개범위에 따라 접근 제어. 내 캘린더 또는 권한 있는 캘린더만 조회 가능")
-    @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "조회 성공"),
-            @ApiResponse(responseCode = "403", description = "FORBIDDEN: 접근 권한 없음"),
-            @ApiResponse(responseCode = "404", description = "NOT_FOUND")
-    })
-    @GetMapping("/{calendarId}")
-    public ResponseEntity<CalendarDetailResponse> getCalendar(@PathVariable Long calendarId) {
+  @Operation(summary = "캘린더 개별 조회", description = "공개범위에 따라 접근 제어. 내 캘린더 또는 권한 있는 캘린더만 조회 가능")
+  @ApiResponses({
+      @ApiResponse(responseCode = "200", description = "조회 성공"),
+      @ApiResponse(responseCode = "403", description = "FORBIDDEN: 접근 권한 없음"),
+      @ApiResponse(responseCode = "404", description = "NOT_FOUND")
+  })
+  @GetMapping("/{calendarId}")
+  public ResponseEntity<CalendarDetailResponse> getCalendar(@PathVariable Long calendarId) {
 
-        CalendarDetailResponse response = calendarService.getCalendar(calendarId);
-        return ResponseEntity.ok(response);
-    }
+    CalendarDetailResponse response = calendarService.getCalendar(calendarId);
+    return ResponseEntity.ok(response);
+  }
 
-    @Operation(
-            summary = "월별 통합 캘린더 조회",
-            description = """
-                      특정 년월의 내 모든 캘린더를 조회합니다. (최대 4개)
-                      - 조회 결과가 없을 경우 빈 배열([])을 반환합니다.
-                      - 본인의 캘린더만 조회 가능합니다.
-                    """
-    )
-    @GetMapping("/monthly")
-    public ResponseEntity<List<CalendarDetailResponse>> getMonthlyCalendars(
-            @RequestParam
-            @DateTimeFormat(pattern = "yyyy-MM")
-            YearMonth yearMonth
-    ) {
-        List<CalendarDetailResponse> response = calendarService.getMonthlyCalendars(yearMonth);
-        return ResponseEntity.ok(response);
-    }
+  @Operation(
+      summary = "월별 통합 캘린더 조회",
+      description = """
+            특정 년월의 내 모든 캘린더를 조회합니다. (최대 4개)
+            - 조회 결과가 없을 경우 빈 배열([])을 반환합니다.
+            - 본인의 캘린더만 조회 가능합니다.
+          """
+  )
+  @GetMapping("/monthly")
+  public ResponseEntity<List<CalendarDetailResponse>> getMonthlyCalendars(
+      @RequestParam
+      @DateTimeFormat(pattern = "yyyy-MM")
+      YearMonth yearMonth
+  ) {
+    List<CalendarDetailResponse> response = calendarService.getMonthlyCalendars(yearMonth);
+    return ResponseEntity.ok(response);
+  }
 
-    @Operation(summary = "내가 만든 캘린더 수정", description = "제목, 설명, 공개범위, 색상, 카테고리를 수정할 수 있습니다. 수정이 필요한 필드만 포함해서 보냅니다. (모든 " +
-            "필드를" +
-            " " +
-            "추가하지 않아도 됨)")
-    @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "수정 성공"),
-            @ApiResponse(responseCode = "400", description = "INVALID_INPUT: 스크랩/배포본 수정 제한"),
-            @ApiResponse(responseCode = "403", description = "FORBIDDEN: 소유자 아님"),
-            @ApiResponse(responseCode = "404", description = "NOT_FOUND")
-    })
-    @PatchMapping("/{calendarId}")
-    public ResponseEntity<CalendarDetailResponse> updateCalendar(
-            @PathVariable Long calendarId,
-            @Valid @RequestBody CalendarUpdateRequest request) {
+  @Operation(summary = "내가 만든 캘린더 수정", description = "제목, 설명, 공개범위, 색상, 카테고리를 수정할 수 있습니다. 수정이 필요한 필드만 포함해서 보냅니다. (모든 " +
+      "필드를" +
+      " " +
+      "추가하지 않아도 됨)")
+  @ApiResponses({
+      @ApiResponse(responseCode = "200", description = "수정 성공"),
+      @ApiResponse(responseCode = "400", description = "INVALID_INPUT: 스크랩/배포본 수정 제한"),
+      @ApiResponse(responseCode = "403", description = "FORBIDDEN: 소유자 아님"),
+      @ApiResponse(responseCode = "404", description = "NOT_FOUND")
+  })
+  @PatchMapping("/{calendarId}")
+  public ResponseEntity<CalendarDetailResponse> updateCalendar(
+      @PathVariable Long calendarId,
+      @Valid @RequestBody CalendarUpdateRequest request) {
 
-        CalendarDetailResponse response = calendarService.updatePersonalCalendar(calendarId, request);
-        return ResponseEntity.ok(response);
-    }
-
-
-    @Operation(summary = "캘린더 삭제", description = "배포받은 공식 캘린더도 삭제 가능합니다.")
-    @ApiResponses({
-            @ApiResponse(responseCode = "204", description = "삭제 성공"),
-            @ApiResponse(responseCode = "403", description = "FORBIDDEN: 소유자 아님"),
-            @ApiResponse(responseCode = "404", description = "NOT_FOUND")
-    })
-    @DeleteMapping("/{calendarId}")
-    public ResponseEntity<Void> deleteCalendar(@PathVariable Long calendarId) {
-        calendarService.deleteCalendar(calendarId);
-        return ResponseEntity.noContent().build();
-    }
+    CalendarDetailResponse response = calendarService.updatePersonalCalendar(calendarId, request);
+    return ResponseEntity.ok(response);
+  }
 
 
-    // todo: 캘린더 스크랩
-    @Operation(summary = "캘린더 스크랩", description = "다른 사용자의 공개 캘린더를 내 컬렉션에 저장합니다.")
-    @ApiResponses({
-            @ApiResponse(responseCode = "201", description = "스크랩 성공"),
-            @ApiResponse(responseCode = "400", description = "INVALID_INPUT: 자기 캘린더 스크랩 시도"),
-            @ApiResponse(responseCode = "403", description = "FORBIDDEN: 스크랩 권한 없음"),
-            @ApiResponse(responseCode = "404", description = "NOT_FOUND"),
-            @ApiResponse(responseCode = "409", description = "ALREADY_EXIST: 이미 스크랩함")
-    })
-    @PostMapping("/{calendarId}/scrap")
-    public ResponseEntity<CalendarDetailResponse> scrapCalendar(
-            @PathVariable Long calendarId) {
+  @Operation(summary = "캘린더 삭제", description = "배포받은 공식 캘린더도 삭제 가능합니다.")
+  @ApiResponses({
+      @ApiResponse(responseCode = "204", description = "삭제 성공"),
+      @ApiResponse(responseCode = "403", description = "FORBIDDEN: 소유자 아님"),
+      @ApiResponse(responseCode = "404", description = "NOT_FOUND")
+  })
+  @DeleteMapping("/{calendarId}")
+  public ResponseEntity<Void> deleteCalendar(@PathVariable Long calendarId) {
+    calendarService.softDeleteCalendar(calendarId);
+    return ResponseEntity.noContent().build();
+  }
 
-        CalendarDetailResponse response = new CalendarDetailResponse(
-                50L,
-                1L,          // 현재 유저 ID
-                "다른 유저 캘린더",
-                "스크랩한 캘린더 설명",
-                LocalDate.of(2024, 12, 1),
-                LocalDate.of(2024, 12, 25),
-                LocalDate.of(2024, 12, 5),
-                LocalDate.of(2024, 12, 20),
-                Visibility.PRIVATE,  // 스크랩한 캘린더는 항상 PRIVATE
-                CalendarColor.LAVENDER,
-                Category.HOBBY,
-                calendarId,  // 원본 캘린더 ID
-                CalendarType.SCRAPED,
-                false,        // 스크랩된 캘린더는 재스크랩 불가
-                1L
-        );
 
-        return ResponseEntity.status(HttpStatus.CREATED).body(response);
-    }
+  @Operation(summary = "캘린더 스크랩", description = "다른 사용자의 공개 캘린더를 내 컬렉션에 저장합니다.")
+  @ApiResponses({
+      @ApiResponse(responseCode = "201", description = "스크랩 성공"),
+      @ApiResponse(responseCode = "400", description = "INVALID_INPUT: 자기 캘린더 스크랩 시도"),
+      @ApiResponse(responseCode = "403", description = "FORBIDDEN: 스크랩 권한 없음"),
+      @ApiResponse(responseCode = "404", description = "NOT_FOUND"),
+      @ApiResponse(responseCode = "409", description = "ALREADY_EXIST: 이미 스크랩함")
+  })
+  @PostMapping("/{calendarId}/scrap")
+  public ResponseEntity<CalendarDetailResponse> scrapCalendar(
+      @PathVariable Long calendarId,
+      @Valid @RequestBody ScrapCalendarRequest request) {
 
-    @Operation(summary = "스크랩한 캘린더 색상 변경", description = "스크랩한 캘린더의 색상만 변경 가능")
-    @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "색상 변경 성공"),
-            @ApiResponse(responseCode = "400", description = "INVALID_INPUT: 스크랩한 캘린더가 아님"),
-            @ApiResponse(responseCode = "403", description = "FORBIDDEN: 소유자 아님"),
-            @ApiResponse(responseCode = "404", description = "NOT_FOUND")
-    })
-    @PatchMapping("/{calendarId}/scrap")
-    public ResponseEntity<CalendarDetailResponse> updateScrapColor(
-            @PathVariable Long calendarId,
-            @Valid @RequestBody ScrapCalendarRequest request) {
+    CalendarDetailResponse response = calendarService.scrapCalendar(calendarId, request);
+    return ResponseEntity.status(HttpStatus.CREATED).body(response);
+  }
 
-        CalendarDetailResponse response = calendarService.updateScrapColor(calendarId, request);
-        return ResponseEntity.ok(response);
-    }
+  @Operation(summary = "스크랩한 캘린더 색상 변경", description = "스크랩한 캘린더의 색상만 변경 가능")
+  @ApiResponses({
+      @ApiResponse(responseCode = "200", description = "색상 변경 성공"),
+      @ApiResponse(responseCode = "400", description = "INVALID_INPUT: 스크랩한 캘린더가 아님"),
+      @ApiResponse(responseCode = "403", description = "FORBIDDEN: 소유자 아님"),
+      @ApiResponse(responseCode = "404", description = "NOT_FOUND")
+  })
+  @PatchMapping("/{calendarId}/scrap")
+  public ResponseEntity<CalendarDetailResponse> updateScrapColor(
+      @PathVariable Long calendarId,
+      @Valid @RequestBody ScrapCalendarRequest request) {
 
-    // todo: 캘린더 스크랩 취소
-    @Operation(summary = "스크랩 취소", description = "스크랩한 캘린더를 삭제")
-    @ApiResponses({
-            @ApiResponse(responseCode = "204", description = "스크랩 취소 성공"),
-            @ApiResponse(responseCode = "400", description = "INVALID_INPUT: 스크랩한 캘린더가 아님"),
-            @ApiResponse(responseCode = "403", description = "FORBIDDEN: 소유자 아님"),
-            @ApiResponse(responseCode = "404", description = "NOT_FOUND")
-    })
-    @DeleteMapping("/{calendarId}/scrap")
-    public ResponseEntity<Void> cancelScrap(@PathVariable Long calendarId) {
-        return ResponseEntity.noContent().build();
-    }
+    CalendarDetailResponse response = calendarService.updateScrapColor(calendarId, request);
+    return ResponseEntity.ok(response);
+  }
 
-    // todo: 특정 캘린더를 스크랩한 사람 목록 조회하기
+  @Operation(summary = "스크랩 취소", description = "스크랩한 캘린더를 삭제. 원본 캘린더의 ID로 요청합니다.")
+  @ApiResponses({
+      @ApiResponse(responseCode = "204", description = "스크랩 취소 성공"),
+      @ApiResponse(responseCode = "404", description = "NOT_FOUND: 스크랩하지 않은 캘린더")
+  })
+  @DeleteMapping("/{calendarId}/scrap")
+  public ResponseEntity<Void> cancelScrap(@PathVariable Long calendarId) {
+    calendarService.cancelScrap(calendarId);
+    return ResponseEntity.noContent().build();
+  }
 
-    // todo: 이번 달 인기 캘린더 목록 조회
-    @Operation(summary = "이번달 인기 캘린더 목록 조회 (비회원 접근 가능)", description = "이번달 인기 캘린더 30개를 조회합니다.\n" +
-            "전체공개 캘린더만 조회됩니다.")
-    @GetMapping("/popular")
-    public ResponseEntity<List<CalendarListResponse>> getPopularCalendars() {
+  @Operation(
+      summary = "캘린더를 스크랩한 사람 목록 조회 (무한스크롤)",
+      description = """
+          커서 기반 무한스크롤로 캘린더를 스크랩한 사용자 목록을 조회합니다.
+          - cursor: 이전 응답값에서 받은 nextCursor (첫 요청시 생략)
+          - size: 페이지 크기 (기본값: 20)
+          """
+  )
+  @ApiResponses({
+      @ApiResponse(responseCode = "200", description = "조회 성공"),
+      @ApiResponse(responseCode = "403", description = "FORBIDDEN: 접근 권한 없음"),
+      @ApiResponse(responseCode = "404", description = "NOT_FOUND")
+  })
+  @GetMapping("/{calendarId}/scrappers")
+  public ResponseEntity<ScrapperScrollResponse> getScrappers(
+      @PathVariable Long calendarId,
+      @RequestParam(required = false) Long cursor,
+      @RequestParam(required = false, defaultValue = "20") Integer size) {
 
-        List<CalendarListResponse> response = List.of(
-                new CalendarListResponse(
-                        101L, 11L, "인기 캘린더 1", "설명",
-                        LocalDate.of(2025, 12, 1), LocalDate.of(2025, 12, 25),
-                        Visibility.PUBLIC, CalendarColor.BLUE, Category.CHALLENGE,
-                        null, CalendarType.PERSONAL, 150L
-                ),
-                new CalendarListResponse(
-                        102L, 12L, "인기 캘린더 2", "설명",
-                        LocalDate.of(2025, 12, 1), LocalDate.of(2025, 12, 25),
-                        Visibility.PUBLIC, CalendarColor.PEACH, Category.HOBBY,
-                        null, CalendarType.PERSONAL, 120L
-                ),
-                new CalendarListResponse(
-                        103L, 13L, "인기 캘린더 3", "설명",
-                        LocalDate.of(2025, 12, 1), LocalDate.of(2025, 12, 25),
-                        Visibility.PUBLIC, CalendarColor.MINT, Category.CHALLENGE,
-                        null, CalendarType.PERSONAL, 100L
-                ),
-                new CalendarListResponse(
-                        104L, 14L, "인기 캘린더 4", "설명",
-                        LocalDate.of(2025, 12, 1), LocalDate.of(2025, 12, 25),
-                        Visibility.PUBLIC, CalendarColor.LAVENDER, Category.HOBBY,
-                        null, CalendarType.PERSONAL, 90L
-                ),
-                new CalendarListResponse(
-                        105L, 15L, "인기 캘린더 5", "설명",
-                        LocalDate.of(2025, 12, 1), LocalDate.of(2025, 12, 25),
-                        Visibility.PUBLIC, CalendarColor.YELLOW, Category.CHALLENGE,
-                        null, CalendarType.PERSONAL, 85L
-                ),
-                new CalendarListResponse(
-                        106L, 16L, "인기 캘린더 6", "설명",
-                        LocalDate.of(2025, 12, 1), LocalDate.of(2025, 12, 25),
-                        Visibility.PUBLIC, CalendarColor.BLUE, Category.HOBBY,
-                        null, CalendarType.PERSONAL, 75L
-                ),
-                new CalendarListResponse(
-                        107L, 17L, "인기 캘린더 7", "설명",
-                        LocalDate.of(2025, 12, 1), LocalDate.of(2025, 12, 25),
-                        Visibility.PUBLIC, CalendarColor.PEACH, Category.CHALLENGE,
-                        null, CalendarType.PERSONAL, 70L
-                ),
-                new CalendarListResponse(
-                        108L, 18L, "인기 캘린더 8", "설명",
-                        LocalDate.of(2025, 12, 1), LocalDate.of(2025, 12, 25),
-                        Visibility.PUBLIC, CalendarColor.MINT, Category.HOBBY,
-                        null, CalendarType.PERSONAL, 65L
-                ),
-                new CalendarListResponse(
-                        109L, 19L, "인기 캘린더 9", "설명",
-                        LocalDate.of(2025, 12, 1), LocalDate.of(2025, 12, 25),
-                        Visibility.PUBLIC, CalendarColor.LAVENDER, Category.CHALLENGE,
-                        null, CalendarType.PERSONAL, 60L
-                ),
-                new CalendarListResponse(
-                        110L, 20L, "인기 캘린더 10", "설명",
-                        LocalDate.of(2025, 12, 1), LocalDate.of(2025, 12, 25),
-                        Visibility.PUBLIC, CalendarColor.YELLOW, Category.HOBBY,
-                        null, CalendarType.PERSONAL, 55L
-                )
-        );
+    ScrapperScrollResponse response = calendarService.getScrappers(calendarId, cursor, size);
+    return ResponseEntity.ok(response);
+  }
 
-        return ResponseEntity.ok(response);
-    }
+  // todo: 이번 달 인기 캘린더 목록 조회
+  @Operation(summary = "이번달 인기 캘린더 목록 조회 (비회원 접근 가능)", description = "이번달 인기 캘린더 30개를 조회합니다.\n" +
+      "전체공개 캘린더만 조회됩니다.")
+  @GetMapping("/popular")
+  public ResponseEntity<List<CalendarListResponse>> getPopularCalendars() {
+
+    List<CalendarListResponse> response = List.of(
+        new CalendarListResponse(
+            101L, 11L, "인기 캘린더 1", "설명",
+            LocalDate.of(2025, 12, 1), LocalDate.of(2025, 12, 25),
+            Visibility.PUBLIC, CalendarColor.BLUE, Category.CHALLENGE,
+            null, CalendarType.PERSONAL, 150L
+        ),
+        new CalendarListResponse(
+            102L, 12L, "인기 캘린더 2", "설명",
+            LocalDate.of(2025, 12, 1), LocalDate.of(2025, 12, 25),
+            Visibility.PUBLIC, CalendarColor.PEACH, Category.HOBBY,
+            null, CalendarType.PERSONAL, 120L
+        ),
+        new CalendarListResponse(
+            103L, 13L, "인기 캘린더 3", "설명",
+            LocalDate.of(2025, 12, 1), LocalDate.of(2025, 12, 25),
+            Visibility.PUBLIC, CalendarColor.MINT, Category.CHALLENGE,
+            null, CalendarType.PERSONAL, 100L
+        ),
+        new CalendarListResponse(
+            104L, 14L, "인기 캘린더 4", "설명",
+            LocalDate.of(2025, 12, 1), LocalDate.of(2025, 12, 25),
+            Visibility.PUBLIC, CalendarColor.LAVENDER, Category.HOBBY,
+            null, CalendarType.PERSONAL, 90L
+        ),
+        new CalendarListResponse(
+            105L, 15L, "인기 캘린더 5", "설명",
+            LocalDate.of(2025, 12, 1), LocalDate.of(2025, 12, 25),
+            Visibility.PUBLIC, CalendarColor.YELLOW, Category.CHALLENGE,
+            null, CalendarType.PERSONAL, 85L
+        ),
+        new CalendarListResponse(
+            106L, 16L, "인기 캘린더 6", "설명",
+            LocalDate.of(2025, 12, 1), LocalDate.of(2025, 12, 25),
+            Visibility.PUBLIC, CalendarColor.BLUE, Category.HOBBY,
+            null, CalendarType.PERSONAL, 75L
+        ),
+        new CalendarListResponse(
+            107L, 17L, "인기 캘린더 7", "설명",
+            LocalDate.of(2025, 12, 1), LocalDate.of(2025, 12, 25),
+            Visibility.PUBLIC, CalendarColor.PEACH, Category.CHALLENGE,
+            null, CalendarType.PERSONAL, 70L
+        ),
+        new CalendarListResponse(
+            108L, 18L, "인기 캘린더 8", "설명",
+            LocalDate.of(2025, 12, 1), LocalDate.of(2025, 12, 25),
+            Visibility.PUBLIC, CalendarColor.MINT, Category.HOBBY,
+            null, CalendarType.PERSONAL, 65L
+        ),
+        new CalendarListResponse(
+            109L, 19L, "인기 캘린더 9", "설명",
+            LocalDate.of(2025, 12, 1), LocalDate.of(2025, 12, 25),
+            Visibility.PUBLIC, CalendarColor.LAVENDER, Category.CHALLENGE,
+            null, CalendarType.PERSONAL, 60L
+        ),
+        new CalendarListResponse(
+            110L, 20L, "인기 캘린더 10", "설명",
+            LocalDate.of(2025, 12, 1), LocalDate.of(2025, 12, 25),
+            Visibility.PUBLIC, CalendarColor.YELLOW, Category.HOBBY,
+            null, CalendarType.PERSONAL, 55L
+        )
+    );
+
+    return ResponseEntity.ok(response);
+  }
 }
 

--- a/src/main/java/kr/santanrudolph/everyvent/domain/calendar/dto/ScrapperResponse.java
+++ b/src/main/java/kr/santanrudolph/everyvent/domain/calendar/dto/ScrapperResponse.java
@@ -1,0 +1,18 @@
+package kr.santanrudolph.everyvent.domain.calendar.dto;
+
+import kr.santanrudolph.everyvent.domain.user.User;
+
+public record ScrapperResponse(
+    Long id,
+    String nickname,
+    String introduction
+) {
+
+  public static ScrapperResponse from(User user) {
+    return new ScrapperResponse(
+        user.getId(),
+        user.getNickname(),
+        user.getIntroduction()
+    );
+  }
+}

--- a/src/main/java/kr/santanrudolph/everyvent/domain/calendar/dto/ScrapperScrollResponse.java
+++ b/src/main/java/kr/santanrudolph/everyvent/domain/calendar/dto/ScrapperScrollResponse.java
@@ -1,0 +1,10 @@
+package kr.santanrudolph.everyvent.domain.calendar.dto;
+
+import java.util.List;
+
+public record ScrapperScrollResponse(
+    List<ScrapperResponse> scrappers,
+    Long nextCursor,
+    boolean hasNext
+) {
+}

--- a/src/main/java/kr/santanrudolph/everyvent/domain/calendar/repository/CalendarRepository.java
+++ b/src/main/java/kr/santanrudolph/everyvent/domain/calendar/repository/CalendarRepository.java
@@ -48,4 +48,6 @@ public interface CalendarRepository extends JpaRepository<Calendar, Long> {
   Optional<Calendar> findFirstByUserAndDeletedAtIsNullAndStartDateBeforeOrderByStartDateDesc(User user, LocalDate startDate);
 
   Optional<Calendar> findByIdAndDeletedAtIsNull(Long calendarId);
+
+  Optional<Calendar> findByOriginalCalendarIdAndUserId(Long originalCalendarId, Long id);
 }

--- a/src/main/java/kr/santanrudolph/everyvent/domain/calendar/repository/CalendarRepository.java
+++ b/src/main/java/kr/santanrudolph/everyvent/domain/calendar/repository/CalendarRepository.java
@@ -13,48 +13,39 @@ import java.util.Optional;
 
 public interface CalendarRepository extends JpaRepository<Calendar, Long> {
 
-    @Query("""
-            SELECT COUNT(c)
-            FROM Calendar c
-            WHERE c.user = :user
-              AND YEAR(c.startDate) = :year
-              AND MONTH(c.startDate) = :month
-              AND c.calendarType IN :types
-              AND c.deletedAt IS NULL
-            """)
-    long countByUserAndYearMonthAndTypes(
-            @Param("user") User user,
-            @Param("year") int year,
-            @Param("month") int month,
-            @Param("types") List<CalendarType> types
-    );
+  @Query("""
+      SELECT COUNT(c)
+      FROM Calendar c
+      WHERE c.user = :user
+        AND YEAR(c.startDate) = :year
+        AND MONTH(c.startDate) = :month
+        AND c.calendarType IN :types
+        AND c.deletedAt IS NULL
+      """)
+  long countByUserAndYearMonthAndTypes(
+      @Param("user") User user,
+      @Param("year") int year,
+      @Param("month") int month,
+      @Param("types") List<CalendarType> types
+  );
 
-    @Query("""
-            SELECT c
-            FROM Calendar c
-            WHERE c.user = :user
-              AND c.deletedAt IS NULL
-            ORDER BY c.startDate DESC
-            """)
-    List<Calendar> findAllByUserAndDeletedAtIsNull(@Param("user") User user);
-
-    @Query("""
-                SELECT c
-                FROM Calendar c
-                WHERE c.user = :user
-                  AND c.deletedAt IS NULL
-                  AND c.startDate >= :startDate
-                  AND c.startDate <= :endDate
-                ORDER BY c.startDate DESC
-            """)
-    List<Calendar> findByUserAndStartDateBetween(
-            @Param("user") User user,
-            @Param("startDate") LocalDate startDate,
-            @Param("endDate") LocalDate endDate
-    );
+  @Query("""
+          SELECT c
+          FROM Calendar c
+          WHERE c.user = :user
+            AND c.deletedAt IS NULL
+            AND c.startDate >= :startDate
+            AND c.startDate <= :endDate
+          ORDER BY c.startDate DESC
+      """)
+  List<Calendar> findByUserAndStartDateBetween(
+      @Param("user") User user,
+      @Param("startDate") LocalDate startDate,
+      @Param("endDate") LocalDate endDate
+  );
 
 
-    Optional<Calendar> findFirstByUserAndDeletedAtIsNullAndStartDateBeforeOrderByStartDateDesc(User user, LocalDate startDate);
+  Optional<Calendar> findFirstByUserAndDeletedAtIsNullAndStartDateBeforeOrderByStartDateDesc(User user, LocalDate startDate);
 
-    Optional<Calendar> findByIdAndDeletedAtIsNull(Long calendarId);
+  Optional<Calendar> findByIdAndDeletedAtIsNull(Long calendarId);
 }

--- a/src/main/java/kr/santanrudolph/everyvent/domain/calendar/repository/ScrapRepository.java
+++ b/src/main/java/kr/santanrudolph/everyvent/domain/calendar/repository/ScrapRepository.java
@@ -1,6 +1,7 @@
 package kr.santanrudolph.everyvent.domain.calendar.repository;
 
 import kr.santanrudolph.everyvent.domain.calendar.Scrap;
+import kr.santanrudolph.everyvent.domain.user.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -10,34 +11,50 @@ import java.util.List;
 public interface ScrapRepository extends JpaRepository<Scrap, Long> {
 
 
-    List<Scrap> findAllByIdIn(List<Long> calendarIds);
+  List<Scrap> findAllByIdIn(List<Long> calendarIds);
 
-    @Query("""
-            SELECT s.scrapCount FROM Scrap s WHERE s.calendar.id = :calendarId
-            """)
-    Long countScrapsByCalendarId(@Param("calendarId") Long calendarId);
+  @Query("""
+      SELECT s.scrapCount FROM Scrap s WHERE s.calendar.id = :calendarId
+      """)
+  Long countScrapsByCalendarId(@Param("calendarId") Long calendarId);
 
-    @Query("""
-            SELECT s.id AS calendarId, s.scrapCount AS scrapCount
-            FROM Scrap s
-            WHERE s.id in :calendarIds
-            """)
-    List<ScrapCountProjection> findScrapCountsByCalendarIds(@Param("calendarIds") List<Long> calendarIds);
+  @Query("""
+      SELECT s.id AS calendarId, s.scrapCount AS scrapCount
+      FROM Scrap s
+      WHERE s.id in :calendarIds
+      """)
+  List<ScrapCountProjection> findScrapCountsByCalendarIds(@Param("calendarIds") List<Long> calendarIds);
 
 
-    @Query("""
-                SELECT
-                    CASE
-                        WHEN COUNT(scrappers) > 0 THEN true
-                        ELSE false
-                    END
-                FROM Scrap s
-                    JOIN s.scrappers scrappers
-                WHERE s.id = :calendarId
-                  AND scrappers.id = :scrapperId
-            """)
-    boolean existsScrapper(
-            @Param("calendarId") Long calendarId,
-            @Param("scrapperId") Long scrapperId
-    );
+  @Query("""
+          SELECT
+              CASE
+                  WHEN COUNT(scrappers) > 0 THEN true
+                  ELSE false
+              END
+          FROM Scrap s
+              JOIN s.scrappers scrappers
+          WHERE s.id = :calendarId
+            AND scrappers.id = :scrapperId
+      """)
+  boolean existsScrapper(
+      @Param("calendarId") Long calendarId,
+      @Param("scrapperId") Long scrapperId
+  );
+
+  @Query(value = """
+      SELECT u.*
+      FROM scrap s
+      JOIN scrap_user su ON s.id = su.scrap_id
+      JOIN users u ON su.user_id = u.id
+      WHERE s.id = :calendarId
+        AND (:cursor IS NULL OR u.id < :cursor)
+      ORDER BY u.id DESC
+      LIMIT :limit
+      """, nativeQuery = true)
+  List<User> findScrappersByCalendarId(
+      @Param("calendarId") Long calendarId,
+      @Param("cursor") Long cursor,
+      @Param("limit") int limit
+  );
 }

--- a/src/main/java/kr/santanrudolph/everyvent/domain/calendar/service/CalendarPolicy.java
+++ b/src/main/java/kr/santanrudolph/everyvent/domain/calendar/service/CalendarPolicy.java
@@ -1,5 +1,6 @@
 package kr.santanrudolph.everyvent.domain.calendar.service;
 
+
 import kr.santanrudolph.everyvent.domain.calendar.Calendar;
 import kr.santanrudolph.everyvent.domain.calendar.CalendarConstants;
 import kr.santanrudolph.everyvent.domain.calendar.enums.CalendarType;
@@ -10,6 +11,7 @@ import kr.santanrudolph.everyvent.domain.user.User;
 import kr.santanrudolph.everyvent.domain.user.enums.Role;
 import kr.santanrudolph.everyvent.global.exception.ErrorCode;
 import kr.santanrudolph.everyvent.global.exception.EveryventException;
+import kr.santanrudolph.everyvent.global.util.TimeUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -19,148 +21,198 @@ import java.time.YearMonth;
 @Component
 @RequiredArgsConstructor
 public class CalendarPolicy {
-    private final CalendarRepository calendarRepository;
-    private final FollowService followService;
-    private final ScrapService scrapService;
+  private final CalendarRepository calendarRepository;
+  private final FollowService followService;
+  private final ScrapService scrapService;
 
-    public boolean canView(User user, Calendar calendar) {
-        if (user.getRole() == Role.ADMIN) {
-            return true;
-        }
-
-        if (isOwner(user, calendar)) {
-            return true;
-        }
-
-        Visibility visibility = calendar.getVisibility();
-        if (visibility == Visibility.PUBLIC) {
-            return true;
-        }
-
-        Long followerId = user.getId();
-        Long targetId = calendar.getUser().getId();
-        if (visibility == Visibility.FOLLOWER) {
-            return followService.isFollowing(followerId, targetId);
-        }
-
-        if (visibility == Visibility.MUTUAL) {
-            return followService.isMutualFollow(followerId, targetId);
-        }
-
-        return false;
+  public boolean canView(User user, Calendar calendar) {
+    if (user.getRole() == Role.ADMIN) {
+      return true;
     }
 
-    public boolean canScrap(User user, Calendar calendar) {
-        if (isOwner(user, calendar)) {
-            return false;
-        }
-
-        if (!canView(user, calendar)) {
-            return false;
-        }
-
-        return !scrapService.isScrapped(user, calendar.getId());
+    if (isOwner(user, calendar)) {
+      return true;
     }
 
-    public boolean isOwner(User user, Calendar calendar) {
-        return calendar.getUser().getId().equals(user.getId());
+    Visibility visibility = calendar.getVisibility();
+    if (visibility == Visibility.PUBLIC) {
+      return true;
     }
 
-    public void validateCanCreate(User user, LocalDate startDate) {
-        try {
-            validateCalendarLimit(user, startDate);
-            validateFuture(startDate);
-        } catch (EveryventException e) {
-            throw new EveryventException(e.getErrorCode(), "캘린더를 만들 수 없습니다. " + e.getMessage());
-        }
+    Long followerId = user.getId();
+    Long targetId = calendar.getUser().getId();
+    if (visibility == Visibility.FOLLOWER) {
+      return followService.isFollowing(followerId, targetId);
     }
 
-    public void validateCanUpdate(User user, Calendar calendar) {
-        try {
-            validateFuture(calendar.getStartDate());
-            validateDeleted(calendar);
-            validateOwner(user, calendar);
-            validateOriginalCalendar(calendar);
-        } catch (EveryventException e) {
-            throw new EveryventException(e.getErrorCode(), "캘린더를 수정할 수 없습니다. " + e.getMessage());
-        }
+    if (visibility == Visibility.MUTUAL) {
+      return followService.isMutualFollow(followerId, targetId);
     }
 
-    public void validateCanUpdateScrapColor(User user, Calendar calendar) {
-        try {
-            validateFuture(calendar.getStartDate());
-            validateDeleted(calendar);
-            validateOwner(user, calendar);
-            validateScrappedCalendar(calendar);
-        } catch (EveryventException e) {
-            throw new EveryventException(e.getErrorCode(), "캘린더 색상을 수정할 수 없습니다. " + e.getMessage());
-        }
+    return false;
+  }
+
+  public boolean canScrap(User user, Calendar calendar) {
+    if (isOwner(user, calendar)) {
+      return false;
     }
 
-    public void validateCanDelete(User user, Calendar calendar) {
-        try {
-            validateFuture(calendar.getStartDate());
-            validateDeleted(calendar);
-            validateOwner(user, calendar);
-        } catch (EveryventException e) {
-            throw new EveryventException(e.getErrorCode(), "캘린더를 삭제할 수 없습니다." + e.getMessage());
-        }
+    if (!canView(user, calendar)) {
+      return false;
     }
 
-    public void validateCanView(User user, Calendar calendar) {
-        if (!canView(user, calendar)) {
-            throw new EveryventException(ErrorCode.FORBIDDEN, "해당 캘린더에 접근 권한이 없습니다.");
-        }
+    return !scrapService.isScrapped(user, calendar.getId());
+  }
+
+  public boolean isOwner(User user, Calendar calendar) {
+    return calendar.getUser().getId().equals(user.getId());
+  }
+
+  public void validateCanCreate(User user, LocalDate startDate) {
+    try {
+      validateCalendarLimit(user, startDate);
+      validateFuture(startDate);
+    } catch (EveryventException e) {
+      throw new EveryventException(e.getErrorCode(), "캘린더를 만들 수 없습니다. " + e.getMessage());
     }
+  }
 
-    private void validateCalendarLimit(User user, LocalDate targetDate) {
-        int year = targetDate.getYear();
-        int month = targetDate.getMonthValue();
-
-        long count = calendarRepository.countByUserAndYearMonthAndTypes(
-                user, year, month, CalendarConstants.LIMITED_CALENDAR_TYPES
-        );
-
-        if (count >= CalendarConstants.MAX_CNT_PER_MONTH) {
-            throw new EveryventException(
-                    ErrorCode.INVALID_INPUT,
-                    String.format("%d년 %d월에 생성 가능한 캘린더 수를 초과했습니다.", year, month)
-            );
-        }
+  public void validateCanUpdate(User user, Calendar calendar) {
+    try {
+      validateFuture(calendar.getStartDate());
+      validateDeleted(calendar);
+      validateOwner(user, calendar);
+      validateOriginalCalendar(calendar);
+    } catch (EveryventException e) {
+      throw new EveryventException(e.getErrorCode(), "캘린더를 수정할 수 없습니다. " + e.getMessage());
     }
+  }
 
-    public void validateOwner(User user, Calendar calendar) {
-        if (!isOwner(user, calendar)) {
-            throw new EveryventException(ErrorCode.FORBIDDEN, "본인 캘린더가 아닙니다.");
-        }
+  public void validateCanUpdateScrapColor(User user, Calendar calendar) {
+    try {
+      // 이번달 캘린더일 때 update 가능
+      validateThisMonth(calendar.getStartDate());
+      validateDeleted(calendar);
+      validateOwner(user, calendar);
+      validateIsScrappedCalendar(calendar);
+    } catch (EveryventException e) {
+      throw new EveryventException(e.getErrorCode(), "캘린더 색상을 수정할 수 없습니다. " + e.getMessage());
     }
+  }
 
-    private void validateFuture(LocalDate startDate) {
-        YearMonth calendarYearMonth = YearMonth.from(startDate);
-        YearMonth currentYearMonth = YearMonth.now();
-
-        if (calendarYearMonth.isAfter(currentYearMonth)) {
-            return;
-        }
-        throw new EveryventException(ErrorCode.INVALID_INPUT, "과거입니다.");
+  public void validateCanDelete(User user, Calendar calendar) {
+    try {
+      validateFuture(calendar.getStartDate());
+      validateDeleted(calendar);
+      validateOwner(user, calendar);
+    } catch (EveryventException e) {
+      throw new EveryventException(e.getErrorCode(), "캘린더를 삭제할 수 없습니다." + e.getMessage());
     }
+  }
 
-    private void validateDeleted(Calendar calendar) {
-        if (calendar.isDeleted()) {
-            throw new EveryventException(ErrorCode.NOT_FOUND, "삭제된 캘린더입니다.");
-        }
+  public void validateCanView(User user, Calendar calendar) {
+    if (!canView(user, calendar)) {
+      throw new EveryventException(ErrorCode.FORBIDDEN, "해당 캘린더에 접근 권한이 없습니다.");
     }
+  }
 
-    private void validateOriginalCalendar(Calendar calendar) {
-        if (!calendar.isOriginalCalendar()) {
-            throw new EveryventException(ErrorCode.FORBIDDEN, "원본 캘린더가 아닙니다.");
-        }
+  public void validateCanScrap(User user, Calendar calendar) {
+    try {
+      validateDeleted(calendar);
+      validateNotOwner(user, calendar);
+      validateNotAlreadyScrapped(user, calendar);
+      validateCanView(user, calendar);
+    } catch (EveryventException e) {
+      throw new EveryventException(e.getErrorCode(), "캘린더를 스크랩할 수 없습니다. " + e.getMessage());
     }
+  }
 
-    private void validateScrappedCalendar(Calendar calendar) {
-        if (!calendar.getCalendarType().equals(CalendarType.SCRAPED)) {
-            throw new EveryventException(ErrorCode.INVALID_INPUT, "스크랩한 캘린더가 아닙니다.");
-        }
+  public void validateCanCancelScrap(User user, Calendar calendar) {
+    try {
+      validateDeleted(calendar);
+      validateAlreadyScrapped(user, calendar);
+    } catch (EveryventException e) {
+      throw new EveryventException(e.getErrorCode(), "스크랩을 취소할 수 없습니다. " + e.getMessage());
     }
+  }
+
+  private void validateCalendarLimit(User user, LocalDate targetDate) {
+    int year = targetDate.getYear();
+    int month = targetDate.getMonthValue();
+
+    long count = calendarRepository.countByUserAndYearMonthAndTypes(
+        user, year, month, CalendarConstants.LIMITED_CALENDAR_TYPES
+    );
+
+    if (count >= CalendarConstants.MAX_CNT_PER_MONTH) {
+      throw new EveryventException(
+          ErrorCode.INVALID_INPUT,
+          String.format("%d년 %d월에 생성 가능한 캘린더 수를 초과했습니다.", year, month)
+      );
+    }
+  }
+
+  public void validateOwner(User user, Calendar calendar) {
+    if (!isOwner(user, calendar)) {
+      throw new EveryventException(ErrorCode.FORBIDDEN, "본인 캘린더가 아닙니다.");
+    }
+  }
+
+  private void validateFuture(LocalDate startDate) {
+    YearMonth calendarYearMonth = YearMonth.from(startDate);
+    YearMonth currentYearMonth = TimeUtil.currentYearMonth();
+
+    if (calendarYearMonth.isAfter(currentYearMonth)) {
+      return;
+    }
+    throw new EveryventException(ErrorCode.INVALID_INPUT, "과거입니다.");
+  }
+
+  private void validateThisMonth(LocalDate startDate) {
+    YearMonth calendarYearMonth = YearMonth.from(startDate);
+    YearMonth currentYearMonth = TimeUtil.currentYearMonth();
+
+    if (calendarYearMonth.isAfter(currentYearMonth)) {
+      throw new EveryventException(ErrorCode.INVALID_INPUT, "미래입니다.");
+    } else if (calendarYearMonth.isBefore(currentYearMonth)) {
+      throw new EveryventException(ErrorCode.INVALID_INPUT, "과거입니다.");
+    }
+  }
+
+  private void validateDeleted(Calendar calendar) {
+    if (calendar.isDeleted()) {
+      throw new EveryventException(ErrorCode.NOT_FOUND, "삭제된 캘린더입니다.");
+    }
+  }
+
+  private void validateOriginalCalendar(Calendar calendar) {
+    if (!calendar.isOriginalCalendar()) {
+      throw new EveryventException(ErrorCode.FORBIDDEN, "원본 캘린더가 아닙니다.");
+    }
+  }
+
+  private void validateIsScrappedCalendar(Calendar calendar) {
+    if (!calendar.getCalendarType().equals(CalendarType.SCRAPED)) {
+      throw new EveryventException(ErrorCode.INVALID_INPUT, "스크랩한 캘린더가 아닙니다.");
+    }
+  }
+
+  private void validateNotOwner(User user, Calendar calendar) {
+    if (isOwner(user, calendar)) {
+      throw new EveryventException(ErrorCode.INVALID_INPUT, "본인 캘린더입니다.");
+    }
+  }
+
+  private void validateNotAlreadyScrapped(User user, Calendar calendar) {
+    if (scrapService.isScrapped(user, calendar.getId())) {
+      throw new EveryventException(ErrorCode.ALREADY_EXIST, "이미 스크랩한 캘린더입니다.");
+    }
+  }
+
+  private void validateAlreadyScrapped(User user, Calendar calendar) {
+    if (!scrapService.isScrapped(user, calendar.getId())) {
+      throw new EveryventException(ErrorCode.NOT_FOUND, "스크랩하지 않은 캘린더입니다.");
+    }
+  }
 
 }

--- a/src/main/java/kr/santanrudolph/everyvent/domain/calendar/service/CalendarPolicy.java
+++ b/src/main/java/kr/santanrudolph/everyvent/domain/calendar/service/CalendarPolicy.java
@@ -100,9 +100,19 @@ public class CalendarPolicy {
     }
   }
 
-  public void validateCanDelete(User user, Calendar calendar) {
+  public void validateCanSoftDelete(User user, Calendar calendar) {
     try {
       validateFuture(calendar.getStartDate());
+      validateDeleted(calendar);
+      validateOwner(user, calendar);
+    } catch (EveryventException e) {
+      throw new EveryventException(e.getErrorCode(), "캘린더를 삭제할 수 없습니다." + e.getMessage());
+    }
+  }
+
+  public void validateCanHardDelete(User user, Calendar calendar) {
+    try {
+      validateThisMonth(calendar);
       validateDeleted(calendar);
       validateOwner(user, calendar);
     } catch (EveryventException e) {
@@ -131,8 +141,8 @@ public class CalendarPolicy {
   public void validateCanCancelScrap(User user, Calendar calendar) {
     try {
       validateDeleted(calendar);
-      validateAlreadyScrapped(user, calendar);
       validateThisMonth(calendar);
+      validateOwner(user, calendar);
     } catch (EveryventException e) {
       throw new EveryventException(e.getErrorCode(), "스크랩을 취소할 수 없습니다. " + e.getMessage());
     }
@@ -208,12 +218,6 @@ public class CalendarPolicy {
   private void validateNotAlreadyScrapped(User user, Calendar calendar) {
     if (scrapService.isScrapped(user, calendar.getId())) {
       throw new EveryventException(ErrorCode.ALREADY_EXIST, "이미 스크랩한 캘린더입니다.");
-    }
-  }
-
-  private void validateAlreadyScrapped(User user, Calendar calendar) {
-    if (!scrapService.isScrapped(user, calendar.getId())) {
-      throw new EveryventException(ErrorCode.NOT_FOUND, "스크랩하지 않은 캘린더입니다.");
     }
   }
 

--- a/src/main/java/kr/santanrudolph/everyvent/domain/calendar/service/CalendarPolicy.java
+++ b/src/main/java/kr/santanrudolph/everyvent/domain/calendar/service/CalendarPolicy.java
@@ -91,7 +91,7 @@ public class CalendarPolicy {
   public void validateCanUpdateScrapColor(User user, Calendar calendar) {
     try {
       // 이번달 캘린더일 때 update 가능
-      validateThisMonth(calendar.getStartDate());
+      validateThisMonth(calendar);
       validateDeleted(calendar);
       validateOwner(user, calendar);
       validateIsScrappedCalendar(calendar);
@@ -118,10 +118,11 @@ public class CalendarPolicy {
 
   public void validateCanScrap(User user, Calendar calendar) {
     try {
+      validateCanView(user, calendar);
+      validateThisMonth(calendar);
       validateDeleted(calendar);
       validateNotOwner(user, calendar);
       validateNotAlreadyScrapped(user, calendar);
-      validateCanView(user, calendar);
     } catch (EveryventException e) {
       throw new EveryventException(e.getErrorCode(), "캘린더를 스크랩할 수 없습니다. " + e.getMessage());
     }
@@ -131,6 +132,7 @@ public class CalendarPolicy {
     try {
       validateDeleted(calendar);
       validateAlreadyScrapped(user, calendar);
+      validateThisMonth(calendar);
     } catch (EveryventException e) {
       throw new EveryventException(e.getErrorCode(), "스크랩을 취소할 수 없습니다. " + e.getMessage());
     }
@@ -168,8 +170,8 @@ public class CalendarPolicy {
     throw new EveryventException(ErrorCode.INVALID_INPUT, "과거입니다.");
   }
 
-  private void validateThisMonth(LocalDate startDate) {
-    YearMonth calendarYearMonth = YearMonth.from(startDate);
+  private void validateThisMonth(Calendar calendar) {
+    YearMonth calendarYearMonth = YearMonth.from(calendar.getStartDate());
     YearMonth currentYearMonth = TimeUtil.currentYearMonth();
 
     if (calendarYearMonth.isAfter(currentYearMonth)) {

--- a/src/main/java/kr/santanrudolph/everyvent/domain/calendar/service/CalendarService.java
+++ b/src/main/java/kr/santanrudolph/everyvent/domain/calendar/service/CalendarService.java
@@ -1,10 +1,12 @@
 package kr.santanrudolph.everyvent.domain.calendar.service;
 
 import kr.santanrudolph.everyvent.domain.calendar.Calendar;
+import kr.santanrudolph.everyvent.domain.calendar.Scrap;
 import kr.santanrudolph.everyvent.domain.calendar.dto.*;
 import kr.santanrudolph.everyvent.domain.calendar.enums.CalendarType;
 import kr.santanrudolph.everyvent.domain.calendar.repository.CalendarRepository;
-import kr.santanrudolph.everyvent.domain.task.TaskRepository;
+import kr.santanrudolph.everyvent.domain.task.TaskService;
+import kr.santanrudolph.everyvent.domain.task.dto.TaskResponse;
 import kr.santanrudolph.everyvent.domain.user.User;
 import kr.santanrudolph.everyvent.domain.user.UserService;
 import kr.santanrudolph.everyvent.global.exception.ErrorCode;
@@ -31,7 +33,7 @@ public class CalendarService {
   private static final long INITIAL_SCRAP_COUNT = 0L;
 
   private final CalendarRepository calendarRepository;
-  private final TaskRepository taskRepository;
+  private final TaskService taskService;
   private final UserService userService;
   private final ScrapService scrapService;
   private final CalendarPolicy calendarPolicy;
@@ -183,6 +185,54 @@ public class CalendarService {
   }
 
   @Transactional
+  public CalendarDetailResponse scrapCalendar(Long calendarId, ScrapCalendarRequest request) {
+    User currentUser = userService.getCurrentUser();
+    Calendar originalCalendar = findCalendarByIdAndDeletedAtIsNull(calendarId);
+
+    calendarPolicy.validateCanScrap(currentUser, originalCalendar);
+
+    Calendar scrappedCalendar = Calendar.createScrappedCalendar(
+        currentUser,
+        originalCalendar,
+        request.color()
+    );
+
+    // Calendar 저장
+    Calendar savedCalendar = calendarRepository.save(scrappedCalendar);
+    // Scrap 저장
+    Scrap scrap = scrapService.addScrap(currentUser, originalCalendar);
+    // Task 저장
+    List<TaskResponse> taskResponses = taskService.saveCopyTasks(originalCalendar, savedCalendar);
+    log.info(
+        "캘린더 스크랩 완료 - originalCalendarId={}, newCalendarId={}, copiedTaskCount={}",
+        originalCalendar.getId(),
+        savedCalendar.getId(),
+        taskResponses.size()
+    );
+
+    Long scrapCount = scrap.getScrapCount();
+    return CalendarDetailResponse.from(savedCalendar, NOT_SCRAPPABLE, scrapCount);
+  }
+
+  @Transactional
+  public void cancelScrap(Long originalCalendarId) {
+    User currentUser = userService.getCurrentUser();
+    Calendar scrappedCalendar = calendarRepository
+        .findByOriginalCalendarIdAndUserId(originalCalendarId, currentUser.getId())
+        .orElseThrow(() ->
+            new EveryventException(ErrorCode.NOT_FOUND, "스크랩하지 않은 캘린더입니다.")
+        );
+
+    calendarPolicy.validateCanCancelScrap(currentUser, scrappedCalendar);
+
+    // calendar + task 삭제
+    hardDeleteCalendar(scrappedCalendar.getId());
+    // scrap에서 유저 삭제
+    scrapService.removeScrap(currentUser, scrappedCalendar.getOriginalCalendarId());
+
+  }
+
+  @Transactional
   public CalendarDetailResponse updateScrapColor(Long calendarId, ScrapCalendarRequest request) {
     User currentUser = userService.getCurrentUser();
     Calendar calendar = calendarRepository.findById(calendarId)
@@ -193,23 +243,47 @@ public class CalendarService {
     calendar.updateColor(request.color());
 
     Long scrapCount = scrapService.getScrapCount(calendar.getId());
-    return CalendarDetailResponse.from(calendar, SCRAPPABLE, scrapCount);
+    return CalendarDetailResponse.from(calendar, NOT_SCRAPPABLE, scrapCount);
   }
 
   @Transactional
-  public void deleteCalendar(Long calendarId) {
+  public void softDeleteCalendar(Long calendarId) {
     User currentUser = userService.getCurrentUser();
     Calendar calendar = findCalendarByIdAndDeletedAtIsNull(calendarId);
 
-    calendarPolicy.validateCanDelete(currentUser, calendar);
+    calendarPolicy.validateCanSoftDelete(currentUser, calendar);
 
-    taskRepository.deleteByCalendarId(calendarId);
+    taskService.deleteByCalendarId(calendarId);
     calendar.softDelete();
+  }
+
+  @Transactional
+  public void hardDeleteCalendar(Long calendarId) {
+    User currentUser = userService.getCurrentUser();
+    Calendar calendar = findCalendarByIdAndDeletedAtIsNull(calendarId);
+
+    calendarPolicy.validateCanHardDelete(currentUser, calendar);
+
+    taskService.deleteByCalendarId(calendarId);
+    calendarRepository.deleteById(calendarId);
   }
 
   public Calendar findCalendarByIdAndDeletedAtIsNull(Long calendarId) {
     return calendarRepository.findByIdAndDeletedAtIsNull(calendarId)
         .orElseThrow(() -> new EveryventException(ErrorCode.NOT_FOUND, "캘린더를 찾을 수 없습니다."));
+  }
+
+  public ScrapperScrollResponse getScrappers(Long calendarId, Long cursor, Integer size) {
+    if (size <= 0) {
+      throw new EveryventException(ErrorCode.INVALID_INPUT, "size는 1 이상이어야 합니다.");
+    }
+
+    Calendar calendar = findCalendarByIdAndDeletedAtIsNull(calendarId);
+    User currentUser = userService.getCurrentUser();
+
+    calendarPolicy.validateCanView(currentUser, calendar);
+
+    return scrapService.getScrappers(calendarId, cursor, size);
   }
 
   private Map<Long, Long> getScrapCountMapFromCalendars(List<Calendar> calendars) {

--- a/src/main/java/kr/santanrudolph/everyvent/domain/calendar/service/ScrapService.java
+++ b/src/main/java/kr/santanrudolph/everyvent/domain/calendar/service/ScrapService.java
@@ -2,6 +2,8 @@ package kr.santanrudolph.everyvent.domain.calendar.service;
 
 import kr.santanrudolph.everyvent.domain.calendar.Calendar;
 import kr.santanrudolph.everyvent.domain.calendar.Scrap;
+import kr.santanrudolph.everyvent.domain.calendar.dto.ScrapperResponse;
+import kr.santanrudolph.everyvent.domain.calendar.dto.ScrapperScrollResponse;
 import kr.santanrudolph.everyvent.domain.calendar.repository.ScrapRepository;
 import kr.santanrudolph.everyvent.domain.calendar.repository.ScrapCountProjection;
 import kr.santanrudolph.everyvent.domain.user.User;
@@ -60,6 +62,25 @@ public class ScrapService {
                                         ScrapCountProjection::getCalendarId,
                                         ScrapCountProjection::getScrapCount
                                 ));
+    }
+
+    public ScrapperScrollResponse getScrappers(Long calendarId, Long cursor, Integer size) {
+        List<User> scrappers = scrapRepository.findScrappersByCalendarId(calendarId, cursor, size + 1);
+
+        boolean hasNext = scrappers.size() > size;
+        Long nextCursor = null;
+
+        if (hasNext) {
+            List<User> limitedScrappers = scrappers.subList(0, size);
+            nextCursor = limitedScrappers.get(limitedScrappers.size() - 1).getId();
+            scrappers = limitedScrappers;
+        }
+
+        List<ScrapperResponse> scrapperResponses = scrappers.stream()
+                .map(ScrapperResponse::from)
+                .toList();
+
+        return new ScrapperScrollResponse(scrapperResponses, nextCursor, hasNext);
     }
 
 }

--- a/src/main/java/kr/santanrudolph/everyvent/domain/calendar/service/ScrapService.java
+++ b/src/main/java/kr/santanrudolph/everyvent/domain/calendar/service/ScrapService.java
@@ -29,6 +29,15 @@ public class ScrapService {
         return scrapRepository.save(scrap);
     }
 
+    @Transactional
+    public void removeScrap(User user, Long calendarId) {
+        Scrap scrap = scrapRepository.findById(calendarId).orElse(null);
+        if (scrap != null) {
+            scrap.removeScrapper(user);
+            scrapRepository.save(scrap);
+        }
+    }
+
     public Long getScrapCount(Long calendarId) {
         Scrap scrap = scrapRepository.findById(calendarId).orElse(null);
         if (scrap == null) {

--- a/src/main/java/kr/santanrudolph/everyvent/domain/task/TaskService.java
+++ b/src/main/java/kr/santanrudolph/everyvent/domain/task/TaskService.java
@@ -2,8 +2,8 @@ package kr.santanrudolph.everyvent.domain.task;
 
 
 import kr.santanrudolph.everyvent.domain.calendar.Calendar;
+import kr.santanrudolph.everyvent.domain.calendar.repository.CalendarRepository;
 import kr.santanrudolph.everyvent.domain.calendar.service.CalendarPolicy;
-import kr.santanrudolph.everyvent.domain.calendar.service.CalendarService;
 import kr.santanrudolph.everyvent.domain.task.dto.TaskCreateRequest;
 import kr.santanrudolph.everyvent.domain.task.dto.TaskResponse;
 import kr.santanrudolph.everyvent.domain.task.dto.TaskUpdateRequest;
@@ -28,211 +28,215 @@ import java.util.stream.Collectors;
 @Transactional(readOnly = true)
 public class TaskService {
 
-  private static final int MAX_TASKS_PER_DAY = 3;
-  private static final boolean UNLOCKED = false;
+    private static final int MAX_TASKS_PER_DAY = 3;
+    private static final boolean UNLOCKED = false;
 
-  private final TaskRepository taskRepository;
-  private final CalendarService calendarService;
-  private final UserService userService;
-  private final CalendarPolicy calendarPolicy;
+    private final TaskRepository taskRepository;
+    private final CalendarRepository calendarRepository;
+    private final UserService userService;
+    private final CalendarPolicy calendarPolicy;
 
-  @Transactional
-  public List<TaskResponse> createTasks(Long calendarId, List<TaskCreateRequest> requests) {
-    User currentUser = userService.getCurrentUser();
-    Calendar calendar = calendarService.findCalendarByIdAndDeletedAtIsNull(calendarId);
+    @Transactional
+    public List<TaskResponse> createTasks(Long calendarId, List<TaskCreateRequest> requests) {
+        User currentUser = userService.getCurrentUser();
+        Calendar calendar = findCalendarById(calendarId);
 
-    try {
-      calendarPolicy.validateCanUpdate(currentUser, calendar);
-    } catch (EveryventException e) {
-      throw new EveryventException(e.getErrorCode(), "태스크를 생성할 수 없습니다. " + e.getMessage());
+        try {
+            calendarPolicy.validateCanUpdate(currentUser, calendar);
+        } catch (EveryventException e) {
+            throw new EveryventException(e.getErrorCode(), "태스크를 생성할 수 없습니다. " + e.getMessage());
+        }
+
+        List<Task> tasks = requestsToTasks(calendar, requests);
+        List<Task> results = taskRepository.saveAll(tasks);
+
+        return results.stream()
+                .map(task -> TaskResponse.from(task, UNLOCKED))
+                .toList();
     }
 
-    List<Task> tasks = requestsToTasks(calendar, requests);
-    List<Task> results = taskRepository.saveAll(tasks);
+    public List<TaskResponse> getTasksAllInformation(Long calendarId) {
+        User currentUser = userService.getCurrentUser();
+        Calendar calendar = findCalendarById(calendarId);
 
-    return results.stream()
-        .map(task -> TaskResponse.from(task, UNLOCKED))
-        .toList();
-  }
+        try {
+            calendarPolicy.validateCanView(currentUser, calendar);
+        } catch (EveryventException e) {
+            throw new EveryventException(e.getErrorCode(), "태스크를 조회할 수 없습니다. " + e.getMessage());
+        }
 
-  public List<TaskResponse> getTasksAllInformation(Long calendarId) {
-    User currentUser = userService.getCurrentUser();
-    Calendar calendar = calendarService.findCalendarByIdAndDeletedAtIsNull(calendarId);
+        List<Task> tasks = taskRepository.findAllByCalendarId(calendarId);
 
-    try {
-      calendarPolicy.validateCanView(currentUser, calendar);
-    } catch (EveryventException e) {
-      throw new EveryventException(e.getErrorCode(), "태스크를 조회할 수 없습니다. " + e.getMessage());
+        return tasks.stream()
+                .map(task -> TaskResponse.from(task, UNLOCKED))
+                .toList();
     }
 
-    List<Task> tasks = taskRepository.findAllByCalendarId(calendarId);
 
-    return tasks.stream()
-        .map(task -> TaskResponse.from(task, UNLOCKED))
-        .toList();
-  }
+    public List<TaskResponse> getTasks(Long calendarId) {
+        User currentUser = userService.getCurrentUser();
+        Calendar calendar = findCalendarById(calendarId);
+        try {
+            calendarPolicy.validateCanView(currentUser, calendar);
+        } catch (EveryventException e) {
+            throw new EveryventException(e.getErrorCode(), "태스크를 조회할 수 없습니다. " + e.getMessage());
+        }
 
+        List<Task> tasks = taskRepository.findAllByCalendarId(calendarId);
 
-  public List<TaskResponse> getTasks(Long calendarId) {
-    User currentUser = userService.getCurrentUser();
-    Calendar calendar = calendarService.findCalendarByIdAndDeletedAtIsNull(calendarId);
-
-    try {
-      calendarPolicy.validateCanView(currentUser, calendar);
-    } catch (EveryventException e) {
-      throw new EveryventException(e.getErrorCode(), "태스크를 조회할 수 없습니다. " + e.getMessage());
+        return tasks.stream()
+                .map(task -> TaskResponse.from(task, isLocked(calendar, task)))
+                .toList();
     }
 
-    List<Task> tasks = taskRepository.findAllByCalendarId(calendarId);
+    @Transactional
+    public TaskResponse updateTask(Long calendarId, Long taskId, TaskUpdateRequest request) {
+        User currentUser = userService.getCurrentUser();
+        Calendar calendar = findCalendarById(calendarId);
+        Task task = findTaskById(taskId);
 
-    return tasks.stream()
-        .map(task -> TaskResponse.from(task, isLocked(calendar, task)))
-        .toList();
-  }
+        try {
+            calendarPolicy.validateCanUpdate(currentUser, calendar);
+            validateTaskBelongsToCalendar(task, calendarId);
+        } catch (EveryventException e) {
+            throw new EveryventException(e.getErrorCode(), "태스크를 수정할 수 없습니다. " + e.getMessage());
+        }
 
-  @Transactional
-  public TaskResponse updateTask(Long calendarId, Long taskId, TaskUpdateRequest request) {
-    User currentUser = userService.getCurrentUser();
-    Calendar calendar = calendarService.findCalendarByIdAndDeletedAtIsNull(calendarId);
-    Task task = findTaskById(taskId);
+        if (request.content() != null) {
+            task.updateContent(request.content());
+        }
 
-    try {
-      calendarPolicy.validateCanUpdate(currentUser, calendar);
-      validateTaskBelongsToCalendar(task, calendarId);
-    } catch (EveryventException e) {
-      throw new EveryventException(e.getErrorCode(), "태스크를 수정할 수 없습니다. " + e.getMessage());
+        return TaskResponse.from(task, UNLOCKED);
     }
 
-    if (request.content() != null) {
-      task.updateContent(request.content());
+    @Transactional
+    public void deleteTask(Long calendarId, Long taskId) {
+        User currentUser = userService.getCurrentUser();
+        Calendar calendar = findCalendarById(calendarId);
+        Task task = findTaskById(taskId);
+
+        try {
+            calendarPolicy.validateCanUpdate(currentUser, calendar);
+            validateTaskBelongsToCalendar(task, calendarId);
+        } catch (EveryventException e) {
+            throw new EveryventException(e.getErrorCode(), "태스크를 삭제할 수 없습니다. " + e.getMessage());
+        }
+
+        taskRepository.delete(task);
     }
 
-    return TaskResponse.from(task, UNLOCKED);
-  }
+    @Transactional
+    public TaskResponse updateTaskCompletion(Long calendarId, Long taskId, Boolean completed) {
+        User currentUser = userService.getCurrentUser();
+        Calendar calendar = findCalendarById(calendarId);
+        Task task = findTaskById(taskId);
 
-  @Transactional
-  public void deleteTask(Long calendarId, Long taskId) {
-    User currentUser = userService.getCurrentUser();
-    Calendar calendar = calendarService.findCalendarByIdAndDeletedAtIsNull(calendarId);
-    Task task = findTaskById(taskId);
+        validateCanComplete(currentUser, calendar, task);
 
-    try {
-      calendarPolicy.validateCanUpdate(currentUser, calendar);
-      validateTaskBelongsToCalendar(task, calendarId);
-    } catch (EveryventException e) {
-      throw new EveryventException(e.getErrorCode(), "태스크를 삭제할 수 없습니다. " + e.getMessage());
+        if (completed) {
+            task.complete();
+        } else {
+            task.uncomplete();
+        }
+
+        return TaskResponse.from(task, false);
     }
 
-    taskRepository.delete(task);
-  }
-
-  @Transactional
-  public TaskResponse updateTaskCompletion(Long calendarId, Long taskId, Boolean completed) {
-    User currentUser = userService.getCurrentUser();
-    Calendar calendar = calendarService.findCalendarByIdAndDeletedAtIsNull(calendarId);
-    Task task = findTaskById(taskId);
-
-    validateCanComplete(currentUser, calendar, task);
-
-    if (completed) {
-      task.complete();
-    } else {
-      task.uncomplete();
+    private Calendar findCalendarById(Long calendarId) {
+        return calendarRepository.findByIdAndDeletedAtIsNull(calendarId)
+                .orElseThrow(() -> new EveryventException(ErrorCode.NOT_FOUND, "캘린더를 찾을 수 없습니다."));
     }
 
-    return TaskResponse.from(task, false);
-  }
-
-  private Task findTaskById(Long taskId) {
-    return taskRepository.findById(taskId)
-        .orElseThrow(() -> new EveryventException(ErrorCode.NOT_FOUND, "태스크를 찾을 수 없습니다."));
-  }
-
-  private List<Task> requestsToTasks(Calendar calendar, List<TaskCreateRequest> requests) {
-    Map<Integer, Long> requestedTaskCountByDay = requests.stream()
-        .collect(Collectors.groupingBy(TaskCreateRequest::day, Collectors.counting()));
-
-    return requests.stream()
-        .map(request -> {
-          LocalDate taskDay = parseTaskDay(calendar, request);
-
-          validateDateWithinCalendarRange(calendar, taskDay);
-          validateTaskLimit(calendar, taskDay, requestedTaskCountByDay.get(request.day()));
-
-          return Task.createTask(calendar, taskDay, request.content());
-        })
-        .toList();
-  }
-
-  private LocalDate parseTaskDay(Calendar calendar, TaskCreateRequest request) {
-    LocalDate startDay = calendar.getStartDate();
-    try {
-      return startDay.withDayOfMonth(request.day());
-    } catch (DateTimeException e) {
-      throw new EveryventException(
-          ErrorCode.INVALID_INPUT,
-          String.format("%d월에는 %d일이 존재하지 않습니다.", startDay.getMonthValue(), request.day())
-      );
-    }
-  }
-
-  private void validateTaskLimit(Calendar calendar, LocalDate day, long requestedTaskCountByDay) {
-    long calendarId = calendar.getId();
-    long count = taskRepository.countByCalendarIdAndDay(calendarId, day);
-
-    if (count + requestedTaskCountByDay > MAX_TASKS_PER_DAY) {
-      throw new EveryventException(
-          ErrorCode.INVALID_INPUT,
-          String.format("하루에 최대 %d개의 태스크만 생성할 수 있습니다.", MAX_TASKS_PER_DAY)
-      );
-    }
-  }
-
-  private void validateDateWithinCalendarRange(Calendar calendar, LocalDate day) {
-    if (day.isBefore(calendar.getStartDate()) || day.isAfter(calendar.getEndDate())) {
-      throw new EveryventException(
-          ErrorCode.INVALID_INPUT, "태스크 날짜는 캘린더 기간 내에 있어야 합니다."
-      );
-    }
-  }
-
-  private void validateTaskBelongsToCalendar(Task task, Long calendarId) {
-    if (!task.getCalendar().getId().equals(calendarId)) {
-      throw new EveryventException(ErrorCode.INVALID_INPUT, "해당 태스크는 이 캘린더에 속하지 않습니다.");
-    }
-  }
-
-  private void validateCanComplete(User currentUser, Calendar calendar, Task task) {
-    try {
-      calendarPolicy.validateCanView(currentUser, calendar);
-      validateTaskBelongsToCalendar(task, calendar.getId());
-    } catch (EveryventException e) {
-      throw new EveryventException(e.getErrorCode(), "태스크 완료 상태를 변경할 수 없습니다. " + e.getMessage());
+    private Task findTaskById(Long taskId) {
+        return taskRepository.findById(taskId)
+                .orElseThrow(() -> new EveryventException(ErrorCode.NOT_FOUND, "태스크를 찾을 수 없습니다."));
     }
 
-    if (isFutureTask(task)) {
-      throw new EveryventException(ErrorCode.FORBIDDEN, "태스크 완료 상태를 변경할 수 없습니다. 미래의 태스크입니다.");
-    }
-  }
+    private List<Task> requestsToTasks(Calendar calendar, List<TaskCreateRequest> requests) {
+        Map<Integer, Long> requestedTaskCountByDay = requests.stream()
+                .collect(Collectors.groupingBy(TaskCreateRequest::day, Collectors.counting()));
 
-  private boolean isLocked(Calendar calendar, Task task) {
-    LocalDate now = TimeUtil.today();
+        return requests.stream()
+                .map(request -> {
+                    LocalDate taskDay = parseTaskDay(calendar, request);
 
-    LocalDate previewStartDay = calendar.getPreviewStartDay();
-    LocalDate previewEndDay = calendar.getPreviewEndDay();
+                    validateDateWithinCalendarRange(calendar, taskDay);
+                    validateTaskLimit(calendar, taskDay, requestedTaskCountByDay.get(request.day()));
 
-    // 미리보기 범위 안에 있으면 잠겨있지 않음
-    if (previewStartDay != null && previewEndDay != null) {
-      if (TimeUtil.isInRange(previewStartDay, previewEndDay, task.getDay())) {
-        return false;
-      }
+                    return Task.createTask(calendar, taskDay, request.content());
+                })
+                .toList();
     }
 
-    // 해당 날짜가 미래면 잠겨있음
-    return task.getDay().isAfter(now);
-  }
+    private LocalDate parseTaskDay(Calendar calendar, TaskCreateRequest request) {
+        LocalDate startDay = calendar.getStartDate();
+        try {
+            return startDay.withDayOfMonth(request.day());
+        } catch (DateTimeException e) {
+            throw new EveryventException(
+                    ErrorCode.INVALID_INPUT,
+                    String.format("%d월에는 %d일이 존재하지 않습니다.", startDay.getMonthValue(), request.day())
+            );
+        }
+    }
 
-  private boolean isFutureTask(Task task) {
-    return TimeUtil.isAfter(task.getDay(), TimeUtil.today());
-  }
+    private void validateTaskLimit(Calendar calendar, LocalDate day, long requestedTaskCountByDay) {
+        long calendarId = calendar.getId();
+        long count = taskRepository.countByCalendarIdAndDay(calendarId, day);
+
+        if (count + requestedTaskCountByDay > MAX_TASKS_PER_DAY) {
+            throw new EveryventException(
+                    ErrorCode.INVALID_INPUT,
+                    String.format("하루에 최대 %d개의 태스크만 생성할 수 있습니다.", MAX_TASKS_PER_DAY)
+            );
+        }
+    }
+
+    private void validateDateWithinCalendarRange(Calendar calendar, LocalDate day) {
+        if (day.isBefore(calendar.getStartDate()) || day.isAfter(calendar.getEndDate())) {
+            throw new EveryventException(
+                    ErrorCode.INVALID_INPUT, "태스크 날짜는 캘린더 기간 내에 있어야 합니다."
+            );
+        }
+    }
+
+    private void validateTaskBelongsToCalendar(Task task, Long calendarId) {
+        if (!task.getCalendar().getId().equals(calendarId)) {
+            throw new EveryventException(ErrorCode.INVALID_INPUT, "해당 태스크는 이 캘린더에 속하지 않습니다.");
+        }
+    }
+
+    private void validateCanComplete(User currentUser, Calendar calendar, Task task) {
+        try {
+            calendarPolicy.validateCanView(currentUser, calendar);
+            validateTaskBelongsToCalendar(task, calendar.getId());
+        } catch (EveryventException e) {
+            throw new EveryventException(e.getErrorCode(), "태스크 완료 상태를 변경할 수 없습니다. " + e.getMessage());
+        }
+
+        if (isFutureTask(task)) {
+            throw new EveryventException(ErrorCode.FORBIDDEN, "태스크 완료 상태를 변경할 수 없습니다. 미래의 태스크입니다.");
+        }
+    }
+
+    private boolean isLocked(Calendar calendar, Task task) {
+        LocalDate now = TimeUtil.today();
+
+        LocalDate previewStartDay = calendar.getPreviewStartDay();
+        LocalDate previewEndDay = calendar.getPreviewEndDay();
+
+        // 미리보기 범위 안에 있으면 잠겨있지 않음
+        if (previewStartDay != null && previewEndDay != null) {
+            if (TimeUtil.isInRange(previewStartDay, previewEndDay, task.getDay())) {
+                return false;
+            }
+        }
+
+        // 해당 날짜가 미래면 잠겨있음
+        return task.getDay().isAfter(now);
+    }
+
+    private boolean isFutureTask(Task task) {
+        return TimeUtil.isAfter(task.getDay(), TimeUtil.today());
+    }
 }

--- a/src/main/java/kr/santanrudolph/everyvent/domain/task/TaskService.java
+++ b/src/main/java/kr/santanrudolph/everyvent/domain/task/TaskService.java
@@ -56,22 +56,28 @@ public class TaskService {
     }
 
     public List<TaskResponse> getTasksAllInformation(Long calendarId) {
-        User currentUser = userService.getCurrentUser();
-        Calendar calendar = findCalendarById(calendarId);
-
-        try {
-            calendarPolicy.validateCanView(currentUser, calendar);
-        } catch (EveryventException e) {
-            throw new EveryventException(e.getErrorCode(), "태스크를 조회할 수 없습니다. " + e.getMessage());
-        }
-
-        List<Task> tasks = taskRepository.findAllByCalendarId(calendarId);
+        List<Task> tasks = getAllTasks(calendarId);
 
         return tasks.stream()
                 .map(task -> TaskResponse.from(task, UNLOCKED))
                 .toList();
     }
 
+    public List<TaskResponse> saveCopyTasks(Calendar originalCalendar, Calendar ScrappedCalendar) {
+        List<Task> originalTasks = getAllTasks(originalCalendar.getId());
+        List<Task> copyTasks = new ArrayList<>();
+
+        for (Task original : originalTasks) {
+            copyTasks.add(
+                    Task.createTask(ScrappedCalendar, original.getDay(), original.getContent())
+            );
+        }
+        List<Task> results = taskRepository.saveAll(copyTasks);
+
+        return results.stream()
+                .map(task -> TaskResponse.from(task, UNLOCKED))
+                .toList();
+    }
 
     public List<TaskResponse> getTasks(Long calendarId) {
         User currentUser = userService.getCurrentUser();
@@ -140,6 +146,24 @@ public class TaskService {
         }
 
         return TaskResponse.from(task, false);
+    }
+
+    @Transactional
+    public void deleteByCalendarId(Long calendarId) {
+        taskRepository.deleteByCalendarId(calendarId);
+    }
+
+    private List<Task> getAllTasks(Long calendarId) {
+        User currentUser = userService.getCurrentUser();
+        Calendar calendar = findCalendarById(calendarId);
+
+        try {
+            calendarPolicy.validateCanView(currentUser, calendar);
+        } catch (EveryventException e) {
+            throw new EveryventException(e.getErrorCode(), "태스크를 조회할 수 없습니다. " + e.getMessage());
+        }
+
+        return taskRepository.findAllByCalendarId(calendarId);
     }
 
     private Calendar findCalendarById(Long calendarId) {
@@ -239,4 +263,5 @@ public class TaskService {
     private boolean isFutureTask(Task task) {
         return TimeUtil.isAfter(task.getDay(), TimeUtil.today());
     }
+
 }

--- a/src/main/java/kr/santanrudolph/everyvent/global/util/TimeUtil.java
+++ b/src/main/java/kr/santanrudolph/everyvent/global/util/TimeUtil.java
@@ -1,6 +1,7 @@
 package kr.santanrudolph.everyvent.global.util;
 
 import java.time.LocalDate;
+import java.time.YearMonth;
 import java.time.ZoneId;
 
 public class TimeUtil {
@@ -9,6 +10,10 @@ public class TimeUtil {
 
   public static LocalDate today() {
     return LocalDate.now(DEFAULT_ZONE);
+  }
+
+  public static YearMonth currentYearMonth() {
+    return YearMonth.now(DEFAULT_ZONE);
   }
 
   public static boolean isAfter(LocalDate after, LocalDate before) {


### PR DESCRIPTION
## 📝 무엇을 했나요?
**스크랩하기 / 스크랩 취소하기 기능을 구현했어요.**

또한 `CalendarService`와 `TaskService` 간 의존성 순환 문제가 있어,  
`TaskService`에서 `CalendarService`를 참조하지 않고  
`CalendarRepository`를 통해 캘린더를 조회하도록 로직을 수정했어요.

캘린더 삭제 정책도 함께 정리했어요.
- **원본 캘린더**: `validateCanSoftDelete`로 삭제 가능 여부를 검증해요
- **스크랩한 캘린더**: `validateCanHardDelete`로 삭제 가능 여부를 검증해요


---

## 💭 고민 지점과 리뷰 포인트
<!-- 예상되는 리팩터링 지점이 있다면 추가로 작성해 주세요.-->
@bomii1, @meteorqz6

구현 완료된 엔드포인트는 아래와 같아요.

- `POST /api/calendars/{calendarId}/scrap` (캘린더 스크랩)
- `DELETE /api/calendars/{calendarId}/scrap`  (스크랩 취소)
  (두 엔드포인트 모두 `{calendarId}`는 원본 캘린더 ID예요)

- (스크랩은 이번 달 캘린더일 때 스크랩 가능)
- (스크랩 취소도 이번 달 캘린더일 때만 가능)

---

### 🔄 스크랩 취소 방식
스크랩 취소는 아래 두 가지 방법으로 가능해요.

1. **원본 캘린더 화면에서 스크랩 취소 버튼을 누르는 경우**  
   → `DELETE /api/calendars/{calendarId}/scrap` (calendarId는 원본 캘린더 Id)

2. **스크랩된 캘린더 ID로 캘린더를 삭제하는 경우**  
   → `DELETE /api/calendars/{calendarId}` (calendarId는 스크랩해온 현재 유저의 캘린더 Id)

스크랩 취소 시, 프론트엔드에서  
현재 유저가 스크랩으로 생성한 캘린더 ID를 직접 찾기 어려울 것 같아 
위와 같은 API 구조로 설계했어요.

더 나은 API 설계 방향이나 개선 의견이 있다면 편하게 말씀 주세요!


## 🔗 관련 이슈
Close #75

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 캘린더 스크랩 기능 추가 - 다른 사용자의 캘린더를 스크랩하여 일정 및 할 일을 자동으로 복사할 수 있습니다.
  * 스크래퍼 목록 조회 - 캘린더를 스크랩한 사용자 목록을 페이지네이션으로 조회할 수 있습니다.
  * 스크랩 취소 기능 - 스크랩한 캘린더를 취소할 수 있습니다.

* **Changes**
  * 캘린더 삭제 시 소프트 삭제 방식으로 변경되었습니다.
  * 할 일 관리 기능이 개선되었습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->