### PR TITLE
refactor(docker): docker-compose에서 환경변수를 .env로 분리

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     image: redis:7.2-alpine
     container_name: everyvent-redis
     ports:
-      - "6379:6379"
+      - "127.0.0.1:6379:6379"
     volumes:
       - redis-data:/data
     command: redis-server --appendonly yes

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,20 +21,8 @@ services:
     container_name: everyvent-app
     ports:
       - "8080:8080"
-    environment:
-      SPRING_PROFILES_ACTIVE: ${SPRING_PROFILES_ACTIVE:-prod}
-      RDS_HOST: ${RDS_HOST}
-      RDS_PORT: ${RDS_PORT:-5432}
-      RDS_DB_NAME: ${RDS_DB_NAME}
-      RDS_USERNAME: ${RDS_USERNAME}
-      RDS_PASSWORD: ${RDS_PASSWORD}
-      REDIS_HOST: redis
-      REDIS_PORT: ${REDIS_PORT:-6379}
-      JWT_SECRET: ${JWT_SECRET}
-      KAKAO_CLIENT_ID: ${KAKAO_CLIENT_ID}
-      KAKAO_CLIENT_SECRET: ${KAKAO_CLIENT_SECRET:-}
-      SWAGGER_USERNAME: ${SWAGGER_USERNAME}
-      SWAGGER_PASSWORD: ${SWAGGER_PASSWORD}
+    env_file:
+      - .env
     depends_on:
       redis:
         condition: service_healthy


### PR DESCRIPTION
## 📝 무엇을 했나요?

`docker-compose.yml`에서 환경변수를 직접 명시하고 있어
해당 파일에 정의하지 않으면 `docker-compose` 명령어로 실행할 때 환경변수가 정상적으로 주입되지 않는 문제가 있었어요.

환경변수 관리의 편의성과 일관성을 위해
`.env` 파일만 수정해도 환경변수가 적용되도록 구성 방식을 변경했어요.

또한 Redis(6379) 포트의 외부 네트워크 접근을 차단해
로컬 환경에서만 접근 가능하도록 수정했어요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * 인프라 설정 개선을 위해 Docker 컨테이너 네트워킹 설정을 업데이트했습니다.
  * 환경 설정 관리 방식을 개선하여 더욱 체계적인 배포 환경을 구성했습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->