### PR TITLE
fix(user): native query 테이블명 불일치 오류 수정

### DIFF
--- a/src/main/java/kr/santanrudolph/everyvent/domain/user/repository/UserRepository.java
+++ b/src/main/java/kr/santanrudolph/everyvent/domain/user/repository/UserRepository.java
@@ -39,13 +39,13 @@ public interface UserRepository extends JpaRepository<User, Long>, UserRepositor
                 PARTITION BY f1.target_id
                 ORDER BY f1.follower_id
               ) AS rn
-            FROM follow f1
-            JOIN follow f2
+            FROM follows f1
+            JOIN follows f2
               ON f2.target_id = f1.follower_id
              AND f2.follower_id = :currentUserId
             WHERE f1.target_id IN (:targetUserIds)
           ) t
-          JOIN user u ON u.id = t.follower_id
+          JOIN users u ON u.id = t.follower_id
           WHERE t.rn <= 3
             AND u.deleted_at IS NULL
           """,


### PR DESCRIPTION
## 📝 무엇을 했나요?
`/api/users/search` API 호출 시 서버 내부 에러가 발생했어요.
<img width="1240" height="275" alt="image" src="https://github.com/user-attachments/assets/80d830da-94d0-4eb9-b34e-07ab4b185f20" />

해당 오류는 Native Query에서 사용한 테이블명이 실제 DB 스키마와 일치하지 않아  
`follow` 테이블을 찾지 못해 발생한 문제였어요.

이를 해결하기 위해 Native Query의 테이블명을 실제 테이블명과 일치하도록 수정했어요.

- follow → follows
- user → users


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* 공통 팔로워 조회 기능의 데이터베이스 쿼리를 수정하여 정확한 결과를 반환하도록 개선했습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->