### PR TITLE
chore(swagger): Swagger 인증 스킴에서 불필요한 Basic Auth 제거

### DIFF
--- a/src/main/java/kr/santanrudolph/everyvent/global/config/SwaggerConfig.java
+++ b/src/main/java/kr/santanrudolph/everyvent/global/config/SwaggerConfig.java
@@ -17,13 +17,9 @@ public class SwaggerConfig {
   @Bean
   public OpenAPI openAPI() {
     String jwtSchemeName = "JWT Token";
-    String basicAuthSchemeName = "Basic Auth";
 
     SecurityRequirement jwtSecurityRequirement = new SecurityRequirement()
         .addList(jwtSchemeName);
-
-    SecurityRequirement basicAuthSecurityRequirement = new SecurityRequirement()
-        .addList(basicAuthSchemeName);
 
     Components components = new Components()
         .addSecuritySchemes(jwtSchemeName, new SecurityScheme()
@@ -31,13 +27,7 @@ public class SwaggerConfig {
             .type(SecurityScheme.Type.HTTP)
             .scheme("bearer")
             .bearerFormat("JWT")
-            .description("JWT 토큰을 입력하세요. 'Bearer ' 접두사는 자동으로 추가됩니다."))
-
-        .addSecuritySchemes(basicAuthSchemeName, new SecurityScheme()
-            .name(basicAuthSchemeName)
-            .type(SecurityScheme.Type.HTTP)
-            .scheme("basic")
-            .description("Swagger UI 접근을 위한 Basic Authentication"));
+            .description("JWT 토큰을 입력하세요. 'Bearer ' 접두사는 자동으로 추가됩니다."));
 
     return new OpenAPI()
         .info(new Info()
@@ -53,7 +43,6 @@ public class SwaggerConfig {
                 .description("로컬 개발 서버")
         ))
         .addSecurityItem(jwtSecurityRequirement)
-        .addSecurityItem(basicAuthSecurityRequirement)
         .components(components);
   }
 }


### PR DESCRIPTION
## 📝 무엇을 했나요?
<img width="855" height="805" alt="image" src="https://github.com/user-attachments/assets/040d017a-2b3d-4285-98d3-9f15a7ae6115" />
Swagger 인증 스킴에 표시되던 불필요한 Basic Auth 항목을 제거했어요.

Swagger 접근용 Basic Auth는 SecurityConfig에서만 사용하면 되는데,
SwaggerConfig에도 함께 설정되어 있어 중복된 인증 스킴이 노출되어 swagger 사용 시 혼란이 있었어요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **변경사항**
  * API 보안 설정이 업데이트되었습니다. 기본 인증(Basic Authentication) 지원이 제거되었으며, JWT 기반 인증만 지원됩니다.
  * API 문서의 보안 구성이 간소화되었습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->